### PR TITLE
Add support for RETURNING operator for ORCA

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4171,7 +4171,8 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 	m_dxl_to_plstmt_context->AddRTE(rte);
 
 	CDXLNode *project_list_dxlnode = (*dml_dxlnode)[0];
-	CDXLNode *child_dxlnode = (*dml_dxlnode)[1];
+	CDXLNode *project_list_output_dxlnode = (*dml_dxlnode)[1];
+	CDXLNode *child_dxlnode = (*dml_dxlnode)[2];
 
 	CDXLTranslateContext child_context(m_mp, false,
 									   output_context->GetColIdToParamIdMap());
@@ -4187,6 +4188,10 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 	List *dml_target_list =
 		TranslateDXLProjList(project_list_dxlnode,
 							 NULL,	// translate context for the base table
+							 child_contexts, output_context);
+
+	dml->returningList =
+		TranslateDXLProjList(project_list_output_dxlnode, &base_table_context,
 							 child_contexts, output_context);
 
 	// Create target list with nulls if rel has dropped cols. DELETE may have

--- a/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-1.mdp
@@ -207,10 +207,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2">
         <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t1_random">
@@ -244,9 +241,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1" ActionCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="18" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.023480" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.023480" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -257,17 +254,16 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t1_random">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RandomMotion InputSegments="0,1" OutputSegments="0,1">
@@ -281,8 +277,8 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-              <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
+              <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -298,7 +294,7 @@
               <dxl:ProjElem ColId="1" Alias="b">
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+              <dxl:ProjElem ColId="18" Alias="ColRef_0018">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-2.mdp
@@ -198,10 +198,7 @@
       </dxl:GPDBScalarOp>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2">
         <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t1_random">
@@ -251,9 +248,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="10">
-      <dxl:DMLInsert Columns="0,1" ActionCol="11" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="20" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="882688.190319" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="882688.190319" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -264,17 +261,16 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t1_random">
           <dxl:Columns>
-            <dxl:Column ColId="12" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="13" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RandomMotion InputSegments="0,1" OutputSegments="0,1">
@@ -288,8 +284,8 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-              <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+              <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -305,7 +301,7 @@
               <dxl:ProjElem ColId="1" Alias="b">
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-3.mdp
@@ -228,10 +228,7 @@
       </dxl:GPDBScalarOp>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2">
         <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t1_random">
@@ -281,9 +278,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="10">
-      <dxl:DMLInsert Columns="0,1" ActionCol="11" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="20" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="882688.194415" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="882688.194415" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -294,17 +291,16 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t1_random">
           <dxl:Columns>
-            <dxl:Column ColId="12" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="13" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RandomMotion InputSegments="0,1" OutputSegments="0,1">
@@ -318,8 +314,8 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-              <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+              <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -335,7 +331,7 @@
               <dxl:ProjElem ColId="1" Alias="b">
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-4.mdp
@@ -245,10 +245,7 @@
       </dxl:GPDBScalarOp>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2">
         <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t1_random">
@@ -335,9 +332,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="42">
-      <dxl:DMLInsert Columns="0,1" ActionCol="22" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="31" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1765376.365372" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1765376.365372" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -348,17 +345,16 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t1_random">
           <dxl:Columns>
-            <dxl:Column ColId="23" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="24" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RandomMotion InputSegments="0,1" OutputSegments="0,1">
@@ -372,8 +368,8 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-              <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="31" Alias="ColRef_0031">
+              <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -389,7 +385,7 @@
               <dxl:ProjElem ColId="1" Alias="b">
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+              <dxl:ProjElem ColId="31" Alias="ColRef_0031">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-5.mdp
@@ -214,10 +214,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2">
         <dxl:TableDescriptor Mdid="6.16474.1.0" TableName="t1_random">
@@ -251,9 +248,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1" ActionCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="18" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.015656" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.015656" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -264,17 +261,16 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16474.1.0" TableName="t1_random">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
@@ -288,8 +284,8 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-              <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
+              <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -305,7 +301,7 @@
               <dxl:ProjElem ColId="1" Alias="b">
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+              <dxl:ProjElem ColId="18" Alias="ColRef_0018">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelAppend-Insert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelAppend-Insert.mdp
@@ -142,9 +142,7 @@ INSERT INTO t VALUES (11),(12),(13);
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1">
         <dxl:TableDescriptor Mdid="6.6861048.1.1" TableName="lubo">
@@ -191,9 +189,9 @@ INSERT INTO t VALUES (11),(12),(13);
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="0">
-      <dxl:DMLInsert Columns="0" ActionCol="3" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0" ActionCol="11" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.031272" Rows="3.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.031272" Rows="3.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -201,16 +199,17 @@ INSERT INTO t VALUES (11),(12),(13);
             <dxl:Ident ColId="0" ColName="column1" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.6861048.1.1" TableName="lubo">
           <dxl:Columns>
-            <dxl:Column ColId="4" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="3" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -221,7 +220,7 @@ INSERT INTO t VALUES (11),(12),(13);
             <dxl:ProjElem ColId="0" Alias="column1">
               <dxl:Ident ColId="0" ColName="column1" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="3" Alias="ColRef_0003">
+            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-Random.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-Random.mdp
@@ -213,8 +213,8 @@
         </dxl:Properties>
         <dxl:DistrOpclasses/>
         <dxl:Columns>
-          <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-          <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="12" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="13" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
         <dxl:ProjList>
@@ -236,7 +236,7 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
@@ -717,7 +717,7 @@
         </dxl:Properties>
         <dxl:DistrOpclasses/>
         <dxl:Columns>
-          <dxl:Column ColId="13" Attno="1" ColName="avg" TypeMdid="0.1700.1.0"/>
+          <dxl:Column ColId="14" Attno="1" ColName="avg" TypeMdid="0.1700.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
         <dxl:ProjList>
@@ -733,7 +733,7 @@
             <dxl:ProjElem ColId="10" Alias="avg">
               <dxl:Ident ColId="10" ColName="avg" TypeMdid="0.1700.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="12" Alias="ColRef_0012">
+            <dxl:ProjElem ColId="13" Alias="ColRef_0013">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
@@ -757,9 +757,9 @@
               <dxl:GroupingColumns/>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="avg">
-                  <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+                  <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                     <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.1016.1.0"/>
+                      <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.1016.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -773,8 +773,8 @@
                   <dxl:Cost StartupCost="0" TotalCost="438.378816" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-                    <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.1016.1.0"/>
+                  <dxl:ProjElem ColId="12" Alias="ColRef_0012">
+                    <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.1016.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
@@ -785,10 +785,10 @@
                   </dxl:Properties>
                   <dxl:GroupingColumns/>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-                      <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                    <dxl:ProjElem ColId="12" Alias="ColRef_0012">
+                      <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                         <dxl:ValuesList ParamType="aggargs">
-                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                         </dxl:ValuesList>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-random-distr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-random-distr.mdp
@@ -178,9 +178,9 @@
         </dxl:Properties>
         <dxl:DistrOpclasses/>
         <dxl:Columns>
-          <dxl:Column ColId="4" Attno="1" ColName="time" TypeMdid="0.1184.1.0"/>
-          <dxl:Column ColId="5" Attno="2" ColName="device_id" TypeMdid="0.23.1.0"/>
-          <dxl:Column ColId="6" Attno="3" ColName="cpu_usage" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="7" Attno="1" ColName="time" TypeMdid="0.1184.1.0"/>
+          <dxl:Column ColId="8" Attno="2" ColName="device_id" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="9" Attno="3" ColName="cpu_usage" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
         <dxl:ProjList>
@@ -208,8 +208,8 @@
             <dxl:ProjElem ColId="2" Alias="cpu_usage">
               <dxl:Ident ColId="2" ColName="cpu_usage" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="3" Alias="ColRef_0003">
-              <dxl:Ident ColId="3" ColName="ColRef_0003" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="6" Alias="ColRef_0006">
+              <dxl:Ident ColId="6" ColName="ColRef_0006" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -228,7 +228,7 @@
               <dxl:ProjElem ColId="2" Alias="cpu_usage">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="100"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="3" Alias="ColRef_0003">
+              <dxl:ProjElem ColId="6" Alias="ColRef_0006">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-random-distributed-from-replicated-distributed-table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-random-distributed-from-replicated-distributed-table.mdp
@@ -243,8 +243,8 @@
         </dxl:Properties>
         <dxl:DistrOpclasses/>
         <dxl:Columns>
-          <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.25.1.0"/>
-          <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="12" Attno="1" ColName="a" TypeMdid="0.25.1.0"/>
+          <dxl:Column ColId="13" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
         <dxl:ProjList>
@@ -266,8 +266,8 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-              <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+              <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -283,7 +283,7 @@
               <dxl:ProjElem ColId="1" Alias="b">
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+              <dxl:ProjElem ColId="11" Alias="ColRef_0011">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>
@@ -316,7 +316,7 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="6.24577.1.0" TableName="test_replicated" LockMode="1">
+                <dxl:TableDescriptor Mdid="6.24577.1.0" TableName="test_replicated">
                   <dxl:Columns>
                     <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.25.1.0" ColWidth="8"/>
                     <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-with-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-with-Limit.mdp
@@ -656,8 +656,8 @@
         </dxl:Properties>
         <dxl:DistrOpclasses/>
         <dxl:Columns>
-          <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-          <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="12" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="13" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
         <dxl:ProjList>
@@ -679,7 +679,7 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-with-hashed-distributed-external-table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-with-hashed-distributed-external-table.mdp
@@ -247,9 +247,9 @@ EXPLAIN CREATE TABLE Test AS SELECT * FROM test_gpfdist_ext DISTRIBUTED BY (a);
           <dxl:DistrOpclass Mdid="0.10027.1.0"/>
         </dxl:DistrOpclasses>
         <dxl:Columns>
-          <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-          <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.25.1.0"/>
-          <dxl:Column ColId="13" Attno="3" ColName="c" TypeMdid="0.25.1.0"/>
+          <dxl:Column ColId="14" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="15" Attno="2" ColName="b" TypeMdid="0.25.1.0"/>
+          <dxl:Column ColId="16" Attno="3" ColName="c" TypeMdid="0.25.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
         <dxl:ProjList>
@@ -277,7 +277,7 @@ EXPLAIN CREATE TABLE Test AS SELECT * FROM test_gpfdist_ext DISTRIBUTED BY (a);
             <dxl:ProjElem ColId="2" Alias="c">
               <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+            <dxl:ProjElem ColId="13" Alias="ColRef_0013">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-with-randomly-distributed-external-table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-with-randomly-distributed-external-table.mdp
@@ -234,9 +234,9 @@ EXPLAIN CREATE TABLE Test AS SELECT * FROM test_ext DISTRIBUTED RANDOMLY;
         </dxl:Properties>
         <dxl:DistrOpclasses/>
         <dxl:Columns>
-          <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-          <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.25.1.0"/>
-          <dxl:Column ColId="13" Attno="3" ColName="c" TypeMdid="0.25.1.0"/>
+          <dxl:Column ColId="14" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="15" Attno="2" ColName="b" TypeMdid="0.25.1.0"/>
+          <dxl:Column ColId="16" Attno="3" ColName="c" TypeMdid="0.25.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
         <dxl:ProjList>
@@ -264,8 +264,8 @@ EXPLAIN CREATE TABLE Test AS SELECT * FROM test_ext DISTRIBUTED RANDOMLY;
             <dxl:ProjElem ColId="2" Alias="c">
               <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-              <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="13" Alias="ColRef_0013">
+              <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -284,7 +284,7 @@ EXPLAIN CREATE TABLE Test AS SELECT * FROM test_ext DISTRIBUTED RANDOMLY;
               <dxl:ProjElem ColId="2" Alias="c">
                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+              <dxl:ProjElem ColId="13" Alias="ColRef_0013">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CTAS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS.mdp
@@ -223,8 +223,8 @@
           <dxl:DistrOpclass Mdid="0.10027.1.0"/>
         </dxl:DistrOpclasses>
         <dxl:Columns>
-          <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-          <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="12" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="13" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
         <dxl:ProjList>
@@ -246,7 +246,7 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CTAS_OrderedAgg_multiple_cols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS_OrderedAgg_multiple_cols.mdp
@@ -1815,9 +1815,9 @@ EXPLAIN CREATE TABLE test AS
         </dxl:Properties>
         <dxl:DistrOpclasses/>
         <dxl:Columns>
-          <dxl:Column ColId="131" Attno="1" ColName="first_quartile" TypeMdid="0.1022.1.0"/>
-          <dxl:Column ColId="132" Attno="2" ColName="median_quartile" TypeMdid="0.1022.1.0"/>
-          <dxl:Column ColId="133" Attno="3" ColName="third_quartile" TypeMdid="0.1022.1.0"/>
+          <dxl:Column ColId="134" Attno="1" ColName="first_quartile" TypeMdid="0.1022.1.0"/>
+          <dxl:Column ColId="135" Attno="2" ColName="median_quartile" TypeMdid="0.1022.1.0"/>
+          <dxl:Column ColId="136" Attno="3" ColName="third_quartile" TypeMdid="0.1022.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
         <dxl:ProjList>
@@ -1845,7 +1845,7 @@ EXPLAIN CREATE TABLE test AS
             <dxl:ProjElem ColId="21" Alias="third_quartile">
               <dxl:Ident ColId="21" ColName="third_quartile" TypeMdid="0.1022.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="130" Alias="ColRef_0130">
+            <dxl:ProjElem ColId="133" Alias="ColRef_0133">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
@@ -1913,16 +1913,16 @@ EXPLAIN CREATE TABLE test AS
                   <dxl:Ident ColId="18" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:CTEProducer CTEId="0" Columns="23,24">
+              <dxl:CTEProducer CTEId="0" Columns="26,27">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.005234" Rows="99.999999" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="23" Alias="a">
-                    <dxl:Ident ColId="23" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="26" Alias="a">
+                    <dxl:Ident ColId="26" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="24" Alias="ColRef_0022">
-                    <dxl:Ident ColId="24" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="27" Alias="ColRef_0025">
+                    <dxl:Ident ColId="27" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
@@ -1930,16 +1930,16 @@ EXPLAIN CREATE TABLE test AS
                     <dxl:Cost StartupCost="0" TotalCost="431.005200" Rows="99.999999" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="23"/>
+                    <dxl:GroupingColumn ColId="26"/>
                   </dxl:GroupingColumns>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="23" Alias="a">
-                      <dxl:Ident ColId="23" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="26" Alias="a">
+                      <dxl:Ident ColId="26" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="24" Alias="ColRef_0022">
+                    <dxl:ProjElem ColId="27" Alias="ColRef_0025">
                       <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                         <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="23" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="26" ColName="a" TypeMdid="0.23.1.0"/>
                         </dxl:ValuesList>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>
@@ -1953,13 +1953,13 @@ EXPLAIN CREATE TABLE test AS
                       <dxl:Cost StartupCost="0" TotalCost="431.004843" Rows="100.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="23" Alias="a">
-                        <dxl:Ident ColId="23" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="26" Alias="a">
+                        <dxl:Ident ColId="26" ColName="a" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:SortingColumnList>
-                      <dxl:SortingColumn ColId="23" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      <dxl:SortingColumn ColId="26" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                     </dxl:SortingColumnList>
                     <dxl:LimitCount/>
                     <dxl:LimitOffset/>
@@ -1968,23 +1968,23 @@ EXPLAIN CREATE TABLE test AS
                         <dxl:Cost StartupCost="0" TotalCost="431.000770" Rows="100.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="23" Alias="a">
-                          <dxl:Ident ColId="23" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="26" Alias="a">
+                          <dxl:Ident ColId="26" ColName="a" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:TableDescriptor Mdid="6.132001.1.0" TableName="foo1">
                         <dxl:Columns>
-                          <dxl:Column ColId="23" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="25" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="26" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="27" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                          <dxl:Column ColId="28" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="29" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="30" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="31" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="32" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="33" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="26" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="28" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="29" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="30" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="31" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="32" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="33" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="34" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="35" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="36" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                         </dxl:Columns>
                       </dxl:TableDescriptor>
                     </dxl:TableScan>
@@ -2024,16 +2024,16 @@ EXPLAIN CREATE TABLE test AS
                     <dxl:Ident ColId="18" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:CTEProducer CTEId="1" Columns="57,58">
+                <dxl:CTEProducer CTEId="1" Columns="60,61">
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.005651" Rows="99.999999" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="57" Alias="b">
-                      <dxl:Ident ColId="57" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="60" Alias="b">
+                      <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="58" Alias="ColRef_0056">
-                      <dxl:Ident ColId="58" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="61" Alias="ColRef_0059">
+                      <dxl:Ident ColId="61" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
@@ -2041,16 +2041,16 @@ EXPLAIN CREATE TABLE test AS
                       <dxl:Cost StartupCost="0" TotalCost="431.005618" Rows="99.999999" Width="12"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="57"/>
+                      <dxl:GroupingColumn ColId="60"/>
                     </dxl:GroupingColumns>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="57" Alias="b">
-                        <dxl:Ident ColId="57" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="60" Alias="b">
+                        <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="58" Alias="ColRef_0056">
+                      <dxl:ProjElem ColId="61" Alias="ColRef_0059">
                         <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                           <dxl:ValuesList ParamType="aggargs">
-                            <dxl:Ident ColId="57" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>
@@ -2064,13 +2064,13 @@ EXPLAIN CREATE TABLE test AS
                         <dxl:Cost StartupCost="0" TotalCost="431.005260" Rows="100.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="57" Alias="b">
-                          <dxl:Ident ColId="57" ColName="b" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="60" Alias="b">
+                          <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:SortingColumnList>
-                        <dxl:SortingColumn ColId="57" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="60" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                       </dxl:SortingColumnList>
                       <dxl:LimitCount/>
                       <dxl:LimitOffset/>
@@ -2079,15 +2079,15 @@ EXPLAIN CREATE TABLE test AS
                           <dxl:Cost StartupCost="0" TotalCost="431.001435" Rows="100.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="57" Alias="b">
-                            <dxl:Ident ColId="57" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="60" Alias="b">
+                            <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
                           <dxl:HashExpr Opfamily="0.1977.1.0">
-                            <dxl:Ident ColId="57" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>
                         <dxl:TableScan>
@@ -2095,23 +2095,23 @@ EXPLAIN CREATE TABLE test AS
                             <dxl:Cost StartupCost="0" TotalCost="431.000770" Rows="100.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="57" Alias="b">
-                              <dxl:Ident ColId="57" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="60" Alias="b">
+                              <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
                           <dxl:TableDescriptor Mdid="6.132001.1.0" TableName="foo1">
                             <dxl:Columns>
-                              <dxl:Column ColId="59" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="57" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="60" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="61" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                              <dxl:Column ColId="62" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="63" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="64" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="65" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="66" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="67" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="62" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="60" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="63" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="64" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="65" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="66" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="67" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="68" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="69" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="70" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                             </dxl:Columns>
                           </dxl:TableDescriptor>
                         </dxl:TableScan>
@@ -2152,16 +2152,16 @@ EXPLAIN CREATE TABLE test AS
                       <dxl:Ident ColId="18" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:CTEProducer CTEId="2" Columns="91,92">
+                  <dxl:CTEProducer CTEId="2" Columns="94,95">
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="431.005651" Rows="99.999999" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="91" Alias="c">
-                        <dxl:Ident ColId="91" ColName="c" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="94" Alias="c">
+                        <dxl:Ident ColId="94" ColName="c" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="92" Alias="ColRef_0090">
-                        <dxl:Ident ColId="92" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                      <dxl:ProjElem ColId="95" Alias="ColRef_0093">
+                        <dxl:Ident ColId="95" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
@@ -2169,16 +2169,16 @@ EXPLAIN CREATE TABLE test AS
                         <dxl:Cost StartupCost="0" TotalCost="431.005618" Rows="99.999999" Width="12"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
-                        <dxl:GroupingColumn ColId="91"/>
+                        <dxl:GroupingColumn ColId="94"/>
                       </dxl:GroupingColumns>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="91" Alias="c">
-                          <dxl:Ident ColId="91" ColName="c" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="94" Alias="c">
+                          <dxl:Ident ColId="94" ColName="c" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="92" Alias="ColRef_0090">
+                        <dxl:ProjElem ColId="95" Alias="ColRef_0093">
                           <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                             <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="91" ColName="c" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="94" ColName="c" TypeMdid="0.23.1.0"/>
                             </dxl:ValuesList>
                             <dxl:ValuesList ParamType="aggdirectargs"/>
                             <dxl:ValuesList ParamType="aggorder"/>
@@ -2192,13 +2192,13 @@ EXPLAIN CREATE TABLE test AS
                           <dxl:Cost StartupCost="0" TotalCost="431.005260" Rows="100.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="91" Alias="c">
-                            <dxl:Ident ColId="91" ColName="c" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="94" Alias="c">
+                            <dxl:Ident ColId="94" ColName="c" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:SortingColumnList>
-                          <dxl:SortingColumn ColId="91" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          <dxl:SortingColumn ColId="94" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                         </dxl:SortingColumnList>
                         <dxl:LimitCount/>
                         <dxl:LimitOffset/>
@@ -2207,15 +2207,15 @@ EXPLAIN CREATE TABLE test AS
                             <dxl:Cost StartupCost="0" TotalCost="431.001435" Rows="100.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="91" Alias="c">
-                              <dxl:Ident ColId="91" ColName="c" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="94" Alias="c">
+                              <dxl:Ident ColId="94" ColName="c" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
                           <dxl:SortingColumnList/>
                           <dxl:HashExprList>
                             <dxl:HashExpr Opfamily="0.1977.1.0">
-                              <dxl:Ident ColId="91" ColName="c" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="94" ColName="c" TypeMdid="0.23.1.0"/>
                             </dxl:HashExpr>
                           </dxl:HashExprList>
                           <dxl:TableScan>
@@ -2223,23 +2223,23 @@ EXPLAIN CREATE TABLE test AS
                               <dxl:Cost StartupCost="0" TotalCost="431.000770" Rows="100.000000" Width="4"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="91" Alias="c">
-                                <dxl:Ident ColId="91" ColName="c" TypeMdid="0.23.1.0"/>
+                              <dxl:ProjElem ColId="94" Alias="c">
+                                <dxl:Ident ColId="94" ColName="c" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:TableDescriptor Mdid="6.132001.1.0" TableName="foo1">
                               <dxl:Columns>
-                                <dxl:Column ColId="93" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="94" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="91" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="95" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                <dxl:Column ColId="96" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="97" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="98" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="99" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="100" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="101" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="96" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="97" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="94" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="98" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="99" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="100" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="101" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="102" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="103" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="104" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                               </dxl:Columns>
                             </dxl:TableDescriptor>
                           </dxl:TableScan>
@@ -2360,8 +2360,8 @@ EXPLAIN CREATE TABLE test AS
                                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                                   </dxl:Cast>
                                   <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
-                                  <dxl:Ident ColId="89" ColName="ColRef_0089" TypeMdid="0.20.1.0"/>
-                                  <dxl:Ident ColId="56" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="92" ColName="ColRef_0092" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="59" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
                                 </dxl:ValuesList>
                                 <dxl:ValuesList ParamType="aggdirectargs"/>
                                 <dxl:ValuesList ParamType="aggorder"/>
@@ -2375,8 +2375,8 @@ EXPLAIN CREATE TABLE test AS
                                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                                   </dxl:Cast>
                                   <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                                  <dxl:Ident ColId="89" ColName="ColRef_0089" TypeMdid="0.20.1.0"/>
-                                  <dxl:Ident ColId="56" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="92" ColName="ColRef_0092" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="59" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
                                 </dxl:ValuesList>
                                 <dxl:ValuesList ParamType="aggdirectargs"/>
                                 <dxl:ValuesList ParamType="aggorder"/>
@@ -2390,8 +2390,8 @@ EXPLAIN CREATE TABLE test AS
                                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                                   </dxl:Cast>
                                   <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA6D8=" DoubleValue="0.750000"/>
-                                  <dxl:Ident ColId="89" ColName="ColRef_0089" TypeMdid="0.20.1.0"/>
-                                  <dxl:Ident ColId="56" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="92" ColName="ColRef_0092" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="59" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
                                 </dxl:ValuesList>
                                 <dxl:ValuesList ParamType="aggdirectargs"/>
                                 <dxl:ValuesList ParamType="aggorder"/>
@@ -2408,11 +2408,11 @@ EXPLAIN CREATE TABLE test AS
                               <dxl:ProjElem ColId="1" Alias="b">
                                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="56" Alias="ColRef_0056">
-                                <dxl:Ident ColId="56" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                              <dxl:ProjElem ColId="59" Alias="ColRef_0059">
+                                <dxl:Ident ColId="59" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="89" Alias="ColRef_0089">
-                                <dxl:Ident ColId="89" ColName="ColRef_0089" TypeMdid="0.20.1.0"/>
+                              <dxl:ProjElem ColId="92" Alias="ColRef_0092">
+                                <dxl:Ident ColId="92" ColName="ColRef_0092" TypeMdid="0.20.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
@@ -2423,11 +2423,11 @@ EXPLAIN CREATE TABLE test AS
                                 <dxl:ProjElem ColId="1" Alias="b">
                                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
-                                <dxl:ProjElem ColId="56" Alias="ColRef_0056">
-                                  <dxl:Ident ColId="56" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                                <dxl:ProjElem ColId="59" Alias="ColRef_0059">
+                                  <dxl:Ident ColId="59" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
                                 </dxl:ProjElem>
-                                <dxl:ProjElem ColId="89" Alias="ColRef_0089">
-                                  <dxl:Ident ColId="89" ColName="ColRef_0089" TypeMdid="0.20.1.0"/>
+                                <dxl:ProjElem ColId="92" Alias="ColRef_0092">
+                                  <dxl:Ident ColId="92" ColName="ColRef_0092" TypeMdid="0.20.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
@@ -2442,18 +2442,18 @@ EXPLAIN CREATE TABLE test AS
                                   <dxl:ProjElem ColId="1" Alias="b">
                                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="56" Alias="ColRef_0056">
-                                    <dxl:Ident ColId="56" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                                  <dxl:ProjElem ColId="59" Alias="ColRef_0059">
+                                    <dxl:Ident ColId="59" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
                                   </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="89" Alias="ColRef_0089">
-                                    <dxl:Ident ColId="89" ColName="ColRef_0089" TypeMdid="0.20.1.0"/>
+                                  <dxl:ProjElem ColId="92" Alias="ColRef_0092">
+                                    <dxl:Ident ColId="92" ColName="ColRef_0092" TypeMdid="0.20.1.0"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
                                 <dxl:JoinFilter>
                                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                                 </dxl:JoinFilter>
-                                <dxl:CTEConsumer CTEId="1" Columns="1,56">
+                                <dxl:CTEConsumer CTEId="1" Columns="1,59">
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="431.000964" Rows="99.999999" Width="12"/>
                                   </dxl:Properties>
@@ -2461,8 +2461,8 @@ EXPLAIN CREATE TABLE test AS
                                     <dxl:ProjElem ColId="1" Alias="b">
                                       <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                                     </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="56" Alias="ColRef_0056">
-                                      <dxl:Ident ColId="56" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                                    <dxl:ProjElem ColId="59" Alias="ColRef_0059">
+                                      <dxl:Ident ColId="59" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
                                 </dxl:CTEConsumer>
@@ -2471,8 +2471,8 @@ EXPLAIN CREATE TABLE test AS
                                     <dxl:Cost StartupCost="0" TotalCost="431.001249" Rows="3.000000" Width="8"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
-                                    <dxl:ProjElem ColId="89" Alias="ColRef_0089">
-                                      <dxl:Ident ColId="89" ColName="ColRef_0089" TypeMdid="0.20.1.0"/>
+                                    <dxl:ProjElem ColId="92" Alias="ColRef_0092">
+                                      <dxl:Ident ColId="92" ColName="ColRef_0092" TypeMdid="0.20.1.0"/>
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
                                   <dxl:Filter/>
@@ -2481,9 +2481,9 @@ EXPLAIN CREATE TABLE test AS
                                       <dxl:Cost StartupCost="0" TotalCost="431.001241" Rows="3.000000" Width="8"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
-                                      <dxl:ProjElem ColId="89" Alias="ColRef_0089">
-                                        <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
-                                          <dxl:Ident ColId="88" ColName="ColRef_0088" TypeMdid="0.1700.1.0"/>
+                                      <dxl:ProjElem ColId="92" Alias="ColRef_0092">
+                                        <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0" FuncVariadic="false">
+                                          <dxl:Ident ColId="91" ColName="ColRef_0091" TypeMdid="0.1700.1.0"/>
                                         </dxl:FuncExpr>
                                       </dxl:ProjElem>
                                     </dxl:ProjList>
@@ -2494,8 +2494,8 @@ EXPLAIN CREATE TABLE test AS
                                         <dxl:Cost StartupCost="0" TotalCost="431.001133" Rows="3.000000" Width="8"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
-                                        <dxl:ProjElem ColId="88" Alias="ColRef_0088">
-                                          <dxl:Ident ColId="88" ColName="ColRef_0088" TypeMdid="0.1700.1.0"/>
+                                        <dxl:ProjElem ColId="91" Alias="ColRef_0091">
+                                          <dxl:Ident ColId="91" ColName="ColRef_0091" TypeMdid="0.1700.1.0"/>
                                         </dxl:ProjElem>
                                       </dxl:ProjList>
                                       <dxl:Filter/>
@@ -2506,10 +2506,10 @@ EXPLAIN CREATE TABLE test AS
                                         </dxl:Properties>
                                         <dxl:GroupingColumns/>
                                         <dxl:ProjList>
-                                          <dxl:ProjElem ColId="88" Alias="ColRef_0088">
+                                          <dxl:ProjElem ColId="91" Alias="ColRef_0091">
                                             <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                                               <dxl:ValuesList ParamType="aggargs">
-                                                <dxl:Ident ColId="125" ColName="ColRef_0125" TypeMdid="0.17.1.0"/>
+                                                <dxl:Ident ColId="128" ColName="ColRef_0128" TypeMdid="0.17.1.0"/>
                                               </dxl:ValuesList>
                                               <dxl:ValuesList ParamType="aggdirectargs"/>
                                               <dxl:ValuesList ParamType="aggorder"/>
@@ -2523,8 +2523,8 @@ EXPLAIN CREATE TABLE test AS
                                             <dxl:Cost StartupCost="0" TotalCost="431.000702" Rows="1.000000" Width="8"/>
                                           </dxl:Properties>
                                           <dxl:ProjList>
-                                            <dxl:ProjElem ColId="125" Alias="ColRef_0125">
-                                              <dxl:Ident ColId="125" ColName="ColRef_0125" TypeMdid="0.17.1.0"/>
+                                            <dxl:ProjElem ColId="128" Alias="ColRef_0128">
+                                              <dxl:Ident ColId="128" ColName="ColRef_0128" TypeMdid="0.17.1.0"/>
                                             </dxl:ProjElem>
                                           </dxl:ProjList>
                                           <dxl:Filter/>
@@ -2535,10 +2535,10 @@ EXPLAIN CREATE TABLE test AS
                                             </dxl:Properties>
                                             <dxl:GroupingColumns/>
                                             <dxl:ProjList>
-                                              <dxl:ProjElem ColId="125" Alias="ColRef_0125">
+                                              <dxl:ProjElem ColId="128" Alias="ColRef_0128">
                                                 <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                                                   <dxl:ValuesList ParamType="aggargs">
-                                                    <dxl:Ident ColId="69" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                                                    <dxl:Ident ColId="72" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
                                                   </dxl:ValuesList>
                                                   <dxl:ValuesList ParamType="aggdirectargs"/>
                                                   <dxl:ValuesList ParamType="aggorder"/>
@@ -2547,16 +2547,16 @@ EXPLAIN CREATE TABLE test AS
                                               </dxl:ProjElem>
                                             </dxl:ProjList>
                                             <dxl:Filter/>
-                                            <dxl:CTEConsumer CTEId="1" Columns="68,69">
+                                            <dxl:CTEConsumer CTEId="1" Columns="71,72">
                                               <dxl:Properties>
                                                 <dxl:Cost StartupCost="0" TotalCost="431.000643" Rows="99.999999" Width="8"/>
                                               </dxl:Properties>
                                               <dxl:ProjList>
-                                                <dxl:ProjElem ColId="68" Alias="b">
-                                                  <dxl:Ident ColId="68" ColName="b" TypeMdid="0.23.1.0"/>
+                                                <dxl:ProjElem ColId="71" Alias="b">
+                                                  <dxl:Ident ColId="71" ColName="b" TypeMdid="0.23.1.0"/>
                                                 </dxl:ProjElem>
-                                                <dxl:ProjElem ColId="69" Alias="ColRef_0056">
-                                                  <dxl:Ident ColId="69" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                                                <dxl:ProjElem ColId="72" Alias="ColRef_0059">
+                                                  <dxl:Ident ColId="72" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
                                                 </dxl:ProjElem>
                                               </dxl:ProjList>
                                             </dxl:CTEConsumer>
@@ -2605,8 +2605,8 @@ EXPLAIN CREATE TABLE test AS
                                       <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                                     </dxl:Cast>
                                     <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
-                                    <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
-                                    <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                    <dxl:Ident ColId="58" ColName="ColRef_0058" TypeMdid="0.20.1.0"/>
+                                    <dxl:Ident ColId="25" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
                                   </dxl:ValuesList>
                                   <dxl:ValuesList ParamType="aggdirectargs"/>
                                   <dxl:ValuesList ParamType="aggorder"/>
@@ -2620,8 +2620,8 @@ EXPLAIN CREATE TABLE test AS
                                       <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                                     </dxl:Cast>
                                     <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                                    <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
-                                    <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                    <dxl:Ident ColId="58" ColName="ColRef_0058" TypeMdid="0.20.1.0"/>
+                                    <dxl:Ident ColId="25" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
                                   </dxl:ValuesList>
                                   <dxl:ValuesList ParamType="aggdirectargs"/>
                                   <dxl:ValuesList ParamType="aggorder"/>
@@ -2635,8 +2635,8 @@ EXPLAIN CREATE TABLE test AS
                                       <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                                     </dxl:Cast>
                                     <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA6D8=" DoubleValue="0.750000"/>
-                                    <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
-                                    <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                    <dxl:Ident ColId="58" ColName="ColRef_0058" TypeMdid="0.20.1.0"/>
+                                    <dxl:Ident ColId="25" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
                                   </dxl:ValuesList>
                                   <dxl:ValuesList ParamType="aggdirectargs"/>
                                   <dxl:ValuesList ParamType="aggorder"/>
@@ -2653,11 +2653,11 @@ EXPLAIN CREATE TABLE test AS
                                 <dxl:ProjElem ColId="0" Alias="a">
                                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
-                                <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                                  <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                <dxl:ProjElem ColId="25" Alias="ColRef_0025">
+                                  <dxl:Ident ColId="25" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
                                 </dxl:ProjElem>
-                                <dxl:ProjElem ColId="55" Alias="ColRef_0055">
-                                  <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                                <dxl:ProjElem ColId="58" Alias="ColRef_0058">
+                                  <dxl:Ident ColId="58" ColName="ColRef_0058" TypeMdid="0.20.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
@@ -2668,11 +2668,11 @@ EXPLAIN CREATE TABLE test AS
                                   <dxl:ProjElem ColId="0" Alias="a">
                                     <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                                    <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                  <dxl:ProjElem ColId="25" Alias="ColRef_0025">
+                                    <dxl:Ident ColId="25" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
                                   </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="55" Alias="ColRef_0055">
-                                    <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                                  <dxl:ProjElem ColId="58" Alias="ColRef_0058">
+                                    <dxl:Ident ColId="58" ColName="ColRef_0058" TypeMdid="0.20.1.0"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
@@ -2687,18 +2687,18 @@ EXPLAIN CREATE TABLE test AS
                                     <dxl:ProjElem ColId="0" Alias="a">
                                       <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                                     </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                                      <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                    <dxl:ProjElem ColId="25" Alias="ColRef_0025">
+                                      <dxl:Ident ColId="25" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
                                     </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="55" Alias="ColRef_0055">
-                                      <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                                    <dxl:ProjElem ColId="58" Alias="ColRef_0058">
+                                      <dxl:Ident ColId="58" ColName="ColRef_0058" TypeMdid="0.20.1.0"/>
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
                                   <dxl:Filter/>
                                   <dxl:JoinFilter>
                                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                                   </dxl:JoinFilter>
-                                  <dxl:CTEConsumer CTEId="0" Columns="0,22">
+                                  <dxl:CTEConsumer CTEId="0" Columns="0,25">
                                     <dxl:Properties>
                                       <dxl:Cost StartupCost="0" TotalCost="431.000964" Rows="99.999999" Width="12"/>
                                     </dxl:Properties>
@@ -2706,8 +2706,8 @@ EXPLAIN CREATE TABLE test AS
                                       <dxl:ProjElem ColId="0" Alias="a">
                                         <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                                       </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                                        <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                      <dxl:ProjElem ColId="25" Alias="ColRef_0025">
+                                        <dxl:Ident ColId="25" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
                                       </dxl:ProjElem>
                                     </dxl:ProjList>
                                   </dxl:CTEConsumer>
@@ -2716,8 +2716,8 @@ EXPLAIN CREATE TABLE test AS
                                       <dxl:Cost StartupCost="0" TotalCost="431.001249" Rows="3.000000" Width="8"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
-                                      <dxl:ProjElem ColId="55" Alias="ColRef_0055">
-                                        <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                                      <dxl:ProjElem ColId="58" Alias="ColRef_0058">
+                                        <dxl:Ident ColId="58" ColName="ColRef_0058" TypeMdid="0.20.1.0"/>
                                       </dxl:ProjElem>
                                     </dxl:ProjList>
                                     <dxl:Filter/>
@@ -2726,8 +2726,8 @@ EXPLAIN CREATE TABLE test AS
                                         <dxl:Cost StartupCost="0" TotalCost="431.001241" Rows="3.000000" Width="8"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
-                                        <dxl:ProjElem ColId="55" Alias="ColRef_0055">
-                                          <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                                        <dxl:ProjElem ColId="58" Alias="ColRef_0058">
+                                          <dxl:Ident ColId="58" ColName="ColRef_0058" TypeMdid="0.20.1.0"/>
                                         </dxl:ProjElem>
                                       </dxl:ProjList>
                                       <dxl:Filter/>
@@ -2737,9 +2737,9 @@ EXPLAIN CREATE TABLE test AS
                                           <dxl:Cost StartupCost="0" TotalCost="431.000811" Rows="1.000000" Width="8"/>
                                         </dxl:Properties>
                                         <dxl:ProjList>
-                                          <dxl:ProjElem ColId="55" Alias="ColRef_0055">
-                                            <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
-                                              <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.1700.1.0"/>
+                                          <dxl:ProjElem ColId="58" Alias="ColRef_0058">
+                                            <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0" FuncVariadic="false">
+                                              <dxl:Ident ColId="57" ColName="ColRef_0057" TypeMdid="0.1700.1.0"/>
                                             </dxl:FuncExpr>
                                           </dxl:ProjElem>
                                         </dxl:ProjList>
@@ -2751,10 +2751,10 @@ EXPLAIN CREATE TABLE test AS
                                           </dxl:Properties>
                                           <dxl:GroupingColumns/>
                                           <dxl:ProjList>
-                                            <dxl:ProjElem ColId="54" Alias="ColRef_0054">
+                                            <dxl:ProjElem ColId="57" Alias="ColRef_0057">
                                               <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                                                 <dxl:ValuesList ParamType="aggargs">
-                                                  <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.17.1.0"/>
+                                                  <dxl:Ident ColId="129" ColName="ColRef_0129" TypeMdid="0.17.1.0"/>
                                                 </dxl:ValuesList>
                                                 <dxl:ValuesList ParamType="aggdirectargs"/>
                                                 <dxl:ValuesList ParamType="aggorder"/>
@@ -2768,8 +2768,8 @@ EXPLAIN CREATE TABLE test AS
                                               <dxl:Cost StartupCost="0" TotalCost="431.000702" Rows="1.000000" Width="8"/>
                                             </dxl:Properties>
                                             <dxl:ProjList>
-                                              <dxl:ProjElem ColId="126" Alias="ColRef_0126">
-                                                <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.17.1.0"/>
+                                              <dxl:ProjElem ColId="129" Alias="ColRef_0129">
+                                                <dxl:Ident ColId="129" ColName="ColRef_0129" TypeMdid="0.17.1.0"/>
                                               </dxl:ProjElem>
                                             </dxl:ProjList>
                                             <dxl:Filter/>
@@ -2780,10 +2780,10 @@ EXPLAIN CREATE TABLE test AS
                                               </dxl:Properties>
                                               <dxl:GroupingColumns/>
                                               <dxl:ProjList>
-                                                <dxl:ProjElem ColId="126" Alias="ColRef_0126">
+                                                <dxl:ProjElem ColId="129" Alias="ColRef_0129">
                                                   <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                                                     <dxl:ValuesList ParamType="aggargs">
-                                                      <dxl:Ident ColId="35" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                                      <dxl:Ident ColId="38" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
                                                     </dxl:ValuesList>
                                                     <dxl:ValuesList ParamType="aggdirectargs"/>
                                                     <dxl:ValuesList ParamType="aggorder"/>
@@ -2792,16 +2792,16 @@ EXPLAIN CREATE TABLE test AS
                                                 </dxl:ProjElem>
                                               </dxl:ProjList>
                                               <dxl:Filter/>
-                                              <dxl:CTEConsumer CTEId="0" Columns="34,35">
+                                              <dxl:CTEConsumer CTEId="0" Columns="37,38">
                                                 <dxl:Properties>
                                                   <dxl:Cost StartupCost="0" TotalCost="431.000643" Rows="99.999999" Width="8"/>
                                                 </dxl:Properties>
                                                 <dxl:ProjList>
-                                                  <dxl:ProjElem ColId="34" Alias="a">
-                                                    <dxl:Ident ColId="34" ColName="a" TypeMdid="0.23.1.0"/>
+                                                  <dxl:ProjElem ColId="37" Alias="a">
+                                                    <dxl:Ident ColId="37" ColName="a" TypeMdid="0.23.1.0"/>
                                                   </dxl:ProjElem>
-                                                  <dxl:ProjElem ColId="35" Alias="ColRef_0022">
-                                                    <dxl:Ident ColId="35" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                                  <dxl:ProjElem ColId="38" Alias="ColRef_0025">
+                                                    <dxl:Ident ColId="38" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
                                                   </dxl:ProjElem>
                                                 </dxl:ProjList>
                                               </dxl:CTEConsumer>
@@ -2852,8 +2852,8 @@ EXPLAIN CREATE TABLE test AS
                                     <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                                   </dxl:Cast>
                                   <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
-                                  <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
-                                  <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
                                 </dxl:ValuesList>
                                 <dxl:ValuesList ParamType="aggdirectargs"/>
                                 <dxl:ValuesList ParamType="aggorder"/>
@@ -2867,8 +2867,8 @@ EXPLAIN CREATE TABLE test AS
                                     <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                                   </dxl:Cast>
                                   <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                                  <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
-                                  <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
                                 </dxl:ValuesList>
                                 <dxl:ValuesList ParamType="aggdirectargs"/>
                                 <dxl:ValuesList ParamType="aggorder"/>
@@ -2882,8 +2882,8 @@ EXPLAIN CREATE TABLE test AS
                                     <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                                   </dxl:Cast>
                                   <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA6D8=" DoubleValue="0.750000"/>
-                                  <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
-                                  <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
                                 </dxl:ValuesList>
                                 <dxl:ValuesList ParamType="aggdirectargs"/>
                                 <dxl:ValuesList ParamType="aggorder"/>
@@ -2900,11 +2900,11 @@ EXPLAIN CREATE TABLE test AS
                               <dxl:ProjElem ColId="2" Alias="c">
                                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="90" Alias="ColRef_0090">
-                                <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                              <dxl:ProjElem ColId="93" Alias="ColRef_0093">
+                                <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="123" Alias="ColRef_0123">
-                                <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
+                              <dxl:ProjElem ColId="126" Alias="ColRef_0126">
+                                <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.20.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
@@ -2915,11 +2915,11 @@ EXPLAIN CREATE TABLE test AS
                                 <dxl:ProjElem ColId="2" Alias="c">
                                   <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
-                                <dxl:ProjElem ColId="90" Alias="ColRef_0090">
-                                  <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                                <dxl:ProjElem ColId="93" Alias="ColRef_0093">
+                                  <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
                                 </dxl:ProjElem>
-                                <dxl:ProjElem ColId="123" Alias="ColRef_0123">
-                                  <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
+                                <dxl:ProjElem ColId="126" Alias="ColRef_0126">
+                                  <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.20.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
@@ -2934,18 +2934,18 @@ EXPLAIN CREATE TABLE test AS
                                   <dxl:ProjElem ColId="2" Alias="c">
                                     <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="90" Alias="ColRef_0090">
-                                    <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                                  <dxl:ProjElem ColId="93" Alias="ColRef_0093">
+                                    <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
                                   </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="123" Alias="ColRef_0123">
-                                    <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
+                                  <dxl:ProjElem ColId="126" Alias="ColRef_0126">
+                                    <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.20.1.0"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
                                 <dxl:JoinFilter>
                                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                                 </dxl:JoinFilter>
-                                <dxl:CTEConsumer CTEId="2" Columns="2,90">
+                                <dxl:CTEConsumer CTEId="2" Columns="2,93">
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="431.000964" Rows="99.999999" Width="12"/>
                                   </dxl:Properties>
@@ -2953,8 +2953,8 @@ EXPLAIN CREATE TABLE test AS
                                     <dxl:ProjElem ColId="2" Alias="c">
                                       <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                                     </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="90" Alias="ColRef_0090">
-                                      <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                                    <dxl:ProjElem ColId="93" Alias="ColRef_0093">
+                                      <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
                                 </dxl:CTEConsumer>
@@ -2963,8 +2963,8 @@ EXPLAIN CREATE TABLE test AS
                                     <dxl:Cost StartupCost="0" TotalCost="431.001249" Rows="3.000000" Width="8"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
-                                    <dxl:ProjElem ColId="123" Alias="ColRef_0123">
-                                      <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
+                                    <dxl:ProjElem ColId="126" Alias="ColRef_0126">
+                                      <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.20.1.0"/>
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
                                   <dxl:Filter/>
@@ -2973,8 +2973,8 @@ EXPLAIN CREATE TABLE test AS
                                       <dxl:Cost StartupCost="0" TotalCost="431.001241" Rows="3.000000" Width="8"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
-                                      <dxl:ProjElem ColId="123" Alias="ColRef_0123">
-                                        <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
+                                      <dxl:ProjElem ColId="126" Alias="ColRef_0126">
+                                        <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.20.1.0"/>
                                       </dxl:ProjElem>
                                     </dxl:ProjList>
                                     <dxl:Filter/>
@@ -2984,9 +2984,9 @@ EXPLAIN CREATE TABLE test AS
                                         <dxl:Cost StartupCost="0" TotalCost="431.000811" Rows="1.000000" Width="8"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
-                                        <dxl:ProjElem ColId="123" Alias="ColRef_0123">
-                                          <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
-                                            <dxl:Ident ColId="122" ColName="ColRef_0122" TypeMdid="0.1700.1.0"/>
+                                        <dxl:ProjElem ColId="126" Alias="ColRef_0126">
+                                          <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0" FuncVariadic="false">
+                                            <dxl:Ident ColId="125" ColName="ColRef_0125" TypeMdid="0.1700.1.0"/>
                                           </dxl:FuncExpr>
                                         </dxl:ProjElem>
                                       </dxl:ProjList>
@@ -2998,10 +2998,10 @@ EXPLAIN CREATE TABLE test AS
                                         </dxl:Properties>
                                         <dxl:GroupingColumns/>
                                         <dxl:ProjList>
-                                          <dxl:ProjElem ColId="122" Alias="ColRef_0122">
+                                          <dxl:ProjElem ColId="125" Alias="ColRef_0125">
                                             <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                                               <dxl:ValuesList ParamType="aggargs">
-                                                <dxl:Ident ColId="124" ColName="ColRef_0124" TypeMdid="0.17.1.0"/>
+                                                <dxl:Ident ColId="127" ColName="ColRef_0127" TypeMdid="0.17.1.0"/>
                                               </dxl:ValuesList>
                                               <dxl:ValuesList ParamType="aggdirectargs"/>
                                               <dxl:ValuesList ParamType="aggorder"/>
@@ -3015,8 +3015,8 @@ EXPLAIN CREATE TABLE test AS
                                             <dxl:Cost StartupCost="0" TotalCost="431.000702" Rows="1.000000" Width="8"/>
                                           </dxl:Properties>
                                           <dxl:ProjList>
-                                            <dxl:ProjElem ColId="124" Alias="ColRef_0124">
-                                              <dxl:Ident ColId="124" ColName="ColRef_0124" TypeMdid="0.17.1.0"/>
+                                            <dxl:ProjElem ColId="127" Alias="ColRef_0127">
+                                              <dxl:Ident ColId="127" ColName="ColRef_0127" TypeMdid="0.17.1.0"/>
                                             </dxl:ProjElem>
                                           </dxl:ProjList>
                                           <dxl:Filter/>
@@ -3027,10 +3027,10 @@ EXPLAIN CREATE TABLE test AS
                                             </dxl:Properties>
                                             <dxl:GroupingColumns/>
                                             <dxl:ProjList>
-                                              <dxl:ProjElem ColId="124" Alias="ColRef_0124">
+                                              <dxl:ProjElem ColId="127" Alias="ColRef_0127">
                                                 <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                                                   <dxl:ValuesList ParamType="aggargs">
-                                                    <dxl:Ident ColId="103" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                                                    <dxl:Ident ColId="106" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
                                                   </dxl:ValuesList>
                                                   <dxl:ValuesList ParamType="aggdirectargs"/>
                                                   <dxl:ValuesList ParamType="aggorder"/>
@@ -3039,16 +3039,16 @@ EXPLAIN CREATE TABLE test AS
                                               </dxl:ProjElem>
                                             </dxl:ProjList>
                                             <dxl:Filter/>
-                                            <dxl:CTEConsumer CTEId="2" Columns="102,103">
+                                            <dxl:CTEConsumer CTEId="2" Columns="105,106">
                                               <dxl:Properties>
                                                 <dxl:Cost StartupCost="0" TotalCost="431.000643" Rows="99.999999" Width="8"/>
                                               </dxl:Properties>
                                               <dxl:ProjList>
-                                                <dxl:ProjElem ColId="102" Alias="c">
-                                                  <dxl:Ident ColId="102" ColName="c" TypeMdid="0.23.1.0"/>
+                                                <dxl:ProjElem ColId="105" Alias="c">
+                                                  <dxl:Ident ColId="105" ColName="c" TypeMdid="0.23.1.0"/>
                                                 </dxl:ProjElem>
-                                                <dxl:ProjElem ColId="103" Alias="ColRef_0090">
-                                                  <dxl:Ident ColId="103" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                                                <dxl:ProjElem ColId="106" Alias="ColRef_0093">
+                                                  <dxl:Ident ColId="106" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
                                                 </dxl:ProjElem>
                                               </dxl:ProjList>
                                             </dxl:CTEConsumer>

--- a/src/backend/gporca/data/dxl/minidump/ConvertHashToRandomInsert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ConvertHashToRandomInsert.mdp
@@ -597,10 +597,7 @@ explain analyze insert into t1 select t2.a,t3.b from t2, t3 where t2.a = t3.a;
       <dxl:ColumnStatistics Mdid="1.16538.1.0.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="1000.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="7" ColName="b" TypeMdid="0.25.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,7">
         <dxl:TableDescriptor Mdid="6.16533.1.0" TableName="t1">
@@ -643,9 +640,9 @@ explain analyze insert into t1 select t2.a,t3.b from t2, t3 where t2.a = t3.a;
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="18">
-      <dxl:DMLInsert Columns="0,6" ActionCol="10" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,6" ActionCol="15" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="877.746838" Rows="1000.000000" Width="7"/>
+          <dxl:Cost StartupCost="0" TotalCost="877.746838" Rows="1000.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -656,13 +653,13 @@ explain analyze insert into t1 select t2.a,t3.b from t2, t3 where t2.a = t3.a;
             <dxl:Ident ColId="6" ColName="b" TypeMdid="0.25.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16533.1.0" TableName="t1">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.25.1.0"/>
-            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="13" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="14" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -676,7 +673,7 @@ explain analyze insert into t1 select t2.a,t3.b from t2, t3 where t2.a = t3.a;
             <dxl:ProjElem ColId="6" Alias="b">
               <dxl:Ident ColId="6" ColName="b" TypeMdid="0.25.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+            <dxl:ProjElem ColId="15" Alias="ColRef_0015">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DML-ComputeScalar-With-Outerref.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-ComputeScalar-With-Outerref.mdp
@@ -236,9 +236,7 @@
       </dxl:GPDBAgg>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1">
         <dxl:TableDescriptor Mdid="6.49152.1.0" TableName="x">
@@ -319,9 +317,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="96">
-      <dxl:DMLInsert Columns="0" ActionCol="29" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0" ActionCol="37" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356691880.647039" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356691880.647039" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -329,16 +327,17 @@
             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.49152.1.0" TableName="x">
           <dxl:Columns>
-            <dxl:Column ColId="30" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="31" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="32" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="33" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="34" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="35" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="36" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="37" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="25" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="26" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -349,7 +348,7 @@
             <dxl:ProjElem ColId="0" Alias="a">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="29" Alias="ColRef_0029">
+            <dxl:ProjElem ColId="37" Alias="ColRef_0037">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DML-Filter-With-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-Filter-With-OuterRef.mdp
@@ -261,9 +261,7 @@
       </dxl:GPDBAgg>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1">
         <dxl:TableDescriptor Mdid="6.49152.1.0" TableName="x">
@@ -340,9 +338,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1620">
-      <dxl:DMLInsert Columns="0" ActionCol="32" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0" ActionCol="40" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356691694.210227" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356691694.210227" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -350,16 +348,17 @@
             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.49152.1.0" TableName="x">
           <dxl:Columns>
-            <dxl:Column ColId="33" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="35" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="36" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="37" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="38" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="39" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="40" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -370,7 +369,7 @@
             <dxl:ProjElem ColId="0" Alias="a">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="32" Alias="ColRef_0032">
+            <dxl:ProjElem ColId="40" Alias="ColRef_0040">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DML-Replicated-Input.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-Replicated-Input.mdp
@@ -269,11 +269,7 @@ WHERE  sach_vsnr = 465132477;
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="ag" TypeMdid="0.21.1.0"/>
-        <dxl:Ident ColId="2" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="11" ColName="idx_lfd_053" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2,11">
         <dxl:TableDescriptor Mdid="6.42167058.1.1" TableName="test_row_number_step2">
@@ -339,9 +335,9 @@ WHERE  sach_vsnr = 465132477;
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1,10" ActionCol="11" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1,10" ActionCol="21" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.001226" Rows="1.000000" Width="10"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.001226" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo>
           <dxl:KeyValue>
@@ -359,18 +355,17 @@ WHERE  sach_vsnr = 465132477;
             <dxl:Ident ColId="10" ColName="idx_lfd_053" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.42167058.1.1" TableName="test_row_number_step2">
           <dxl:Columns>
-            <dxl:Column ColId="12" Attno="1" ColName="ag" TypeMdid="0.21.1.0"/>
-            <dxl:Column ColId="13" Attno="2" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="14" Attno="3" ColName="idx_lfd_053" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="15" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="16" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="17" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="18" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="19" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="20" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="21" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="12" Attno="2" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53">
@@ -387,8 +382,8 @@ WHERE  sach_vsnr = 465132477;
             <dxl:ProjElem ColId="10" Alias="idx_lfd_053">
               <dxl:Ident ColId="10" ColName="idx_lfd_053" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-              <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+              <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -410,11 +405,11 @@ WHERE  sach_vsnr = 465132477;
                 <dxl:Ident ColId="1" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="10" Alias="idx_lfd_053">
-                <dxl:FuncExpr FuncId="0.480.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                <dxl:FuncExpr FuncId="0.480.1.0" FuncRetSet="false" TypeMdid="0.23.1.0" FuncVariadic="false">
                   <dxl:Ident ColId="9" ColName="idx_lfd_053" TypeMdid="0.20.1.0"/>
                 </dxl:FuncExpr>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+              <dxl:ProjElem ColId="21" Alias="ColRef_0021">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DML-UnionAll-With-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-UnionAll-With-OuterRef.mdp
@@ -291,9 +291,7 @@
       </dxl:GPDBAgg>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1">
         <dxl:TableDescriptor Mdid="6.49152.1.0" TableName="x">
@@ -387,9 +385,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="354">
-      <dxl:DMLInsert Columns="0" ActionCol="41" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0" ActionCol="49" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1808628108.398402" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1808628108.398402" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -397,16 +395,17 @@
             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.49152.1.0" TableName="x">
           <dxl:Columns>
-            <dxl:Column ColId="42" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="43" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="44" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="45" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="46" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="47" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="48" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="49" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="33" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="35" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="36" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="37" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="38" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="39" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="40" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -417,7 +416,7 @@
             <dxl:ProjElem ColId="0" Alias="a">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+            <dxl:ProjElem ColId="49" Alias="ColRef_0049">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DML-UnionAll-With-Universal-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-UnionAll-With-Universal-Child.mdp
@@ -209,9 +209,7 @@
       </dxl:GPDBScalarOp>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="2">
         <dxl:TableDescriptor Mdid="6.49155.1.0" TableName="y">
@@ -270,9 +268,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLInsert Columns="1" ActionCol="10" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="1" ActionCol="18" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.020983" Rows="2.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.020983" Rows="2.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -280,16 +278,17 @@
             <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.49155.1.0" TableName="y">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
@@ -300,8 +299,8 @@
             <dxl:ProjElem ColId="1" Alias="?column?">
               <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-              <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
+              <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -319,7 +318,7 @@
               <dxl:ProjElem ColId="1" Alias="?column?">
                 <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+              <dxl:ProjElem ColId="18" Alias="ColRef_0018">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DML-Volatile-Function.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-Volatile-Function.mdp
@@ -201,9 +201,7 @@
       <dxl:ColumnStatistics Mdid="1.188449.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="9">
         <dxl:TableDescriptor Mdid="6.188452.1.0" TableName="y">
@@ -249,9 +247,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="3">
-      <dxl:DMLInsert Columns="8" ActionCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="8" ActionCol="17" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.010506" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.010506" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -259,16 +257,17 @@
             <dxl:Ident ColId="8" ColName="test_func_pg_stats" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.188452.1.0" TableName="y">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1,2">
@@ -279,8 +278,8 @@
             <dxl:ProjElem ColId="8" Alias="test_func_pg_stats">
               <dxl:Ident ColId="8" ColName="test_func_pg_stats" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-              <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="17" Alias="ColRef_0017">
+              <dxl:Ident ColId="17" ColName="ColRef_0017" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -298,7 +297,7 @@
               <dxl:ProjElem ColId="8" Alias="test_func_pg_stats">
                 <dxl:Ident ColId="8" ColName="test_func_pg_stats" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+              <dxl:ProjElem ColId="17" Alias="ColRef_0017">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>
@@ -330,7 +329,7 @@
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="8" Alias="test_func_pg_stats">
-                      <dxl:FuncExpr FuncId="0.147456.1.0" FuncRetSet="false" TypeMdid="0.23.1.0"/>
+                      <dxl:FuncExpr FuncId="0.147456.1.0" FuncRetSet="false" TypeMdid="0.23.1.0" FuncVariadic="false"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-CorrelatedNLJ-With-Universal-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-CorrelatedNLJ-With-Universal-Child.mdp
@@ -230,9 +230,7 @@
       </dxl:GPDBAgg>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="2">
         <dxl:TableDescriptor Mdid="6.16388.1.0" TableName="target_table">
@@ -283,9 +281,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="16">
-      <dxl:DMLInsert Columns="1" ActionCol="14" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="1" ActionCol="22" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="882688.057927" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="882688.057927" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo>
           <dxl:KeyValue>
@@ -297,16 +295,17 @@
             <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16388.1.0" TableName="target_table">
           <dxl:Columns>
-            <dxl:Column ColId="15" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
@@ -317,8 +316,8 @@
             <dxl:ProjElem ColId="1" Alias="?column?">
               <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="14" Alias="ColRef_0014">
-              <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+              <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -336,7 +335,7 @@
               <dxl:ProjElem ColId="1" Alias="?column?">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+              <dxl:ProjElem ColId="22" Alias="ColRef_0022">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-HJ-And-UniversalChild.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-HJ-And-UniversalChild.mdp
@@ -712,22 +712,23 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="156">
-      <dxl:DMLDelete Columns="" ActionCol="23" CtidCol="1" SegmentIdCol="7">
+      <dxl:DMLDelete Columns="" ActionCol="31" CtidCol="1" SegmentIdCol="7">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324032.557257" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList/>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.49152.1.0" TableName="x">
           <dxl:Columns>
-            <dxl:Column ColId="24" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="19" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -741,7 +742,7 @@
             <dxl:ProjElem ColId="7" Alias="gp_segment_id">
               <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+            <dxl:ProjElem ColId="31" Alias="ColRef_0031">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-Join-With-Universal-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-Join-With-Universal-Child.mdp
@@ -185,9 +185,7 @@
       </dxl:Type>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1">
         <dxl:TableDescriptor Mdid="6.16388.1.0" TableName="target_table">
@@ -238,9 +236,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLInsert Columns="2" ActionCol="11" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="2" ActionCol="19" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="882688.097734" Rows="2.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="882688.097734" Rows="2.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -248,16 +246,17 @@
             <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16388.1.0" TableName="target_table">
           <dxl:Columns>
-            <dxl:Column ColId="12" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
@@ -268,8 +267,8 @@
             <dxl:ProjElem ColId="2" Alias="a">
               <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-              <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+              <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -287,7 +286,7 @@
               <dxl:ProjElem ColId="2" Alias="a">
                 <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+              <dxl:ProjElem ColId="19" Alias="ColRef_0019">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-MasterOnlyTable-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-MasterOnlyTable-1.mdp
@@ -367,22 +367,23 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="42">
-      <dxl:DMLDelete Columns="" ActionCol="29" CtidCol="1" SegmentIdCol="7">
+      <dxl:DMLDelete Columns="" ActionCol="37" CtidCol="1" SegmentIdCol="7">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324032.699310" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList/>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.49152.1.0" TableName="x">
           <dxl:Columns>
-            <dxl:Column ColId="30" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="31" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="32" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="33" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="34" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="35" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="36" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="37" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="25" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="26" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -396,7 +397,7 @@
             <dxl:ProjElem ColId="7" Alias="gp_segment_id">
               <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="29" Alias="ColRef_0029">
+            <dxl:ProjElem ColId="37" Alias="ColRef_0037">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-WindowFunc-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-WindowFunc-OuterRef.mdp
@@ -367,7 +367,7 @@
         </dxl:Properties>
         <dxl:DistrOpclasses/>
         <dxl:Columns>
-          <dxl:Column ColId="22" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="23" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
         <dxl:ProjList>
@@ -383,7 +383,7 @@
             <dxl:ProjElem ColId="0" Alias="i">
               <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+            <dxl:ProjElem ColId="22" Alias="ColRef_0022">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DMLCollapseProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DMLCollapseProject.mdp
@@ -292,12 +292,7 @@
       </dxl:ColumnStatistics>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="2" ColName="ttype" TypeMdid="0.1042.1.0"/>
-        <dxl:Ident ColId="3" ColName="ordnum" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="4" ColName="partnum" TypeMdid="0.25.1.0"/>
-        <dxl:Ident ColId="14" ColName="value" TypeMdid="0.701.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="2,3,4,14">
         <dxl:TableDescriptor Mdid="6.254053.1.1" TableName="shipped" ExecuteAsUser="10">
@@ -364,9 +359,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="4">
-      <dxl:DMLInsert Columns="1,2,3,13" ActionCol="15" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="1,2,3,13" ActionCol="26" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.062827" Rows="1.000000" Width="28"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.062827" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -383,19 +378,17 @@
             <dxl:Ident ColId="13" ColName="value" TypeMdid="0.701.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.254053.1.1" TableName="shipped" ExecuteAsUser="10">
           <dxl:Columns>
-            <dxl:Column ColId="16" Attno="1" ColName="ttype" TypeMdid="0.1042.1.0" ColWidth="2"/>
-            <dxl:Column ColId="17" Attno="2" ColName="ordnum" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="18" Attno="3" ColName="partnum" TypeMdid="0.25.1.0"/>
-            <dxl:Column ColId="19" Attno="4" ColName="value" TypeMdid="0.701.1.0"/>
-            <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="14" Attno="1" ColName="ttype" TypeMdid="0.1042.1.0" ColWidth="2"/>
+            <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="19" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="20" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="21" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="22" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="23" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="24" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1">
@@ -415,8 +408,8 @@
             <dxl:ProjElem ColId="13" Alias="value">
               <dxl:Ident ColId="13" ColName="value" TypeMdid="0.701.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="15" Alias="ColRef_0015">
-              <dxl:Ident ColId="15" ColName="ColRef_0015" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="26" Alias="ColRef_0026">
+              <dxl:Ident ColId="26" ColName="ColRef_0026" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -443,13 +436,13 @@
               <dxl:ProjElem ColId="13" Alias="value">
                 <dxl:Ident ColId="5" ColName="cost" TypeMdid="0.701.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="15" Alias="ColRef_0015">
+              <dxl:ProjElem ColId="26" Alias="ColRef_0026">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false">
+            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="862.000208" Rows="2.000000" Width="8"/>
               </dxl:Properties>
@@ -486,7 +479,7 @@
                 <dxl:AssertConstraintList>
                   <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.416.1.0">
-                      <dxl:Ident ColId="14" ColName="row_number" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="25" ColName="row_number" TypeMdid="0.20.1.0"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                     </dxl:Comparison>
                   </dxl:AssertConstraint>
@@ -496,7 +489,7 @@
                     <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="14" Alias="row_number">
+                    <dxl:ProjElem ColId="25" Alias="row_number">
                       <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
                     </dxl:ProjElem>
                     <dxl:ProjElem ColId="5" Alias="cost">

--- a/src/backend/gporca/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
@@ -722,22 +722,23 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="238">
-      <dxl:DMLDelete Columns="" ActionCol="21" CtidCol="1" SegmentIdCol="7">
+      <dxl:DMLDelete Columns="" ActionCol="29" CtidCol="1" SegmentIdCol="7">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.960365" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList/>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.49433.1.0" TableName="test2">
           <dxl:Columns>
-            <dxl:Column ColId="22" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="19" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="20" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="21" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="22" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="23" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -751,7 +752,7 @@
             <dxl:ProjElem ColId="7" Alias="gp_segment_id">
               <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+            <dxl:ProjElem ColId="29" Alias="ColRef_0029">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DeleteMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteMismatchedDistribution.mdp
@@ -338,24 +338,23 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="40">
-      <dxl:DMLDelete Columns="" ActionCol="24" CtidCol="3" SegmentIdCol="9">
+      <dxl:DMLDelete Columns="" ActionCol="34" CtidCol="3" SegmentIdCol="9">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.014131" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList/>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.24803.1.0" TableName="pt2">
           <dxl:Columns>
-            <dxl:Column ColId="25" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="26" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="27" Attno="3" ColName="k" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="28" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="29" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="30" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="31" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="32" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="33" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="34" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="20" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -369,7 +368,7 @@
             <dxl:ProjElem ColId="9" Alias="gp_segment_id">
               <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="24" Alias="ColRef_0024">
+            <dxl:ProjElem ColId="34" Alias="ColRef_0034">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DeleteRandomDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteRandomDistr.mdp
@@ -203,23 +203,22 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLDelete Columns="" ActionCol="9" CtidCol="2" SegmentIdCol="8">
+      <dxl:DMLDelete Columns="" ActionCol="18" CtidCol="2" SegmentIdCol="8">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.027391" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList/>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.17027.1.1" TableName="rr">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -233,7 +232,7 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTable.mdp
@@ -196,22 +196,22 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLDelete Columns="" ActionCol="8" CtidCol="1" SegmentIdCol="7">
+      <dxl:DMLDelete Columns="" ActionCol="16" CtidCol="1" SegmentIdCol="7">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.018246" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList/>
-        <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1" LockMode="3">
+        <dxl:ProjList/>
+        <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1">
           <dxl:Columns>
-            <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="11" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="13" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="10" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -225,7 +225,7 @@
             <dxl:ProjElem ColId="7" Alias="gp_segment_id">
               <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="8" Alias="ColRef_0008">
+            <dxl:ProjElem ColId="16" Alias="ColRef_0016">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
@@ -244,7 +244,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1" LockMode="3">
+            <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1">
               <dxl:Columns>
                 <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>

--- a/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTableJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTableJoin.mdp
@@ -278,22 +278,22 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="17">
-      <dxl:DMLDelete Columns="" ActionCol="16" CtidCol="1" SegmentIdCol="7">
+      <dxl:DMLDelete Columns="" ActionCol="24" CtidCol="1" SegmentIdCol="7">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.018692" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList/>
-        <dxl:TableDescriptor Mdid="6.16414.1.0" TableName="foo" LockMode="3">
+        <dxl:ProjList/>
+        <dxl:TableDescriptor Mdid="6.16414.1.0" TableName="foo">
           <dxl:Columns>
-            <dxl:Column ColId="17" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="19" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="20" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="21" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="22" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="23" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="24" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="18" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="19" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="20" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="21" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="22" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="23" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -307,7 +307,7 @@
             <dxl:ProjElem ColId="7" Alias="gp_segment_id">
               <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="16" Alias="ColRef_0016">
+            <dxl:ProjElem ColId="24" Alias="ColRef_0024">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
@@ -385,7 +385,7 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.16414.1.0" TableName="foo" LockMode="3">
+                  <dxl:TableDescriptor Mdid="6.16414.1.0" TableName="foo">
                     <dxl:Columns>
                       <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                       <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
@@ -409,7 +409,7 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="6.16417.1.0" TableName="bar" LockMode="1">
+                <dxl:TableDescriptor Mdid="6.16417.1.0" TableName="bar">
                   <dxl:Columns>
                     <dxl:Column ColId="8" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                     <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>

--- a/src/backend/gporca/data/dxl/minidump/DeleteWithAfterTriggerDroppedCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteWithAfterTriggerDroppedCol.mdp
@@ -251,7 +251,7 @@ drop function func_trigger();
               <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:DMLDelete Columns="0" ActionCol="8" CtidCol="1" SegmentIdCol="7">
+          <dxl:DMLDelete Columns="0" ActionCol="16" CtidCol="1" SegmentIdCol="7">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.023504" Rows="1.000000" Width="4"/>
             </dxl:Properties>
@@ -261,16 +261,45 @@ drop function func_trigger();
                 <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="8" Alias="i">
+                <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="9" Alias="ctid">
+                <dxl:Ident ColId="9" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="xmin">
+                <dxl:Ident ColId="10" ColName="xmin" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="cmin">
+                <dxl:Ident ColId="11" ColName="cmin" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="xmax">
+                <dxl:Ident ColId="12" ColName="xmax" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="13" Alias="cmax">
+                <dxl:Ident ColId="13" ColName="cmax" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="14" Alias="tableoid">
+                <dxl:Ident ColId="14" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="15" Alias="gp_segment_id">
+                <dxl:Ident ColId="15" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="0" Alias="i">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
             <dxl:TableDescriptor Mdid="6.97545.1.0" TableName="t">
               <dxl:Columns>
-                <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
               </dxl:Columns>
             </dxl:TableDescriptor>
             <dxl:Result>
@@ -287,7 +316,7 @@ drop function func_trigger();
                 <dxl:ProjElem ColId="7" Alias="gp_segment_id">
                   <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="8" Alias="ColRef_0008">
+                <dxl:ProjElem ColId="16" Alias="ColRef_0016">
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DeleteWithTriggers.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteWithTriggers.mdp
@@ -233,7 +233,7 @@
               <dxl:Ident ColId="2" ColName="t3" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:DMLDelete Columns="0,1,2" ActionCol="10" CtidCol="3" SegmentIdCol="9">
+          <dxl:DMLDelete Columns="0,1,2" ActionCol="20" CtidCol="3" SegmentIdCol="9">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.050887" Rows="1.000000" Width="12"/>
             </dxl:Properties>
@@ -249,18 +249,51 @@
                 <dxl:Ident ColId="2" ColName="t3" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="t1">
+                <dxl:Ident ColId="10" ColName="t1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="13" Alias="ctid">
+                <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="14" Alias="xmin">
+                <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="15" Alias="cmin">
+                <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="16" Alias="xmax">
+                <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="cmax">
+                <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="tableoid">
+                <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="0" Alias="t1">
+                <dxl:Ident ColId="0" ColName="t1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="t2">
+                <dxl:Ident ColId="1" ColName="t2" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="t3">
+                <dxl:Ident ColId="2" ColName="t3" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
             <dxl:TableDescriptor Mdid="6.187376.1.1" TableName="t_trig">
               <dxl:Columns>
-                <dxl:Column ColId="11" Attno="1" ColName="t1" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="12" Attno="2" ColName="t2" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="13" Attno="3" ColName="t3" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="10" Attno="1" ColName="t1" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:Columns>
             </dxl:TableDescriptor>
             <dxl:RowTrigger RelationMdid="6.187376.1.1" Type="11" OldColumns="0,1,2">
@@ -283,8 +316,8 @@
                 <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                   <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-                  <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                  <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Result>
@@ -307,7 +340,7 @@
                   <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                     <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+                  <dxl:ProjElem ColId="20" Alias="ColRef_0020">
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DontAddRedistributeBeforeInsert-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DontAddRedistributeBeforeInsert-1.mdp
@@ -265,10 +265,7 @@ Physical plan:
       </dxl:GPDBScalarOp>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2">
         <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t1_random">
@@ -355,9 +352,9 @@ Physical plan:
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="168">
-      <dxl:DMLInsert Columns="0,1" ActionCol="22" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="31" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1765376.365398" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1765376.365398" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -368,17 +365,16 @@ Physical plan:
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t1_random">
           <dxl:Columns>
-            <dxl:Column ColId="23" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="24" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -392,7 +388,7 @@ Physical plan:
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+            <dxl:ProjElem ColId="31" Alias="ColRef_0031">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DontAddRedistributeBeforeInsert-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DontAddRedistributeBeforeInsert-2.mdp
@@ -168,9 +168,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.28.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1">
         <dxl:TableDescriptor Mdid="6.20432.1.0" TableName="t1_x">
@@ -221,9 +219,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLInsert Columns="0" ActionCol="16" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0" ActionCol="24" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.010432" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.010432" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -231,16 +229,16 @@
             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.28.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.20432.1.0" TableName="t1_x">
           <dxl:Columns>
-            <dxl:Column ColId="17" Attno="1" ColName="a" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="19" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="20" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="21" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="22" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="23" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="24" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="18" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="19" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="20" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="21" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -251,7 +249,7 @@
             <dxl:ProjElem ColId="0" Alias="a">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.28.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="16" Alias="ColRef_0016">
+            <dxl:ProjElem ColId="24" Alias="ColRef_0024">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/InnerJoinOverJoinExcept.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InnerJoinOverJoinExcept.mdp
@@ -203,9 +203,7 @@ ON (a.col = b.col);
       </dxl:GPDBScalarOp>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="col" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1">
         <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="mytable" LockMode="3">
@@ -296,9 +294,9 @@ ON (a.col = b.col);
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1248">
-      <dxl:DMLInsert Columns="0" ActionCol="32" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0" ActionCol="40" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.011396" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.011396" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -306,16 +304,17 @@ ON (a.col = b.col);
             <dxl:Ident ColId="0" ColName="col" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="mytable">
           <dxl:Columns>
-            <dxl:Column ColId="33" Attno="1" ColName="col" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="35" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="36" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="37" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="38" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="39" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="40" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="32" Attno="1" ColName="col" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="33" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="34" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="35" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="36" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="37" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="38" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="39" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -326,7 +325,7 @@ ON (a.col = b.col);
             <dxl:ProjElem ColId="0" Alias="col">
               <dxl:Ident ColId="0" ColName="col" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="32" Alias="ColRef_0032">
+            <dxl:ProjElem ColId="40" Alias="ColRef_0040">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/InnerJoinOverJoinExceptAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InnerJoinOverJoinExceptAll.mdp
@@ -241,9 +241,7 @@ ON (a.col = b.col);
       </dxl:GPDBScalarOp>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="col" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1">
         <dxl:TableDescriptor Mdid="6.32783.1.0" TableName="mytable" LockMode="3">
@@ -334,9 +332,9 @@ ON (a.col = b.col);
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1127">
-      <dxl:DMLInsert Columns="0" ActionCol="34" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0" ActionCol="42" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.011735" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.011735" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -344,16 +342,17 @@ ON (a.col = b.col);
             <dxl:Ident ColId="0" ColName="col" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.32783.1.0" TableName="mytable">
           <dxl:Columns>
-            <dxl:Column ColId="35" Attno="1" ColName="col" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="36" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="37" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="38" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="39" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="40" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="41" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="42" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="32" Attno="1" ColName="col" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="33" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="34" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="35" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="36" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="37" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="38" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="39" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -364,7 +363,7 @@ ON (a.col = b.col);
             <dxl:ProjElem ColId="0" Alias="col">
               <dxl:Ident ColId="0" ColName="col" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="34" Alias="ColRef_0034">
+            <dxl:ProjElem ColId="42" Alias="ColRef_0042">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
@@ -430,8 +429,8 @@ ON (a.col = b.col);
                 </dxl:Not>
                 <dxl:Not>
                   <dxl:IsDistinctFrom OperatorMdid="0.410.1.0">
-                    <dxl:Ident ColId="32" ColName="row_number" TypeMdid="0.20.1.0"/>
-                    <dxl:Ident ColId="33" ColName="row_number" TypeMdid="0.20.1.0"/>
+                    <dxl:Ident ColId="40" ColName="row_number" TypeMdid="0.20.1.0"/>
+                    <dxl:Ident ColId="41" ColName="row_number" TypeMdid="0.20.1.0"/>
                   </dxl:IsDistinctFrom>
                 </dxl:Not>
               </dxl:HashCondList>
@@ -440,7 +439,7 @@ ON (a.col = b.col);
                   <dxl:Cost StartupCost="0" TotalCost="862.000424" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="32" Alias="row_number">
+                  <dxl:ProjElem ColId="40" Alias="row_number">
                     <dxl:WindowFunc Mdid="0.3100.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="8" Alias="col">
@@ -539,7 +538,7 @@ ON (a.col = b.col);
                   <dxl:Cost StartupCost="0" TotalCost="431.000026" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="33" Alias="row_number">
+                  <dxl:ProjElem ColId="41" Alias="row_number">
                     <dxl:WindowFunc Mdid="0.3100.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="24" Alias="col">

--- a/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned-SortDisabled.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned-SortDisabled.mdp
@@ -196,10 +196,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2">
         <dxl:TableDescriptor Mdid="6.1319741.1.1" TableName="p_parquet">
@@ -229,9 +226,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1" ActionCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="14" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.023465" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.023465" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -242,13 +239,13 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.1319741.1.1" TableName="p_parquet">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="13" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="14" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="12" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="13" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -262,7 +259,7 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+            <dxl:ProjElem ColId="14" Alias="ColRef_0014">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/Insert-Parquet.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-Parquet.mdp
@@ -177,10 +177,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2">
         <dxl:TableDescriptor Mdid="6.1319711.1.1" TableName="r_parquet">
@@ -210,9 +207,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1" ActionCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="14" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.023465" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.023465" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -223,13 +220,13 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.1319711.1.1" TableName="r_parquet">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="13" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="14" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="12" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="13" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -243,7 +240,7 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+            <dxl:ProjElem ColId="14" Alias="ColRef_0014">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
@@ -382,13 +382,7 @@
       <dxl:MDCast Mdid="3.23.1.0;701.1.0" Name="float8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.701.1.0" CastFuncId="0.316.1.0" CoercePathType="1"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="23" ColName="country_code" TypeMdid="0.25.1.0"/>
-        <dxl:Ident ColId="24" ColName="country_name" TypeMdid="0.25.1.0"/>
-        <dxl:Ident ColId="27" ColName="lang_count" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="28" ColName="area" TypeMdid="0.701.1.0"/>
-        <dxl:Ident ColId="29" ColName="gnp" TypeMdid="0.701.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList>
         <dxl:LogicalCTEProducer CTEId="1" Columns="19,1,10">
           <dxl:LogicalGroupBy>
@@ -509,9 +503,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1180">
-      <dxl:DMLInsert Columns="38,39,42,43,44" ActionCol="48" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="38,39,42,43,44" ActionCol="60" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="867.122533" Rows="96.000000" Width="36"/>
+          <dxl:Cost StartupCost="0" TotalCost="867.122533" Rows="96.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -531,20 +525,17 @@
             <dxl:Ident ColId="44" ColName="gnp" TypeMdid="0.701.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.57387.1.0" TableName="countries_results">
           <dxl:Columns>
-            <dxl:Column ColId="49" Attno="1" ColName="country_code" TypeMdid="0.25.1.0" ColWidth="8"/>
-            <dxl:Column ColId="50" Attno="2" ColName="country_name" TypeMdid="0.25.1.0" ColWidth="8"/>
-            <dxl:Column ColId="51" Attno="3" ColName="lang_count" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="52" Attno="4" ColName="area" TypeMdid="0.701.1.0" ColWidth="8"/>
-            <dxl:Column ColId="53" Attno="5" ColName="gnp" TypeMdid="0.701.1.0" ColWidth="8"/>
-            <dxl:Column ColId="54" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="55" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="56" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="57" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="58" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="59" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="60" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="45" Attno="1" ColName="country_code" TypeMdid="0.25.1.0" ColWidth="8"/>
+            <dxl:Column ColId="50" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="51" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="52" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="53" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="54" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="55" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="56" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -559,7 +550,7 @@
               <dxl:Ident ColId="39" ColName="?column?" TypeMdid="0.25.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="42" Alias="lang_count">
-              <dxl:FuncExpr FuncId="0.480.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+              <dxl:FuncExpr FuncId="0.480.1.0" FuncRetSet="false" TypeMdid="0.23.1.0" FuncVariadic="false">
                 <dxl:Ident ColId="19" ColName="lang_count" TypeMdid="0.20.1.0"/>
               </dxl:FuncExpr>
             </dxl:ProjElem>
@@ -573,7 +564,7 @@
                 <dxl:Ident ColId="41" ColName="?column?" TypeMdid="0.23.1.0"/>
               </dxl:Cast>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="48" Alias="ColRef_0048">
+            <dxl:ProjElem ColId="60" Alias="ColRef_0060">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
@@ -663,7 +654,7 @@
                   </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="19" Alias="lang_count">
-                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
+                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                         <dxl:ValuesList ParamType="aggargs"/>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/Insert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert.mdp
@@ -179,7 +179,7 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="1,0" ActionCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="1,0" ActionCol="18" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.023484" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -192,17 +192,17 @@
             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.1435422.1.1" TableName="r">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -216,7 +216,7 @@
             <dxl:ProjElem ColId="0" Alias="a">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/InsertAssertSort.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertAssertSort.mdp
@@ -303,11 +303,7 @@ explain insert into tbl_cds_buysell_orders_new (a,b,c)
       <dxl:ColumnStatistics Mdid="1.30252115.1.1.4" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2,3,21,22,23,24">
         <dxl:TableDescriptor Mdid="6.30252084.1.1" TableName="tbl_cds_buysell_orders_new">
@@ -366,9 +362,9 @@ explain insert into tbl_cds_buysell_orders_new (a,b,c)
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1,2,10,11,12,13" ActionCol="14" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1,2,10,11,12,13" ActionCol="24" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="42587.627692" Rows="1000000.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="42587.627692" Rows="1000000.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -394,18 +390,15 @@ explain insert into tbl_cds_buysell_orders_new (a,b,c)
             <dxl:Ident ColId="13" ColName="g" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.30252084.1.1" TableName="tbl_cds_buysell_orders_new">
           <dxl:Columns>
-            <dxl:Column ColId="15" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="16" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="17" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="18" Attno="4" ColName="d" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="19" Attno="5" ColName="e" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="20" Attno="6" ColName="f" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="21" Attno="7" ColName="g" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="22" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="23" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="24" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="14" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="15" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="16" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
@@ -434,8 +427,8 @@ explain insert into tbl_cds_buysell_orders_new (a,b,c)
             <dxl:ProjElem ColId="13" Alias="g">
               <dxl:Ident ColId="13" ColName="g" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="14" Alias="ColRef_0014">
-              <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="24" Alias="ColRef_0024">
+              <dxl:Ident ColId="24" ColName="ColRef_0024" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -477,8 +470,8 @@ explain insert into tbl_cds_buysell_orders_new (a,b,c)
               <dxl:ProjElem ColId="13" Alias="g">
                 <dxl:Ident ColId="13" ColName="g" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="14" Alias="ColRef_0014">
-                <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="24" Alias="ColRef_0024">
+                <dxl:Ident ColId="24" ColName="ColRef_0024" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:AssertConstraintList>
@@ -497,20 +490,20 @@ explain insert into tbl_cds_buysell_orders_new (a,b,c)
                 <dxl:Cost StartupCost="0" TotalCost="876.907692" Rows="1000000.000000" Width="32"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+                <dxl:ProjElem ColId="24" Alias="ColRef_0024">
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="10" Alias="d">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="11" Alias="e">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="12" Alias="f">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="13" Alias="g">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="0" Alias="a">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/InsertCheckConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertCheckConstraint.mdp
@@ -280,7 +280,7 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="1,2,3,4" ActionCol="5" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="1,2,3,4" ActionCol="16" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="0.039178" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -303,19 +303,17 @@
             <dxl:Ident ColId="4" ColName="d" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.17005.1.1" TableName="r">
           <dxl:Columns>
-            <dxl:Column ColId="6" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="7" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="8" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="9" Attno="4" ColName="d" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="5" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
@@ -335,8 +333,8 @@
             <dxl:ProjElem ColId="4" Alias="d">
               <dxl:Ident ColId="4" ColName="d" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="5" Alias="ColRef_0005">
-              <dxl:Ident ColId="5" ColName="ColRef_0005" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="16" Alias="ColRef_0016">
+              <dxl:Ident ColId="16" ColName="ColRef_0016" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -363,8 +361,8 @@
               <dxl:ProjElem ColId="4" Alias="d">
                 <dxl:Ident ColId="4" ColName="d" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="5" Alias="ColRef_0005">
-                <dxl:Ident ColId="5" ColName="ColRef_0005" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="16" Alias="ColRef_0016">
+                <dxl:Ident ColId="16" ColName="ColRef_0016" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:AssertConstraintList>
@@ -404,8 +402,8 @@
                 <dxl:ProjElem ColId="4" Alias="d">
                   <dxl:Ident ColId="4" ColName="d" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="5" Alias="ColRef_0005">
-                  <dxl:Ident ColId="5" ColName="ColRef_0005" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="16" Alias="ColRef_0016">
+                  <dxl:Ident ColId="16" ColName="ColRef_0016" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:AssertConstraintList>
@@ -422,7 +420,7 @@
                   <dxl:Cost StartupCost="0" TotalCost="0.000021" Rows="1.000000" Width="20"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="5" Alias="ColRef_0005">
+                  <dxl:ProjElem ColId="16" Alias="ColRef_0016">
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="3" Alias="c">

--- a/src/backend/gporca/data/dxl/minidump/InsertConstTuple.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertConstTuple.mdp
@@ -193,7 +193,7 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="3">
-      <dxl:DMLInsert Columns="1,2" ActionCol="3" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="1,2" ActionCol="12" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="0.023474" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -210,17 +210,17 @@
             <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.968511.1.1" TableName="r">
           <dxl:Columns>
-            <dxl:Column ColId="4" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="5" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="3" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -234,7 +234,7 @@
             <dxl:ProjElem ColId="2" Alias="b">
               <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="3" Alias="ColRef_0003">
+            <dxl:ProjElem ColId="12" Alias="ColRef_0012">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/InsertConstTupleRandomDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertConstTupleRandomDistribution.mdp
@@ -169,10 +169,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="3" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="2,3">
         <dxl:TableDescriptor Mdid="6.16462.1.0" TableName="rand">
@@ -209,9 +206,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="1,2" ActionCol="3" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="1,2" ActionCol="12" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.015645" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.015645" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -222,17 +219,16 @@
             <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16462.1.0" TableName="rand">
           <dxl:Columns>
-            <dxl:Column ColId="4" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="5" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
@@ -246,8 +242,8 @@
             <dxl:ProjElem ColId="2" Alias="b">
               <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="3" Alias="ColRef_0003">
-              <dxl:Ident ColId="3" ColName="ColRef_0003" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="12" Alias="ColRef_0012">
+              <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -263,7 +259,7 @@
               <dxl:ProjElem ColId="2" Alias="b">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="3" Alias="ColRef_0003">
+              <dxl:ProjElem ColId="12" Alias="ColRef_0012">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/InsertConstTupleVolatileFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertConstTupleVolatileFunction.mdp
@@ -187,10 +187,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="2" ColName="id" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="3" ColName="a" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="2,3">
         <dxl:TableDescriptor Mdid="6.319018.1.1" TableName="delete_test">
@@ -231,9 +228,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="1,2" ActionCol="3" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="1,2" ActionCol="12" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.023595" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.023595" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -244,17 +241,17 @@
             <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.319018.1.1" TableName="delete_test">
           <dxl:Columns>
-            <dxl:Column ColId="4" Attno="1" ColName="id" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="5" Attno="2" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="3" Attno="1" ColName="id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1">
@@ -268,8 +265,8 @@
             <dxl:ProjElem ColId="2" Alias="a">
               <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="3" Alias="ColRef_0003">
-              <dxl:Ident ColId="3" ColName="ColRef_0003" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="12" Alias="ColRef_0012">
+              <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -290,8 +287,8 @@
               <dxl:ProjElem ColId="2" Alias="a">
                 <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="3" Alias="ColRef_0003">
-                <dxl:Ident ColId="3" ColName="ColRef_0003" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="12" Alias="ColRef_0012">
+                <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:AssertConstraintList>
@@ -308,12 +305,12 @@
                 <dxl:Cost StartupCost="0" TotalCost="0.000113" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="3" Alias="ColRef_0003">
+                <dxl:ProjElem ColId="12" Alias="ColRef_0012">
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="1" Alias="id">
-                  <dxl:FuncExpr FuncId="0.480.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                    <dxl:FuncExpr FuncId="0.1574.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                  <dxl:FuncExpr FuncId="0.480.1.0" FuncRetSet="false" TypeMdid="0.23.1.0" FuncVariadic="false">
+                    <dxl:FuncExpr FuncId="0.1574.1.0" FuncRetSet="false" TypeMdid="0.20.1.0" FuncVariadic="false">
                       <dxl:ConstValue TypeMdid="0.2205.1.0" Value="Hd4EAA=="/>
                     </dxl:FuncExpr>
                   </dxl:FuncExpr>

--- a/src/backend/gporca/data/dxl/minidump/InsertConstTupleVolatileFunctionMOTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertConstTupleVolatileFunctionMOTable.mdp
@@ -177,10 +177,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="3" ColName="id" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="2,3">
         <dxl:TableDescriptor Mdid="6.319084.1.1" TableName="m">
@@ -221,9 +218,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="5">
-      <dxl:DMLInsert Columns="1,2" ActionCol="3" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="1,2" ActionCol="12" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.047000" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.047000" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -234,17 +231,16 @@
             <dxl:Ident ColId="2" ColName="id" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.319084.1.1" TableName="m">
           <dxl:Columns>
-            <dxl:Column ColId="4" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="5" Attno="2" ColName="id" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Assert ErrorCode="23502">
@@ -258,8 +254,8 @@
             <dxl:ProjElem ColId="2" Alias="id">
               <dxl:Ident ColId="2" ColName="id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="3" Alias="ColRef_0003">
-              <dxl:Ident ColId="3" ColName="ColRef_0003" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="12" Alias="ColRef_0012">
+              <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:AssertConstraintList>
@@ -276,15 +272,15 @@
               <dxl:Cost StartupCost="0" TotalCost="0.000113" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="3" Alias="ColRef_0003">
+              <dxl:ProjElem ColId="12" Alias="ColRef_0012">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="1" Alias="a">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="2" Alias="id">
-                <dxl:FuncExpr FuncId="0.480.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                  <dxl:FuncExpr FuncId="0.1574.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                <dxl:FuncExpr FuncId="0.480.1.0" FuncRetSet="false" TypeMdid="0.23.1.0" FuncVariadic="false">
+                  <dxl:FuncExpr FuncId="0.1574.1.0" FuncRetSet="false" TypeMdid="0.20.1.0" FuncVariadic="false">
                     <dxl:ConstValue TypeMdid="0.2205.1.0" Value="g94EAA=="/>
                   </dxl:FuncExpr>
                 </dxl:FuncExpr>

--- a/src/backend/gporca/data/dxl/minidump/InsertDirectedDispatchNullValue.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertDirectedDispatchNullValue.mdp
@@ -163,10 +163,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="2" ColName="col2" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="3" ColName="col3" TypeMdid="0.25.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="14,2,3">
         <dxl:TableDescriptor Mdid="6.1171244.1.1" TableName="inserttest">
@@ -211,9 +208,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="3,1,2" ActionCol="4" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="3,1,2" ActionCol="14" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.039158" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.039158" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo>
           <dxl:KeyValue>
@@ -231,18 +228,17 @@
             <dxl:Ident ColId="2" ColName="col3" TypeMdid="0.25.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.1171244.1.1" TableName="inserttest">
           <dxl:Columns>
-            <dxl:Column ColId="5" Attno="1" ColName="col1" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="6" Attno="2" ColName="col2" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="7" Attno="3" ColName="col3" TypeMdid="0.25.1.0"/>
-            <dxl:Column ColId="8" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="9" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="10" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="11" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="12" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="13" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="14" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="4" Attno="1" ColName="col1" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="7" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="8" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="9" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="10" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="11" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="12" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="13" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
@@ -259,8 +255,8 @@
             <dxl:ProjElem ColId="2" Alias="col3">
               <dxl:Ident ColId="2" ColName="col3" TypeMdid="0.25.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="4" Alias="ColRef_0004">
-              <dxl:Ident ColId="4" ColName="ColRef_0004" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+              <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -284,8 +280,8 @@
               <dxl:ProjElem ColId="2" Alias="col3">
                 <dxl:Ident ColId="2" ColName="col3" TypeMdid="0.25.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="4" Alias="ColRef_0004">
-                <dxl:Ident ColId="4" ColName="ColRef_0004" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+                <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:AssertConstraintList>
@@ -302,7 +298,7 @@
                 <dxl:Cost StartupCost="0" TotalCost="0.000021" Rows="1.000000" Width="20"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="4" Alias="ColRef_0004">
+                <dxl:ProjElem ColId="14" Alias="ColRef_0014">
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="3" Alias="col1">

--- a/src/backend/gporca/data/dxl/minidump/InsertIntoNonNullAfterDroppingColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertIntoNonNullAfterDroppingColumn.mdp
@@ -148,9 +148,7 @@ EXPLAIN INSERT INTO ColumnMapping VALUES (NULL);
     </dxl:Relation>
   </dxl:Metadata>
   <dxl:Query>
-    <dxl:OutputColumns>
-      <dxl:Ident ColId="2" ColName="id" TypeMdid="0.23.1.0"/>
-    </dxl:OutputColumns>
+    <dxl:OutputColumns />
     <dxl:CTEList/>
     <dxl:LogicalInsert InsertColumns="2">
       <dxl:TableDescriptor Mdid="6.616755.1.1" TableName="columnmapping">
@@ -182,14 +180,14 @@ EXPLAIN INSERT INTO ColumnMapping VALUES (NULL);
       </dxl:LogicalProject>
     </dxl:LogicalInsert>
   </dxl:Query>
-  <dxl:Plan Id="0" SpaceSize="2">
-    <dxl:DMLInsert Columns="1" ActionCol="2" CtidCol="0" SegmentIdCol="0">
+      <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:DMLInsert Columns="1" ActionCol="10" CtidCol="0" SegmentIdCol="0">
       <dxl:Properties>
-        <dxl:Cost StartupCost="0" TotalCost="0.010454" Rows="1.000000" Width="4"/>
+        <dxl:Cost StartupCost="0" TotalCost="0.010454" Rows="1.000000" Width="1"/>
       </dxl:Properties>
       <dxl:DirectDispatchInfo>
         <dxl:KeyValue>
-          <dxl:Datum TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+          <dxl:Datum TypeMdid="0.23.1.0" IsNull="true"/>
         </dxl:KeyValue>
       </dxl:DirectDispatchInfo>
       <dxl:ProjList>
@@ -197,16 +195,17 @@ EXPLAIN INSERT INTO ColumnMapping VALUES (NULL);
           <dxl:Ident ColId="1" ColName="id" TypeMdid="0.23.1.0"/>
         </dxl:ProjElem>
       </dxl:ProjList>
+      <dxl:ProjList/>
       <dxl:TableDescriptor Mdid="6.616755.1.1" TableName="columnmapping">
         <dxl:Columns>
-          <dxl:Column ColId="3" Attno="2" ColName="id" TypeMdid="0.23.1.0"/>
-          <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-          <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-          <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-          <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-          <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-          <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-          <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="2" Attno="2" ColName="id" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+          <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+          <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+          <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+          <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+          <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+          <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
       </dxl:TableDescriptor>
       <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
@@ -217,8 +216,8 @@ EXPLAIN INSERT INTO ColumnMapping VALUES (NULL);
           <dxl:ProjElem ColId="1" Alias="id">
             <dxl:Ident ColId="1" ColName="id" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="2" Alias="ColRef_0002">
-            <dxl:Ident ColId="2" ColName="ColRef_0002" TypeMdid="0.23.1.0"/>
+          <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+            <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
@@ -236,8 +235,8 @@ EXPLAIN INSERT INTO ColumnMapping VALUES (NULL);
             <dxl:ProjElem ColId="1" Alias="id">
               <dxl:Ident ColId="1" ColName="id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="2" Alias="ColRef_0002">
-              <dxl:Ident ColId="2" ColName="ColRef_0002" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+              <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:AssertConstraintList>
@@ -254,11 +253,11 @@ EXPLAIN INSERT INTO ColumnMapping VALUES (NULL);
               <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="2" Alias="ColRef_0002">
+              <dxl:ProjElem ColId="10" Alias="ColRef_0010">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="1" Alias="id">
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/InsertIntoReturning.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertIntoReturning.mdp
@@ -1,0 +1,338 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+set optimizer=on;
+set optimizer_enumerate_plans=on;
+
+create table ttt(id bigint, data text) with (appendonly=true) distributed by (id);
+insert into ttt values (123, 'daad') returning id+length(data);
+
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+	<dxl:OptimizerConfig>
+		<dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0" />
+		<dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100" />
+		<dxl:CTEConfig CTEInliningCutoff="0" />
+		<dxl:WindowOids RowNumber="3100" Rank="3101" />
+		<dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+			<dxl:CostParams>
+				<dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000" />
+			</dxl:CostParams>
+		</dxl:CostModelConfig>
+		<dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0" />
+		<dxl:TraceFlags Value="101013,102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103045,104002,104003,104004,104005,106000" />
+	</dxl:OptimizerConfig>
+	<dxl:Metadata SystemIds="0.GPDB">
+		<dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+			<dxl:DistrOpfamily Mdid="0.2222.1.0" />
+			<dxl:LegacyDistrOpfamily Mdid="0.7124.1.0" />
+			<dxl:EqualityOp Mdid="0.91.1.0" />
+			<dxl:InequalityOp Mdid="0.85.1.0" />
+			<dxl:LessThanOp Mdid="0.58.1.0" />
+			<dxl:LessThanEqualsOp Mdid="0.1694.1.0" />
+			<dxl:GreaterThanOp Mdid="0.59.1.0" />
+			<dxl:GreaterThanEqualsOp Mdid="0.1695.1.0" />
+			<dxl:ComparisonOp Mdid="0.1693.1.0" />
+			<dxl:ArrayType Mdid="0.1000.1.0" />
+			<dxl:MinAgg Mdid="0.0.0.0" />
+			<dxl:MaxAgg Mdid="0.0.0.0" />
+			<dxl:AvgAgg Mdid="0.0.0.0" />
+			<dxl:SumAgg Mdid="0.0.0.0" />
+			<dxl:CountAgg Mdid="0.2147.1.0" />
+		</dxl:Type>
+		<dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+			<dxl:DistrOpfamily Mdid="0.1977.1.0" />
+			<dxl:LegacyDistrOpfamily Mdid="0.7100.1.0" />
+			<dxl:EqualityOp Mdid="0.410.1.0" />
+			<dxl:InequalityOp Mdid="0.411.1.0" />
+			<dxl:LessThanOp Mdid="0.412.1.0" />
+			<dxl:LessThanEqualsOp Mdid="0.414.1.0" />
+			<dxl:GreaterThanOp Mdid="0.413.1.0" />
+			<dxl:GreaterThanEqualsOp Mdid="0.415.1.0" />
+			<dxl:ComparisonOp Mdid="0.351.1.0" />
+			<dxl:ArrayType Mdid="0.1016.1.0" />
+			<dxl:MinAgg Mdid="0.2131.1.0" />
+			<dxl:MaxAgg Mdid="0.2115.1.0" />
+			<dxl:AvgAgg Mdid="0.2100.1.0" />
+			<dxl:SumAgg Mdid="0.2107.1.0" />
+			<dxl:CountAgg Mdid="0.2147.1.0" />
+		</dxl:Type>
+		<dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+			<dxl:DistrOpfamily Mdid="0.1977.1.0" />
+			<dxl:LegacyDistrOpfamily Mdid="0.7100.1.0" />
+			<dxl:EqualityOp Mdid="0.96.1.0" />
+			<dxl:InequalityOp Mdid="0.518.1.0" />
+			<dxl:LessThanOp Mdid="0.97.1.0" />
+			<dxl:LessThanEqualsOp Mdid="0.523.1.0" />
+			<dxl:GreaterThanOp Mdid="0.521.1.0" />
+			<dxl:GreaterThanEqualsOp Mdid="0.525.1.0" />
+			<dxl:ComparisonOp Mdid="0.351.1.0" />
+			<dxl:ArrayType Mdid="0.1007.1.0" />
+			<dxl:MinAgg Mdid="0.2132.1.0" />
+			<dxl:MaxAgg Mdid="0.2116.1.0" />
+			<dxl:AvgAgg Mdid="0.2101.1.0" />
+			<dxl:SumAgg Mdid="0.2108.1.0" />
+			<dxl:CountAgg Mdid="0.2147.1.0" />
+		</dxl:Type>
+		<dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+			<dxl:DistrOpfamily Mdid="0.1995.1.0" />
+			<dxl:LegacyDistrOpfamily Mdid="0.7105.1.0" />
+			<dxl:EqualityOp Mdid="0.98.1.0" />
+			<dxl:InequalityOp Mdid="0.531.1.0" />
+			<dxl:LessThanOp Mdid="0.664.1.0" />
+			<dxl:LessThanEqualsOp Mdid="0.665.1.0" />
+			<dxl:GreaterThanOp Mdid="0.666.1.0" />
+			<dxl:GreaterThanEqualsOp Mdid="0.667.1.0" />
+			<dxl:ComparisonOp Mdid="0.360.1.0" />
+			<dxl:ArrayType Mdid="0.1009.1.0" />
+			<dxl:MinAgg Mdid="0.2145.1.0" />
+			<dxl:MaxAgg Mdid="0.2129.1.0" />
+			<dxl:AvgAgg Mdid="0.0.0.0" />
+			<dxl:SumAgg Mdid="0.0.0.0" />
+			<dxl:CountAgg Mdid="0.2147.1.0" />
+		</dxl:Type>
+		<dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+			<dxl:DistrOpfamily Mdid="0.1990.1.0" />
+			<dxl:LegacyDistrOpfamily Mdid="0.7109.1.0" />
+			<dxl:EqualityOp Mdid="0.607.1.0" />
+			<dxl:InequalityOp Mdid="0.608.1.0" />
+			<dxl:LessThanOp Mdid="0.609.1.0" />
+			<dxl:LessThanEqualsOp Mdid="0.611.1.0" />
+			<dxl:GreaterThanOp Mdid="0.610.1.0" />
+			<dxl:GreaterThanEqualsOp Mdid="0.612.1.0" />
+			<dxl:ComparisonOp Mdid="0.356.1.0" />
+			<dxl:ArrayType Mdid="0.1028.1.0" />
+			<dxl:MinAgg Mdid="0.2134.1.0" />
+			<dxl:MaxAgg Mdid="0.2118.1.0" />
+			<dxl:AvgAgg Mdid="0.0.0.0" />
+			<dxl:SumAgg Mdid="0.0.0.0" />
+			<dxl:CountAgg Mdid="0.2147.1.0" />
+		</dxl:Type>
+		<dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+			<dxl:DistrOpfamily Mdid="0.7077.1.0" />
+			<dxl:LegacyDistrOpfamily Mdid="0.7110.1.0" />
+			<dxl:EqualityOp Mdid="0.387.1.0" />
+			<dxl:InequalityOp Mdid="0.402.1.0" />
+			<dxl:LessThanOp Mdid="0.2799.1.0" />
+			<dxl:LessThanEqualsOp Mdid="0.2801.1.0" />
+			<dxl:GreaterThanOp Mdid="0.2800.1.0" />
+			<dxl:GreaterThanEqualsOp Mdid="0.2802.1.0" />
+			<dxl:ComparisonOp Mdid="0.2794.1.0" />
+			<dxl:ArrayType Mdid="0.1010.1.0" />
+			<dxl:MinAgg Mdid="0.2798.1.0" />
+			<dxl:MaxAgg Mdid="0.2797.1.0" />
+			<dxl:AvgAgg Mdid="0.0.0.0" />
+			<dxl:SumAgg Mdid="0.0.0.0" />
+			<dxl:CountAgg Mdid="0.2147.1.0" />
+		</dxl:Type>
+		<dxl:GPDBFunc Mdid="0.1317.1.0" Name="length" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+			<dxl:ResultType Mdid="0.23.1.0" />
+		</dxl:GPDBFunc>
+		<dxl:GPDBScalarOp Mdid="0.688.1.0" Name="+" ComparisonType="Other" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+			<dxl:LeftType Mdid="0.20.1.0" />
+			<dxl:RightType Mdid="0.23.1.0" />
+			<dxl:ResultType Mdid="0.20.1.0" />
+			<dxl:OpFunc Mdid="0.1274.1.0" />
+			<dxl:Commutator Mdid="0.692.1.0" />
+		</dxl:GPDBScalarOp>
+		<dxl:Relation Mdid="6.16384.1.0" Name="ttt" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Hash" DistributionColumns="0" Keys="4,2" NumberLeafPartitions="0">
+			<dxl:Columns>
+				<dxl:Column Name="id" Attno="1" Mdid="0.20.1.0" Nullable="true" ColWidth="8">
+					<dxl:DefaultValue />
+				</dxl:Column>
+				<dxl:Column Name="data" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
+					<dxl:DefaultValue />
+				</dxl:Column>
+				<dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+					<dxl:DefaultValue />
+				</dxl:Column>
+				<dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+					<dxl:DefaultValue />
+				</dxl:Column>
+				<dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+					<dxl:DefaultValue />
+				</dxl:Column>
+			</dxl:Columns>
+			<dxl:IndexInfoList />
+			<dxl:Triggers />
+			<dxl:CheckConstraints />
+			<dxl:DistrOpfamilies>
+				<dxl:DistrOpfamily Mdid="0.1977.1.0" />
+			</dxl:DistrOpfamilies>
+		</dxl:Relation>
+	</dxl:Metadata>
+	<dxl:Query>
+		<dxl:OutputColumns>
+			<dxl:Ident ColId="9" ColName="?column?" TypeMdid="0.20.1.0" />
+		</dxl:OutputColumns>
+		<dxl:CTEList />
+		<dxl:LogicalProject>
+			<dxl:ProjList>
+				<dxl:ProjElem ColId="9" Alias="?column?">
+					<dxl:OpExpr OperatorName="+" OperatorMdid="0.688.1.0" OperatorType="0.20.1.0">
+						<dxl:Ident ColId="4" ColName="id" TypeMdid="0.20.1.0" />
+						<dxl:FuncExpr FuncId="0.1317.1.0" FuncRetSet="false" TypeMdid="0.23.1.0" FuncVariadic="false">
+							<dxl:Ident ColId="5" ColName="data" TypeMdid="0.25.1.0" />
+						</dxl:FuncExpr>
+					</dxl:OpExpr>
+				</dxl:ProjElem>
+			</dxl:ProjList>
+			<dxl:LogicalInsert InsertColumns="2,3">
+				<dxl:TableDescriptor Mdid="6.16384.1.0" TableName="ttt">
+					<dxl:Columns>
+						<dxl:Column ColId="4" Attno="1" ColName="id" TypeMdid="0.20.1.0" ColWidth="8" />
+						<dxl:Column ColId="5" Attno="2" ColName="data" TypeMdid="0.25.1.0" ColWidth="8" />
+						<dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6" />
+						<dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4" />
+						<dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4" />
+					</dxl:Columns>
+				</dxl:TableDescriptor>
+				<dxl:LogicalProject>
+					<dxl:ProjList>
+						<dxl:ProjElem ColId="2" Alias="id">
+							<dxl:ConstValue TypeMdid="0.20.1.0" Value="123" />
+						</dxl:ProjElem>
+						<dxl:ProjElem ColId="3" Alias="data">
+							<dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACGRhYWQ=" LintValue="2009260909" />
+						</dxl:ProjElem>
+					</dxl:ProjList>
+					<dxl:LogicalConstTable>
+						<dxl:Columns>
+							<dxl:Column ColId="1" Attno="1" ColName="" TypeMdid="0.16.1.0" />
+						</dxl:Columns>
+						<dxl:ConstTuple>
+							<dxl:Datum TypeMdid="0.16.1.0" Value="true" />
+						</dxl:ConstTuple>
+					</dxl:LogicalConstTable>
+				</dxl:LogicalProject>
+			</dxl:LogicalInsert>
+		</dxl:LogicalProject>
+	</dxl:Query>
+	<dxl:Plan Id="0" SpaceSize="4">
+		<dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+			<dxl:Properties>
+				<dxl:Cost StartupCost="0" TotalCost="0.026147" Rows="1.000000" Width="8" />
+			</dxl:Properties>
+			<dxl:ProjList>
+				<dxl:ProjElem ColId="8" Alias="?column?">
+					<dxl:Ident ColId="8" ColName="?column?" TypeMdid="0.20.1.0" />
+				</dxl:ProjElem>
+			</dxl:ProjList>
+			<dxl:Filter />
+			<dxl:SortingColumnList />
+			<dxl:Result>
+				<dxl:Properties>
+					<dxl:Cost StartupCost="0" TotalCost="0.026117" Rows="1.000000" Width="8" />
+				</dxl:Properties>
+				<dxl:ProjList>
+					<dxl:ProjElem ColId="8" Alias="?column?">
+						<dxl:OpExpr OperatorName="+" OperatorMdid="0.688.1.0" OperatorType="0.20.1.0">
+							<dxl:Ident ColId="3" ColName="id" TypeMdid="0.20.1.0" />
+							<dxl:FuncExpr FuncId="0.1317.1.0" FuncRetSet="false" TypeMdid="0.23.1.0" FuncVariadic="false">
+								<dxl:Ident ColId="4" ColName="data" TypeMdid="0.25.1.0" />
+							</dxl:FuncExpr>
+						</dxl:OpExpr>
+					</dxl:ProjElem>
+				</dxl:ProjList>
+				<dxl:Filter />
+				<dxl:OneTimeFilter />
+				<dxl:DMLInsert Columns="1,2" ActionCol="9" CtidCol="0" SegmentIdCol="0">
+					<dxl:Properties>
+						<dxl:Cost StartupCost="0" TotalCost="0.026115" Rows="1.000000" Width="16" />
+					</dxl:Properties>
+					<dxl:DirectDispatchInfo>
+						<dxl:KeyValue>
+							<dxl:Datum TypeMdid="0.20.1.0" Value="123" />
+						</dxl:KeyValue>
+					</dxl:DirectDispatchInfo>
+					<dxl:ProjList>
+						<dxl:ProjElem ColId="1" Alias="id">
+							<dxl:Ident ColId="1" ColName="id" TypeMdid="0.20.1.0" />
+						</dxl:ProjElem>
+						<dxl:ProjElem ColId="2" Alias="data">
+							<dxl:Ident ColId="2" ColName="data" TypeMdid="0.25.1.0" />
+						</dxl:ProjElem>
+					</dxl:ProjList>
+					<dxl:ProjList>
+						<dxl:ProjElem ColId="3" Alias="id">
+							<dxl:Ident ColId="3" ColName="id" TypeMdid="0.20.1.0" />
+						</dxl:ProjElem>
+						<dxl:ProjElem ColId="4" Alias="data">
+							<dxl:Ident ColId="4" ColName="data" TypeMdid="0.25.1.0" />
+						</dxl:ProjElem>
+						<dxl:ProjElem ColId="5" Alias="ctid">
+							<dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0" />
+						</dxl:ProjElem>
+						<dxl:ProjElem ColId="6" Alias="tableoid">
+							<dxl:Ident ColId="6" ColName="tableoid" TypeMdid="0.26.1.0" />
+						</dxl:ProjElem>
+						<dxl:ProjElem ColId="7" Alias="gp_segment_id">
+							<dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0" />
+						</dxl:ProjElem>
+					</dxl:ProjList>
+					<dxl:TableDescriptor Mdid="6.16384.1.0" TableName="ttt">
+						<dxl:Columns>
+							<dxl:Column ColId="3" Attno="1" ColName="id" TypeMdid="0.20.1.0" ColWidth="8" />
+							<dxl:Column ColId="4" Attno="2" ColName="data" TypeMdid="0.25.1.0" ColWidth="8" />
+							<dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6" />
+							<dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4" />
+							<dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4" />
+						</dxl:Columns>
+					</dxl:TableDescriptor>
+					<dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+						<dxl:Properties>
+							<dxl:Cost StartupCost="0" TotalCost="0.000073" Rows="1.000000" Width="20" />
+						</dxl:Properties>
+						<dxl:ProjList>
+							<dxl:ProjElem ColId="1" Alias="id">
+								<dxl:Ident ColId="1" ColName="id" TypeMdid="0.20.1.0" />
+							</dxl:ProjElem>
+							<dxl:ProjElem ColId="2" Alias="data">
+								<dxl:Ident ColId="2" ColName="data" TypeMdid="0.25.1.0" />
+							</dxl:ProjElem>
+							<dxl:ProjElem ColId="9" Alias="ColRef_0009">
+								<dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.23.1.0" />
+							</dxl:ProjElem>
+						</dxl:ProjList>
+						<dxl:Filter />
+						<dxl:SortingColumnList />
+						<dxl:HashExprList>
+							<dxl:HashExpr Opfamily="0.1977.1.0">
+								<dxl:Ident ColId="1" ColName="id" TypeMdid="0.20.1.0" />
+							</dxl:HashExpr>
+						</dxl:HashExprList>
+						<dxl:Result>
+							<dxl:Properties>
+								<dxl:Cost StartupCost="0" TotalCost="0.000021" Rows="1.000000" Width="20" />
+							</dxl:Properties>
+							<dxl:ProjList>
+								<dxl:ProjElem ColId="1" Alias="id">
+									<dxl:ConstValue TypeMdid="0.20.1.0" Value="123" />
+								</dxl:ProjElem>
+								<dxl:ProjElem ColId="2" Alias="data">
+									<dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACGRhYWQ=" LintValue="2009260909" />
+								</dxl:ProjElem>
+								<dxl:ProjElem ColId="9" Alias="ColRef_0009">
+									<dxl:ConstValue TypeMdid="0.23.1.0" Value="1" />
+								</dxl:ProjElem>
+							</dxl:ProjList>
+							<dxl:Filter />
+							<dxl:OneTimeFilter />
+							<dxl:Result>
+								<dxl:Properties>
+									<dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1" />
+								</dxl:Properties>
+								<dxl:ProjList>
+									<dxl:ProjElem ColId="0" Alias="">
+										<dxl:ConstValue TypeMdid="0.16.1.0" Value="true" />
+									</dxl:ProjElem>
+								</dxl:ProjList>
+								<dxl:Filter />
+								<dxl:OneTimeFilter />
+							</dxl:Result>
+						</dxl:Result>
+					</dxl:RedistributeMotion>
+				</dxl:DMLInsert>
+			</dxl:Result>
+		</dxl:GatherMotion>
+	</dxl:Plan>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/InsertMasterOnlyTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertMasterOnlyTable.mdp
@@ -197,10 +197,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2">
         <dxl:TableDescriptor Mdid="6.258433.1.1" TableName="m">
@@ -234,9 +231,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1" ActionCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="18" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.093882" Rows="2.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.093882" Rows="2.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -247,17 +244,16 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.258433.1.1" TableName="m">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -271,7 +267,7 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/InsertMasterOnlyTableConstTuple.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertMasterOnlyTableConstTuple.mdp
@@ -135,10 +135,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="3" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="2,3">
         <dxl:TableDescriptor Mdid="6.258433.1.1" TableName="m">
@@ -175,9 +172,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="5">
-      <dxl:DMLInsert Columns="1,2" ActionCol="3" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="1,2" ActionCol="12" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.046888" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.046888" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -188,17 +185,16 @@
             <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.258433.1.1" TableName="m">
           <dxl:Columns>
-            <dxl:Column ColId="4" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="5" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -212,7 +208,7 @@
             <dxl:ProjElem ColId="2" Alias="b">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="3" Alias="ColRef_0003">
+            <dxl:ProjElem ColId="12" Alias="ColRef_0012">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution-2.mdp
@@ -225,11 +225,7 @@ explain insert into pt2 select * from r;
       <dxl:ColumnStatistics Mdid="1.1695445.1.1.6" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="j" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="3" ColName="k" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2,3">
         <dxl:TableDescriptor Mdid="6.1695223.1.1" TableName="pt2">
@@ -265,9 +261,9 @@ explain insert into pt2 select * from r;
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1,2" ActionCol="10" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1,2" ActionCol="20" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.031309" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.031309" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -281,18 +277,17 @@ explain insert into pt2 select * from r;
             <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.1695223.1.1" TableName="pt2">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="10" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -309,7 +304,7 @@ explain insert into pt2 select * from r;
             <dxl:ProjElem ColId="2" Alias="c">
               <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution.mdp
@@ -225,11 +225,7 @@ explain insert into pt2 select * from r;
       <dxl:ColumnStatistics Mdid="1.1695445.1.1.6" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="j" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="3" ColName="k" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2,3">
         <dxl:TableDescriptor Mdid="6.1695223.1.1" TableName="pt2">
@@ -265,9 +261,9 @@ explain insert into pt2 select * from r;
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1,2" ActionCol="10" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1,2" ActionCol="20" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.031284" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.031284" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -281,18 +277,17 @@ explain insert into pt2 select * from r;
             <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.1695223.1.1" TableName="pt2">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="10" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -309,7 +304,7 @@ explain insert into pt2 select * from r;
             <dxl:ProjElem ColId="2" Alias="c">
               <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/InsertNULLNotNULLConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertNULLNotNULLConstraint.mdp
@@ -132,9 +132,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="2">
         <dxl:TableDescriptor Mdid="6.161940.1.1" TableName="orca">
@@ -167,9 +165,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="1" ActionCol="2" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="1" ActionCol="10" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.015664" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.015664" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo>
           <dxl:KeyValue>
@@ -181,16 +179,17 @@
             <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.161940.1.1" TableName="orca">
           <dxl:Columns>
-            <dxl:Column ColId="3" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="2" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
@@ -201,8 +200,8 @@
             <dxl:ProjElem ColId="1" Alias="a">
               <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="2" Alias="ColRef_0002">
-              <dxl:Ident ColId="2" ColName="ColRef_0002" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+              <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -220,8 +219,8 @@
               <dxl:ProjElem ColId="1" Alias="a">
                 <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="2" Alias="ColRef_0002">
-                <dxl:Ident ColId="2" ColName="ColRef_0002" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+                <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:AssertConstraintList>
@@ -238,7 +237,7 @@
                 <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="2" Alias="ColRef_0002">
+                <dxl:ProjElem ColId="10" Alias="ColRef_0010">
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="1" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/InsertNoEnforceConstraints.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertNoEnforceConstraints.mdp
@@ -167,10 +167,7 @@ insert into constraints_tab values (NULL, -1);
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="2" ColName="notnullcol" TypeMdid="0.25.1.0"/>
-        <dxl:Ident ColId="3" ColName="positivecol" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="2,3">
         <dxl:TableDescriptor Mdid="6.16424.1.0" TableName="constraints_tab">
@@ -207,9 +204,9 @@ insert into constraints_tab values (NULL, -1);
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="3">
-      <dxl:DMLInsert Columns="1,2" ActionCol="3" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="1,2" ActionCol="12" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.020883" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.020883" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -220,17 +217,17 @@ insert into constraints_tab values (NULL, -1);
             <dxl:Ident ColId="2" ColName="positivecol" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16424.1.0" TableName="constraints_tab">
           <dxl:Columns>
-            <dxl:Column ColId="4" Attno="1" ColName="notnullcol" TypeMdid="0.25.1.0" ColWidth="8"/>
-            <dxl:Column ColId="5" Attno="2" ColName="positivecol" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="3" Attno="1" ColName="notnullcol" TypeMdid="0.25.1.0" ColWidth="8"/>
+            <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -244,7 +241,7 @@ insert into constraints_tab values (NULL, -1);
             <dxl:ProjElem ColId="2" Alias="positivecol">
               <dxl:Ident ColId="2" ColName="positivecol" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="3" Alias="ColRef_0003">
+            <dxl:ProjElem ColId="12" Alias="ColRef_0012">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/InsertNonSingleton.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertNonSingleton.mdp
@@ -241,9 +241,7 @@ EXPLAIN INSERT INTO snackbox SELECT a FROM (SELECT c FROM hottoast LIMIT 3) hott
       <dxl:ColumnStatistics Mdid="1.16428.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="9">
         <dxl:TableDescriptor Mdid="6.16428.1.0" TableName="snackbox">
@@ -302,9 +300,9 @@ EXPLAIN INSERT INTO snackbox SELECT a FROM (SELECT c FROM hottoast LIMIT 3) hott
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="6">
-      <dxl:DMLInsert Columns="8" ActionCol="16" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="8" ActionCol="24" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.031910" Rows="3.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.031910" Rows="3.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -312,16 +310,16 @@ EXPLAIN INSERT INTO snackbox SELECT a FROM (SELECT c FROM hottoast LIMIT 3) hott
             <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16428.1.0" TableName="snackbox">
           <dxl:Columns>
-            <dxl:Column ColId="17" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="19" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="20" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="21" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="22" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="23" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="24" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="18" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="19" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="20" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="21" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -332,7 +330,7 @@ EXPLAIN INSERT INTO snackbox SELECT a FROM (SELECT c FROM hottoast LIMIT 3) hott
             <dxl:ProjElem ColId="8" Alias="a">
               <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="16" Alias="ColRef_0016">
+            <dxl:ProjElem ColId="24" Alias="ColRef_0024">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/InsertNotNullCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertNotNullCols.mdp
@@ -213,7 +213,7 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLInsert Columns="0,1" ActionCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="18" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.031288" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -226,17 +226,17 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.17140.1.1" TableName="t">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="11" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Assert ErrorCode="23502">
@@ -250,8 +250,8 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-              <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
+              <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:AssertConstraintList>
@@ -268,7 +268,7 @@
               <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+              <dxl:ProjElem ColId="18" Alias="ColRef_0018">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/InsertPrimaryKeyFromMOTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertPrimaryKeyFromMOTable.mdp
@@ -199,10 +199,7 @@
       <dxl:ColumnStatistics Mdid="1.457583.1.1.2" Name="ctid" Width="6.000000"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="id" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="val" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2">
         <dxl:TableDescriptor Mdid="6.457258.1.1" TableName="zzz2">
@@ -236,9 +233,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLInsert Columns="0,1" ActionCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="18" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.047060" Rows="2.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.047060" Rows="2.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -249,17 +246,17 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.457258.1.1" TableName="zzz2">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="id" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="11" Attno="2" ColName="val" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="9" Attno="1" ColName="id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1">
@@ -273,8 +270,8 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-              <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
+              <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -295,8 +292,8 @@
               <dxl:ProjElem ColId="1" Alias="b">
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-                <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="18" Alias="ColRef_0018">
+                <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:AssertConstraintList>
@@ -313,7 +310,7 @@
                 <dxl:Cost StartupCost="0" TotalCost="431.000096" Rows="2.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+                <dxl:ProjElem ColId="18" Alias="ColRef_0018">
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/InsertProjectSort.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertProjectSort.mdp
@@ -231,11 +231,7 @@ explain insert into tbl_cds_buysell_orders_new (a,b,c)
       <dxl:ColumnStatistics Mdid="1.29841831.1.1.6" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2,3,21,22,23,24">
         <dxl:TableDescriptor Mdid="6.29841801.1.1" TableName="tbl_cds_buysell_orders_new">
@@ -294,9 +290,9 @@ explain insert into tbl_cds_buysell_orders_new (a,b,c)
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="5">
-      <dxl:DMLInsert Columns="0,1,2,10,11,12,13" ActionCol="14" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1,2,10,11,12,13" ActionCol="24" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="42556.094359" Rows="1000000.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="42556.094359" Rows="1000000.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -322,18 +318,15 @@ explain insert into tbl_cds_buysell_orders_new (a,b,c)
             <dxl:Ident ColId="13" ColName="g" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.29841801.1.1" TableName="tbl_cds_buysell_orders_new">
           <dxl:Columns>
-            <dxl:Column ColId="15" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="16" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="17" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="18" Attno="4" ColName="d" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="19" Attno="5" ColName="e" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="20" Attno="6" ColName="f" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="21" Attno="7" ColName="g" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="22" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="23" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="24" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="14" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="15" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="16" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -351,18 +344,18 @@ explain insert into tbl_cds_buysell_orders_new (a,b,c)
               <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="10" Alias="d">
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="11" Alias="e">
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="12" Alias="f">
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="13" Alias="g">
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+            <dxl:ProjElem ColId="24" Alias="ColRef_0024">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/InsertRandomDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertRandomDistr.mdp
@@ -195,10 +195,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2">
         <dxl:TableDescriptor Mdid="6.16468.1.0" TableName="rr">
@@ -232,9 +229,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLInsert Columns="0,1" ActionCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="18" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.015649" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.015649" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -245,17 +242,16 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16468.1.0" TableName="rr">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -269,7 +265,7 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/InsertReplicatedIntoSerialHashDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertReplicatedIntoSerialHashDistributedTable.mdp
@@ -272,11 +272,7 @@ EXPLAIN (COSTS OFF) INSERT INTO distributed_table (val1, val2) SELECT val1, val2
       </dxl:GPDBFunc>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="10" ColName="_etl_id" TypeMdid="0.20.1.0"/>
-        <dxl:Ident ColId="1" ColName="val1" TypeMdid="0.1043.1.0"/>
-        <dxl:Ident ColId="2" ColName="val2" TypeMdid="0.1043.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="10,1,2">
         <dxl:TableDescriptor Mdid="6.32776.1.0" TableName="distributed_table" LockMode="3">
@@ -320,9 +316,9 @@ EXPLAIN (COSTS OFF) INSERT INTO distributed_table (val1, val2) SELECT val1, val2
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="3">
-      <dxl:DMLInsert Columns="9,0,1" ActionCol="10" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="9,0,1" ActionCol="20" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="434.676207" Rows="100.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="434.676207" Rows="100.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -336,18 +332,17 @@ EXPLAIN (COSTS OFF) INSERT INTO distributed_table (val1, val2) SELECT val1, val2
             <dxl:Ident ColId="1" ColName="val2" TypeMdid="0.1043.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:TableDescriptor Mdid="6.32776.1.0" TableName="distributed_table" LockMode="3">
+        <dxl:ProjList/>
+        <dxl:TableDescriptor Mdid="6.32776.1.0" TableName="distributed_table">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="_etl_id" TypeMdid="0.20.1.0" ColWidth="8"/>
-            <dxl:Column ColId="12" Attno="2" ColName="val1" TypeMdid="0.1043.1.0" ColWidth="19"/>
-            <dxl:Column ColId="13" Attno="3" ColName="val2" TypeMdid="0.1043.1.0" ColWidth="19"/>
-            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="15" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="19" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="20" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="1" ColName="_etl_id" TypeMdid="0.20.1.0" ColWidth="8"/>
+            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -364,7 +359,7 @@ EXPLAIN (COSTS OFF) INSERT INTO distributed_table (val1, val2) SELECT val1, val2
             <dxl:ProjElem ColId="1" Alias="val2">
               <dxl:Ident ColId="1" ColName="val2" TypeMdid="0.1043.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
@@ -415,7 +410,7 @@ EXPLAIN (COSTS OFF) INSERT INTO distributed_table (val1, val2) SELECT val1, val2
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="_etl_id">
-                    <dxl:FuncExpr FuncId="0.1574.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                    <dxl:FuncExpr FuncId="0.1574.1.0" FuncRetSet="false" TypeMdid="0.20.1.0" FuncVariadic="false">
                       <dxl:ConstValue TypeMdid="0.2205.1.0" Value="BoAAAA=="/>
                     </dxl:FuncExpr>
                   </dxl:ProjElem>
@@ -441,7 +436,7 @@ EXPLAIN (COSTS OFF) INSERT INTO distributed_table (val1, val2) SELECT val1, val2
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.32768.1.0" TableName="replicated_table" LockMode="1">
+                  <dxl:TableDescriptor Mdid="6.32768.1.0" TableName="replicated_table">
                     <dxl:Columns>
                       <dxl:Column ColId="0" Attno="1" ColName="val1" TypeMdid="0.1043.1.0" ColWidth="19"/>
                       <dxl:Column ColId="1" Attno="2" ColName="val2" TypeMdid="0.1043.1.0" ColWidth="19"/>

--- a/src/backend/gporca/data/dxl/minidump/InsertSort.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertSort.mdp
@@ -317,9 +317,7 @@ explain insert into nim1 select * from nim order by 1;
       </dxl:ColumnStatistics>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1">
         <dxl:TableDescriptor Mdid="6.30251873.1.1" TableName="nim1">
@@ -358,9 +356,9 @@ explain insert into nim1 select * from nim order by 1;
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0" ActionCol="8" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0" ActionCol="16" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="106371.615338" Rows="10000818.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="106371.615338" Rows="10000818.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -368,16 +366,17 @@ explain insert into nim1 select * from nim order by 1;
             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.30251873.1.1" TableName="nim1">
           <dxl:Columns>
-            <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="8" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -388,7 +387,7 @@ explain insert into nim1 select * from nim order by 1;
             <dxl:ProjElem ColId="0" Alias="a">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="8" Alias="ColRef_0008">
+            <dxl:ProjElem ColId="16" Alias="ColRef_0016">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/InsertSortDistributed2MasterOnly.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertSortDistributed2MasterOnly.mdp
@@ -238,11 +238,7 @@ explain insert into masteronly select * from distributedtable order by 1;
       <dxl:ColumnStatistics Mdid="1.29236811.1.1.0" Name="a" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.25.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2,3">
         <dxl:TableDescriptor Mdid="6.29236755.1.1" TableName="masteronly">
@@ -285,9 +281,9 @@ explain insert into masteronly select * from distributedtable order by 1;
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1,2" ActionCol="10" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1,2" ActionCol="20" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.078234" Rows="1.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.078234" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -301,18 +297,16 @@ explain insert into masteronly select * from distributedtable order by 1;
             <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.29236755.1.1" TableName="masteronly">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="3" ColName="c" TypeMdid="0.25.1.0"/>
-            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
@@ -329,8 +323,8 @@ explain insert into masteronly select * from distributedtable order by 1;
             <dxl:ProjElem ColId="2" Alias="c">
               <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-              <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+              <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -349,7 +343,7 @@ explain insert into masteronly select * from distributedtable order by 1;
               <dxl:ProjElem ColId="2" Alias="c">
                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/InsertWithDroppedCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertWithDroppedCol.mdp
@@ -201,10 +201,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="2,3">
         <dxl:TableDescriptor Mdid="6.41076.1.1" TableName="altable">
@@ -241,9 +238,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="1,2" ActionCol="3" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="1,2" ActionCol="12" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.023495" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.023495" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo>
           <dxl:KeyValue>
@@ -258,17 +255,17 @@
             <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.41076.1.1" TableName="altable">
           <dxl:Columns>
-            <dxl:Column ColId="4" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="5" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="3" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
@@ -282,8 +279,8 @@
             <dxl:ProjElem ColId="2" Alias="c">
               <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="3" Alias="ColRef_0003">
-              <dxl:Ident ColId="3" ColName="ColRef_0003" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="12" Alias="ColRef_0012">
+              <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -304,8 +301,8 @@
               <dxl:ProjElem ColId="2" Alias="c">
                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="3" Alias="ColRef_0003">
-                <dxl:Ident ColId="3" ColName="ColRef_0003" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="12" Alias="ColRef_0012">
+                <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:AssertConstraintList>
@@ -324,7 +321,7 @@
                 <dxl:Cost StartupCost="0" TotalCost="0.000013" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="3" Alias="ColRef_0003">
+                <dxl:ProjElem ColId="12" Alias="ColRef_0012">
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="1" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/InsertWithTriggers.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertWithTriggers.mdp
@@ -266,7 +266,7 @@
               <dxl:Ident ColId="2" ColName="s3" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:DMLInsert Columns="0,1,2" ActionCol="10" CtidCol="0" SegmentIdCol="0">
+          <dxl:DMLInsert Columns="0,1,2" ActionCol="20" CtidCol="0" SegmentIdCol="0">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.031337" Rows="1.000000" Width="12"/>
             </dxl:Properties>
@@ -286,18 +286,51 @@
                 <dxl:Ident ColId="2" ColName="s3" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="t1">
+                <dxl:Ident ColId="10" ColName="t1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="13" Alias="ctid">
+                <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="14" Alias="xmin">
+                <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="15" Alias="cmin">
+                <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="16" Alias="xmax">
+                <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="cmax">
+                <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="tableoid">
+                <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="0" Alias="s1">
+                <dxl:Ident ColId="0" ColName="s1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="s2">
+                <dxl:Ident ColId="1" ColName="s2" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="s3">
+                <dxl:Ident ColId="2" ColName="s3" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
             <dxl:TableDescriptor Mdid="6.187376.1.1" TableName="t">
               <dxl:Columns>
-                <dxl:Column ColId="11" Attno="1" ColName="t1" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="12" Attno="2" ColName="t2" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="13" Attno="3" ColName="t3" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="10" Attno="1" ColName="t1" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:Columns>
             </dxl:TableDescriptor>
             <dxl:RowTrigger RelationMdid="6.187376.1.1" Type="7" NewColumns="0,1,2">
@@ -314,8 +347,8 @@
                 <dxl:ProjElem ColId="2" Alias="s3">
                   <dxl:Ident ColId="2" ColName="s3" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-                  <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                  <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Result>
@@ -332,7 +365,7 @@
                   <dxl:ProjElem ColId="2" Alias="s3">
                     <dxl:Ident ColId="2" ColName="s3" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+                  <dxl:ProjElem ColId="20" Alias="ColRef_0020">
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoinNullsNotColocated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoinNullsNotColocated.mdp
@@ -427,9 +427,9 @@ on id2 = id3 distributed by (id1);
           <dxl:DistrOpclass Mdid="0.10055.1.0"/>
         </dxl:DistrOpclasses>
         <dxl:Columns>
-          <dxl:Column ColId="25" Attno="1" ColName="id1" TypeMdid="0.20.1.0"/>
-          <dxl:Column ColId="26" Attno="2" ColName="id2" TypeMdid="0.20.1.0"/>
-          <dxl:Column ColId="27" Attno="3" ColName="id3" TypeMdid="0.20.1.0"/>
+          <dxl:Column ColId="28" Attno="1" ColName="id1" TypeMdid="0.20.1.0"/>
+          <dxl:Column ColId="29" Attno="2" ColName="id2" TypeMdid="0.20.1.0"/>
+          <dxl:Column ColId="30" Attno="3" ColName="id3" TypeMdid="0.20.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
         <dxl:ProjList>
@@ -457,7 +457,7 @@ on id2 = id3 distributed by (id1);
             <dxl:ProjElem ColId="16" Alias="id3">
               <dxl:Ident ColId="16" ColName="id3" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="24" Alias="ColRef_0024">
+            <dxl:ProjElem ColId="27" Alias="ColRef_0027">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/MultipleUpdateWithJoinOnDistCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleUpdateWithJoinOnDistCol.mdp
@@ -240,10 +240,7 @@
       </dxl:GPDBScalarOp>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.1043.1.0"/>
-        <dxl:Ident ColId="11" ColName="b" TypeMdid="0.1043.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2" InsertColumns="10,11" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.32769.1.0" TableName="s">
@@ -302,7 +299,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="6">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="18" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="27" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="867.752993" Rows="100.000000" Width="1"/>
         </dxl:Properties>
@@ -315,17 +312,17 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.32769.1.0" TableName="s">
           <dxl:Columns>
-            <dxl:Column ColId="19" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="4"/>
-            <dxl:Column ColId="20" Attno="2" ColName="b" TypeMdid="0.1043.1.0" ColWidth="4"/>
-            <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="4"/>
+            <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
@@ -345,8 +342,8 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
-              <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="27" Alias="ColRef_0027">
+              <dxl:Ident ColId="27" ColName="ColRef_0027" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -356,7 +353,7 @@
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
-          <dxl:Split DeleteColumns="0,1" InsertColumns="9,10" ActionCol="18" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+          <dxl:Split DeleteColumns="0,1" InsertColumns="9,10" ActionCol="27" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="862.019236" Rows="200.000000" Width="22"/>
             </dxl:Properties>
@@ -373,7 +370,7 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="18" Alias="ColRef_0018">
+              <dxl:ProjElem ColId="27" Alias="ColRef_0027">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/PartitionedDelete.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartitionedDelete.mdp
@@ -234,23 +234,23 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLDelete Columns="" ActionCol="9" CtidCol="2" OidCol="7" SegmentIdCol="8">
+      <dxl:DMLDelete Columns="" ActionCol="18" CtidCol="2" OidCol="7" SegmentIdCol="8">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.023473" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList/>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16438.1.0" TableName="test">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="11" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -267,7 +267,7 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/PartitionedInsert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartitionedInsert.mdp
@@ -173,10 +173,7 @@
       </dxl:Type>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="2" ColName="i" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="3" ColName="j" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="2,3">
         <dxl:TableDescriptor Mdid="6.16438.1.0" TableName="test">
@@ -213,9 +210,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="3">
-      <dxl:DMLInsert Columns="1,2" ActionCol="3" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="1,2" ActionCol="12" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.015659" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.015659" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo>
           <dxl:KeyValue>
@@ -230,17 +227,17 @@
             <dxl:Ident ColId="2" ColName="j" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16438.1.0" TableName="test">
           <dxl:Columns>
-            <dxl:Column ColId="4" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="5" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="3" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -254,7 +251,7 @@
             <dxl:ProjElem ColId="2" Alias="j">
               <dxl:Ident ColId="2" ColName="j" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="3" Alias="ColRef_0003">
+            <dxl:ProjElem ColId="12" Alias="ColRef_0012">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/PartitionedUpdate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartitionedUpdate.mdp
@@ -197,9 +197,7 @@
       </dxl:GPDBScalarOp>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2" InsertColumns="10,2" CtidCol="3" SegmentIdCol="9" PreserveOids="false" OidCol="8">
         <dxl:TableDescriptor Mdid="6.16438.1.0" TableName="test">
@@ -246,7 +244,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="10" CtidCol="2" OidCol="7" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="19" CtidCol="2" OidCol="7" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.067820" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -259,17 +257,17 @@
             <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16438.1.0" TableName="test">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
@@ -292,8 +290,8 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-              <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+              <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -303,7 +301,7 @@
               <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
-          <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+          <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000058" Rows="2.000000" Width="26"/>
             </dxl:Properties>
@@ -323,7 +321,7 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+              <dxl:ProjElem ColId="19" Alias="ColRef_0019">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/ProjectSetFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ProjectSetFunction.mdp
@@ -187,10 +187,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="3" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="2,3">
         <dxl:TableDescriptor Mdid="6.16465.1.0" TableName="t1_random">
@@ -230,9 +227,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLInsert Columns="1,2" ActionCol="3" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="1,2" ActionCol="12" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.015771" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.015771" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -243,17 +240,16 @@
             <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16465.1.0" TableName="t1_random">
           <dxl:Columns>
-            <dxl:Column ColId="4" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="5" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
@@ -267,8 +263,8 @@
             <dxl:ProjElem ColId="2" Alias="b">
               <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="3" Alias="ColRef_0003">
-              <dxl:Ident ColId="3" ColName="ColRef_0003" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="12" Alias="ColRef_0012">
+              <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -284,7 +280,7 @@
               <dxl:ProjElem ColId="2" Alias="b">
                 <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="3" Alias="ColRef_0003">
+              <dxl:ProjElem ColId="12" Alias="ColRef_0012">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>
@@ -313,7 +309,7 @@
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="2" Alias="b">
-                    <dxl:FuncExpr FuncId="0.1067.1.0" FuncRetSet="true" TypeMdid="0.23.1.0">
+                    <dxl:FuncExpr FuncId="0.1067.1.0" FuncRetSet="true" TypeMdid="0.23.1.0" FuncVariadic="false">
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="1000000"/>
                     </dxl:FuncExpr>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedTable-CTAS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedTable-CTAS.mdp
@@ -99,8 +99,8 @@
         </dxl:Properties>
         <dxl:DistrOpclasses/>
         <dxl:Columns>
-          <dxl:Column ColId="2" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-          <dxl:Column ColId="3" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="4" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="5" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
         <dxl:ProjList>
@@ -122,8 +122,8 @@
             <dxl:ProjElem ColId="0" Alias="generate_series">
               <dxl:Ident ColId="0" ColName="generate_series" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="ColRef_0001">
-              <dxl:Ident ColId="1" ColName="ColRef_0001" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="3" Alias="ColRef_0003">
+              <dxl:Ident ColId="3" ColName="ColRef_0003" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -133,7 +133,7 @@
               <dxl:Cost StartupCost="0" TotalCost="0.012000" Rows="1000.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="1" Alias="ColRef_0001">
+              <dxl:ProjElem ColId="3" Alias="ColRef_0003">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="0" Alias="generate_series">

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedTableInsert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedTableInsert.mdp
@@ -149,10 +149,7 @@
       </dxl:GPDBFunc>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,1">
         <dxl:TableDescriptor Mdid="6.16421.1.0" TableName="r1">
@@ -178,9 +175,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,0" ActionCol="1" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,0" ActionCol="10" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="31.262000" Rows="1000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="31.262000" Rows="3000.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -191,17 +188,16 @@
             <dxl:Ident ColId="0" ColName="generate_series" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16421.1.0" TableName="r1">
           <dxl:Columns>
-            <dxl:Column ColId="2" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="3" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -209,7 +205,7 @@
             <dxl:Cost StartupCost="0" TotalCost="0.012000" Rows="1000.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="1" Alias="ColRef_0001">
+            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="0" Alias="generate_series">

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedTableSequenceInsert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedTableSequenceInsert.mdp
@@ -253,10 +253,7 @@
       </dxl:GPDBFunc>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="9,1">
         <dxl:TableDescriptor Mdid="6.16398.1.0" TableName="test_table1">
@@ -300,9 +297,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="3">
-      <dxl:DMLInsert Columns="8,0" ActionCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="8,0" ActionCol="18" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.047075" Rows="3.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.047075" Rows="3.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -313,17 +310,16 @@
             <dxl:Ident ColId="0" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16398.1.0" TableName="test_table1">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="13" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -337,7 +333,7 @@
             <dxl:ProjElem ColId="0" Alias="b">
               <dxl:Ident ColId="0" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
@@ -377,8 +373,8 @@
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="8" Alias="a">
-                    <dxl:FuncExpr FuncId="0.480.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:FuncExpr FuncId="0.1574.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                    <dxl:FuncExpr FuncId="0.480.1.0" FuncRetSet="false" TypeMdid="0.23.1.0" FuncVariadic="false">
+                      <dxl:FuncExpr FuncId="0.1574.1.0" FuncRetSet="false" TypeMdid="0.20.1.0" FuncVariadic="false">
                         <dxl:ConstValue TypeMdid="0.2205.1.0" Value="DEAAAA=="/>
                       </dxl:FuncExpr>
                     </dxl:FuncExpr>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedTableWithAggNoMotion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedTableWithAggNoMotion.mdp
@@ -225,9 +225,7 @@
       </dxl:GPDBFunc>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="10">
         <dxl:TableDescriptor Mdid="6.222464.1.0" TableName="foo" LockMode="3">
@@ -283,9 +281,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="5">
-      <dxl:DMLInsert Columns="9" ActionCol="11" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="9" ActionCol="19" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.031385" Rows="3.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.031385" Rows="3.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -293,16 +291,16 @@
             <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:TableDescriptor Mdid="6.222464.1.0" TableName="foo" LockMode="3">
+        <dxl:ProjList/>
+        <dxl:TableDescriptor Mdid="6.222464.1.0" TableName="foo">
           <dxl:Columns>
-            <dxl:Column ColId="12" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -311,11 +309,11 @@
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="a">
-              <dxl:FuncExpr FuncId="0.480.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+              <dxl:FuncExpr FuncId="0.480.1.0" FuncRetSet="false" TypeMdid="0.23.1.0" FuncVariadic="false">
                 <dxl:Ident ColId="8" ColName="sum" TypeMdid="0.20.1.0"/>
               </dxl:FuncExpr>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+            <dxl:ProjElem ColId="19" Alias="ColRef_0019">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
@@ -328,7 +326,7 @@
             <dxl:GroupingColumns/>
             <dxl:ProjList>
               <dxl:ProjElem ColId="8" Alias="sum">
-                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
+                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
                   </dxl:ValuesList>
@@ -349,7 +347,7 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.222467.1.0" TableName="bar" LockMode="1">
+              <dxl:TableDescriptor Mdid="6.222467.1.0" TableName="bar">
                 <dxl:Columns>
                   <dxl:Column ColId="0" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
                   <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>

--- a/src/backend/gporca/data/dxl/minidump/SelfUpdate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SelfUpdate.mdp
@@ -178,9 +178,7 @@ update t1 set b = c;
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="3" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2,3" InsertColumns="1,3,3" CtidCol="4" SegmentIdCol="10" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.47297780.1.1" TableName="t1">
@@ -216,7 +214,7 @@ update t1 set b = c;
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1,2" ActionCol="10" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1,2" ActionCol="20" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.067764" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -232,18 +230,16 @@ update t1 set b = c;
             <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.47297780.1.1" TableName="t1">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Assert ErrorCode="23502">
@@ -266,8 +262,8 @@ update t1 set b = c;
             <dxl:ProjElem ColId="9" Alias="gp_segment_id">
               <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-              <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+              <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:AssertConstraintList>
@@ -279,7 +275,7 @@ update t1 set b = c;
               </dxl:Not>
             </dxl:AssertConstraint>
           </dxl:AssertConstraintList>
-          <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,2,2" ActionCol="10" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+          <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,2,2" ActionCol="20" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="2.000000" Width="26"/>
             </dxl:Properties>
@@ -299,7 +295,7 @@ update t1 set b = c;
               <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                 <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/SqlFuncDmlScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SqlFuncDmlScalar.mdp
@@ -245,9 +245,7 @@ LIMIT 999
       <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="9">
         <dxl:TableDescriptor Mdid="6.49191.1.0" TableName="bar" LockMode="3">
@@ -295,9 +293,9 @@ LIMIT 999
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="3">
-      <dxl:DMLInsert Columns="8" ActionCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="8" ActionCol="17" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.010525" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.010525" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -305,16 +303,17 @@ LIMIT 999
             <dxl:Ident ColId="8" ColName="yolo" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:TableDescriptor Mdid="6.49191.1.0" TableName="bar" LockMode="3">
+        <dxl:ProjList/>
+        <dxl:TableDescriptor Mdid="6.49191.1.0" TableName="bar">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="11" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
@@ -325,8 +324,8 @@ LIMIT 999
             <dxl:ProjElem ColId="8" Alias="yolo">
               <dxl:Ident ColId="8" ColName="yolo" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-              <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="17" Alias="ColRef_0017">
+              <dxl:Ident ColId="17" ColName="ColRef_0017" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -344,7 +343,7 @@ LIMIT 999
               <dxl:ProjElem ColId="8" Alias="yolo">
                 <dxl:Ident ColId="8" ColName="yolo" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+              <dxl:ProjElem ColId="17" Alias="ColRef_0017">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>
@@ -376,7 +375,7 @@ LIMIT 999
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="8" Alias="yolo">
-                      <dxl:FuncExpr FuncId="0.49187.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                      <dxl:FuncExpr FuncId="0.49187.1.0" FuncRetSet="false" TypeMdid="0.23.1.0" FuncVariadic="false">
                         <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                       </dxl:FuncExpr>
                     </dxl:ProjElem>
@@ -393,7 +392,7 @@ LIMIT 999
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="6.49188.1.0" TableName="foo" LockMode="1">
+                    <dxl:TableDescriptor Mdid="6.49188.1.0" TableName="foo">
                       <dxl:Columns>
                         <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                         <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>

--- a/src/backend/gporca/data/dxl/minidump/SqlFuncDmlTvf.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SqlFuncDmlTvf.mdp
@@ -254,10 +254,7 @@ LIMIT 999
       </dxl:GPDBFunc>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="d" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2">
         <dxl:TableDescriptor Mdid="6.49205.1.0" TableName="bar" LockMode="3">
@@ -306,9 +303,9 @@ LIMIT 999
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="12">
-      <dxl:DMLInsert Columns="0,1" ActionCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="18" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="882720.643838" Rows="999.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="882720.643838" Rows="999.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -319,17 +316,17 @@ LIMIT 999
             <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:TableDescriptor Mdid="6.49205.1.0" TableName="bar" LockMode="3">
+        <dxl:ProjList/>
+        <dxl:TableDescriptor Mdid="6.49205.1.0" TableName="bar">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="11" Attno="2" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="13" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
@@ -343,8 +340,8 @@ LIMIT 999
             <dxl:ProjElem ColId="1" Alias="a">
               <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-              <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
+              <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -365,7 +362,7 @@ LIMIT 999
               <dxl:ProjElem ColId="1" Alias="a">
                 <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+              <dxl:ProjElem ColId="18" Alias="ColRef_0018">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:ProjElem>
             </dxl:ProjList>
@@ -423,7 +420,7 @@ LIMIT 999
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="6.49202.1.0" TableName="foo" LockMode="1">
+                    <dxl:TableDescriptor Mdid="6.49202.1.0" TableName="foo">
                       <dxl:Columns>
                         <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                         <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>

--- a/src/backend/gporca/data/dxl/minidump/TaintedReplicatedAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TaintedReplicatedAgg.mdp
@@ -219,9 +219,7 @@
       <dxl:ColumnStatistics Mdid="1.16412.1.0.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="9" ColName="a" TypeMdid="0.700.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="9">
         <dxl:TableDescriptor Mdid="6.16409.1.0" TableName="snackbox">
@@ -268,9 +266,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="8" ActionCol="10" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="8" ActionCol="18" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.031499" Rows="3.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.031499" Rows="3.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -278,16 +276,16 @@
             <dxl:Ident ColId="8" ColName="sum" TypeMdid="0.700.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16409.1.0" TableName="snackbox">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.700.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -298,7 +296,7 @@
             <dxl:ProjElem ColId="8" Alias="sum">
               <dxl:Ident ColId="8" ColName="sum" TypeMdid="0.700.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
@@ -322,9 +320,9 @@
               <dxl:GroupingColumns/>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="8" Alias="sum">
-                  <dxl:AggFunc AggMdid="0.2110.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
+                  <dxl:AggFunc AggMdid="0.2110.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                     <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="0" ColName="c" TypeMdid="0.700.1.0"/>
+                      <dxl:Ident ColId="0" ColName="c" TypeMdid="0.700.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/TaintedReplicatedFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TaintedReplicatedFilter.mdp
@@ -206,10 +206,7 @@
       <dxl:MDCast Mdid="3.23.1.0;701.1.0" Name="float8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.701.1.0" CastFuncId="0.316.1.0" CoercePathType="1"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1,2">
         <dxl:TableDescriptor Mdid="6.32768.1.0" TableName="t1">
@@ -251,9 +248,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1" ActionCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="18" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.047385" Rows="3.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.047385" Rows="3.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -264,17 +261,16 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.32768.1.0" TableName="t1">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="13" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -288,7 +284,7 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
@@ -325,7 +321,7 @@
                   <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
                     <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:Cast>
-                  <dxl:FuncExpr FuncId="0.1598.1.0" FuncRetSet="false" TypeMdid="0.701.1.0"/>
+                  <dxl:FuncExpr FuncId="0.1598.1.0" FuncRetSet="false" TypeMdid="0.701.1.0" FuncVariadic="false"/>
                 </dxl:Comparison>
               </dxl:Filter>
               <dxl:TableDescriptor Mdid="6.32768.1.0" TableName="t1">

--- a/src/backend/gporca/data/dxl/minidump/TaintedReplicatedLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TaintedReplicatedLimit.mdp
@@ -215,9 +215,7 @@
       </dxl:Type>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="1">
         <dxl:TableDescriptor Mdid="6.16402.1.0" TableName="snackbox">
@@ -256,9 +254,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0" ActionCol="8" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0" ActionCol="16" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.031503" Rows="3.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.031503" Rows="3.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -266,16 +264,16 @@
             <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16402.1.0" TableName="snackbox">
           <dxl:Columns>
-            <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -286,7 +284,7 @@
             <dxl:ProjElem ColId="0" Alias="c">
               <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="8" Alias="ColRef_0008">
+            <dxl:ProjElem ColId="16" Alias="ColRef_0016">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/TaintedReplicatedWindowAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TaintedReplicatedWindowAgg.mdp
@@ -220,9 +220,7 @@
       <dxl:ColumnStatistics Mdid="1.16412.1.0.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="9" ColName="a" TypeMdid="0.700.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="9">
         <dxl:TableDescriptor Mdid="6.16409.1.0" TableName="snackbox">
@@ -271,9 +269,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="8" ActionCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="8" ActionCol="17" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.031499" Rows="3.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.031499" Rows="3.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -281,16 +279,16 @@
             <dxl:Ident ColId="8" ColName="sum" TypeMdid="0.700.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16409.1.0" TableName="snackbox">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.700.1.0" ColWidth="4"/>
-            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -301,7 +299,7 @@
             <dxl:ProjElem ColId="8" Alias="sum">
               <dxl:Ident ColId="8" ColName="sum" TypeMdid="0.700.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+            <dxl:ProjElem ColId="17" Alias="ColRef_0017">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateCardinalityAssert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateCardinalityAssert.mdp
@@ -218,9 +218,7 @@
       <dxl:ColumnStatistics Mdid="1.229435.1.1.6" Name="cmax" Width="4.000000"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2" InsertColumns="11,2" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.229435.1.1" TableName="r">
@@ -275,7 +273,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="8">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="18" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="27" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.086861" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -288,17 +286,17 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.229435.1.1" TableName="r">
           <dxl:Columns>
-            <dxl:Column ColId="19" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="20" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="18" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1">
@@ -318,8 +316,8 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
-              <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="27" Alias="ColRef_0027">
+              <dxl:Ident ColId="27" ColName="ColRef_0027" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -329,7 +327,7 @@
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
-          <dxl:Split DeleteColumns="0,1" InsertColumns="10,1" ActionCol="18" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+          <dxl:Split DeleteColumns="0,1" InsertColumns="10,1" ActionCol="27" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="862.000803" Rows="2.000000" Width="22"/>
             </dxl:Properties>
@@ -346,7 +344,7 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="18" Alias="ColRef_0018">
+              <dxl:ProjElem ColId="27" Alias="ColRef_0027">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateCheckConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateCheckConstraint.mdp
@@ -294,7 +294,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1,2,3" ActionCol="12" CtidCol="4" SegmentIdCol="10" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1,2,3" ActionCol="23" CtidCol="4" SegmentIdCol="10" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.117383" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -313,19 +313,17 @@
             <dxl:Ident ColId="3" ColName="d" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.17005.1.1" TableName="r">
           <dxl:Columns>
-            <dxl:Column ColId="13" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="14" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="15" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="16" Attno="4" ColName="d" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="18" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="19" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="20" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="21" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="12" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Assert ErrorCode="23514">
@@ -351,8 +349,8 @@
             <dxl:ProjElem ColId="10" Alias="gp_segment_id">
               <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="12" Alias="ColRef_0012">
-              <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+              <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:AssertConstraintList>
@@ -398,8 +396,8 @@
               <dxl:ProjElem ColId="10" Alias="gp_segment_id">
                 <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="12" Alias="ColRef_0012">
-                <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+                <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:AssertConstraintList>
@@ -411,7 +409,7 @@
                 </dxl:Not>
               </dxl:AssertConstraint>
             </dxl:AssertConstraintList>
-            <dxl:Split DeleteColumns="0,1,2,3" InsertColumns="0,11,2,3" ActionCol="12" CtidCol="4" SegmentIdCol="10" PreserveOids="false">
+            <dxl:Split DeleteColumns="0,1,2,3" InsertColumns="0,11,2,3" ActionCol="23" CtidCol="4" SegmentIdCol="10" PreserveOids="false">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000135" Rows="2.000000" Width="34"/>
               </dxl:Properties>
@@ -437,7 +435,7 @@
                 <dxl:ProjElem ColId="11" Alias="b">
                   <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="12" Alias="ColRef_0012">
+                <dxl:ProjElem ColId="23" Alias="ColRef_0023">
                   <dxl:DMLAction/>
                 </dxl:ProjElem>
               </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateDistKeyMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDistKeyMismatchedDistribution.mdp
@@ -234,9 +234,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="21" ColName="i" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2,3" InsertColumns="21,2,3" CtidCol="4" SegmentIdCol="10" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.24803.1.0" TableName="pt2">
@@ -302,7 +300,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1,2" ActionCol="31" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324057.842928" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -318,18 +316,17 @@
             <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.24803.1.0" TableName="pt2">
           <dxl:Columns>
-            <dxl:Column ColId="22" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="23" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="24" Attno="3" ColName="k" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="21" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
@@ -352,8 +349,8 @@
             <dxl:ProjElem ColId="9" Alias="gp_segment_id">
               <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-              <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="31" Alias="ColRef_0031">
+              <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -363,7 +360,7 @@
               <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
-          <dxl:Split DeleteColumns="0,1,2" InsertColumns="20,1,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+          <dxl:Split DeleteColumns="0,1,2" InsertColumns="20,1,2" ActionCol="31" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="1324057.792106" Rows="2.000000" Width="26"/>
             </dxl:Properties>
@@ -383,7 +380,7 @@
               <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                 <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+              <dxl:ProjElem ColId="31" Alias="ColRef_0031">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateDistKeyWithNestedJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDistKeyWithNestedJoin.mdp
@@ -602,9 +602,7 @@ WHERE t1.id1 = t2.id1;
       </dxl:GPDBScalarOp>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="11" ColName="id1" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2" InsertColumns="11,2" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.57388.1.0" TableName="tab1" LockMode="7">
@@ -680,7 +678,7 @@ WHERE t1.id1 = t2.id1;
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="17">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="27" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="36" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="4755.378785" Rows="60001.000000" Width="1"/>
         </dxl:Properties>
@@ -693,17 +691,17 @@ WHERE t1.id1 = t2.id1;
             <dxl:Ident ColId="1" ColName="id2" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.57388.1.0" TableName="tab1">
           <dxl:Columns>
-            <dxl:Column ColId="28" Attno="1" ColName="id1" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="29" Attno="2" ColName="id2" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="30" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="31" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="32" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="33" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="34" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="35" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="36" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="27" Attno="1" ColName="id1" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="30" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="31" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="32" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="33" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="34" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="35" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
@@ -723,8 +721,8 @@ WHERE t1.id1 = t2.id1;
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="27" Alias="ColRef_0027">
-              <dxl:Ident ColId="27" ColName="ColRef_0027" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="36" Alias="ColRef_0036">
+              <dxl:Ident ColId="36" ColName="ColRef_0036" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -734,7 +732,7 @@ WHERE t1.id1 = t2.id1;
               <dxl:Ident ColId="0" ColName="id1" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
-          <dxl:Split DeleteColumns="0,1" InsertColumns="10,1" ActionCol="27" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+          <dxl:Split DeleteColumns="0,1" InsertColumns="10,1" ActionCol="36" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="1315.067048" Rows="120002.000000" Width="22"/>
             </dxl:Properties>
@@ -751,7 +749,7 @@ WHERE t1.id1 = t2.id1;
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="27" Alias="ColRef_0027">
+              <dxl:ProjElem ColId="36" Alias="ColRef_0036">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateDistrKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDistrKey.mdp
@@ -213,9 +213,7 @@
       <dxl:ColumnStatistics Mdid="1.287352.1.1.6" Name="cmax" Width="4.000000"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.700.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2" InsertColumns="10,2" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.287352.1.1" TableName="s">
@@ -270,7 +268,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="10">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="18" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="27" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1723.841554" Rows="10000.000000" Width="1"/>
         </dxl:Properties>
@@ -283,17 +281,17 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.700.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.287352.1.1" TableName="s">
           <dxl:Columns>
-            <dxl:Column ColId="19" Attno="1" ColName="a" TypeMdid="0.700.1.0"/>
-            <dxl:Column ColId="20" Attno="2" ColName="b" TypeMdid="0.700.1.0"/>
-            <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="18" Attno="1" ColName="a" TypeMdid="0.700.1.0"/>
+            <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
@@ -313,8 +311,8 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
-              <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="27" Alias="ColRef_0027">
+              <dxl:Ident ColId="27" ColName="ColRef_0027" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -324,7 +322,7 @@
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.700.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
-          <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="18" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+          <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="27" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="863.777954" Rows="20000.000000" Width="22"/>
             </dxl:Properties>
@@ -341,7 +339,7 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="18" Alias="ColRef_0018">
+              <dxl:ProjElem ColId="27" Alias="ColRef_0027">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateDroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDroppedCols.mdp
@@ -198,9 +198,7 @@
       <dxl:ColumnStatistics Mdid="1.224805.1.1.0" Name="........pg.dropped.1........" Width="8.000000"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2" InsertColumns="10,2" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.224805.1.1" TableName="p">
@@ -247,7 +245,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.086114" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -260,17 +258,17 @@
             <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.224805.1.1" TableName="p">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
@@ -290,8 +288,8 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-              <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+              <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -301,7 +299,7 @@
               <dxl:Ident ColId="0" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
-          <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+          <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000107" Rows="2.000000" Width="22"/>
             </dxl:Properties>
@@ -318,7 +316,7 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+              <dxl:ProjElem ColId="19" Alias="ColRef_0019">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateNoCardinalityAssert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateNoCardinalityAssert.mdp
@@ -391,7 +391,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="11" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="20" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="517.068550" Rows="1000.000000" Width="1"/>
         </dxl:Properties>
@@ -404,17 +404,17 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.66829.1.1" TableName="r">
           <dxl:Columns>
-            <dxl:Column ColId="12" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
@@ -434,8 +434,8 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-              <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+              <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -445,7 +445,7 @@
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
-          <dxl:Split DeleteColumns="0,1" InsertColumns="9,10" ActionCol="11" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+          <dxl:Split DeleteColumns="0,1" InsertColumns="9,10" ActionCol="20" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.062190" Rows="2000.000000" Width="22"/>
             </dxl:Properties>
@@ -462,7 +462,7 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateNoDistKeyMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateNoDistKeyMismatchedDistribution.mdp
@@ -235,9 +235,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="21" ColName="j" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2,3" InsertColumns="1,21,3" CtidCol="4" SegmentIdCol="10" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.24803.1.0" TableName="pt2">
@@ -303,7 +301,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1,2" ActionCol="31" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324057.842928" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -319,18 +317,17 @@
             <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.24803.1.0" TableName="pt2">
           <dxl:Columns>
-            <dxl:Column ColId="22" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="23" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="24" Attno="3" ColName="k" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="21" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RoutedDistributeMotion SegmentIdCol="9" InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
@@ -353,13 +350,13 @@
             <dxl:ProjElem ColId="9" Alias="gp_segment_id">
               <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-              <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="31" Alias="ColRef_0031">
+              <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
-          <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,20,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+          <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,20,2" ActionCol="31" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="1324057.792106" Rows="2.000000" Width="26"/>
             </dxl:Properties>
@@ -379,7 +376,7 @@
               <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                 <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+              <dxl:ProjElem ColId="31" Alias="ColRef_0031">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateNoEnforceConstraints.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateNoEnforceConstraints.mdp
@@ -190,10 +190,7 @@ update constraints_tab SET notnullcol = NULL, positivecol =-1;
       <dxl:ColumnStatistics Mdid="1.16410.1.0.0" Name="id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="11" ColName="notnullcol" TypeMdid="0.25.1.0"/>
-        <dxl:Ident ColId="12" ColName="positivecol" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2,3" InsertColumns="1,11,12" CtidCol="4" SegmentIdCol="10" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.16410.1.0" TableName="constraints_tab">
@@ -239,7 +236,7 @@ update constraints_tab SET notnullcol = NULL, positivecol =-1;
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1,2" ActionCol="12" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1,2" ActionCol="22" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.078182" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -255,21 +252,20 @@ update constraints_tab SET notnullcol = NULL, positivecol =-1;
             <dxl:Ident ColId="2" ColName="positivecol" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16410.1.0" TableName="constraints_tab">
           <dxl:Columns>
-            <dxl:Column ColId="13" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="2" ColName="notnullcol" TypeMdid="0.25.1.0" ColWidth="8"/>
-            <dxl:Column ColId="15" Attno="3" ColName="positivecol" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="16" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="19" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="20" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="21" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,10,11" ActionCol="12" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+        <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,10,11" ActionCol="22" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000057" Rows="2.000000" Width="30"/>
           </dxl:Properties>
@@ -289,7 +285,7 @@ update constraints_tab SET notnullcol = NULL, positivecol =-1;
             <dxl:ProjElem ColId="9" Alias="gp_segment_id">
               <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="12" Alias="ColRef_0012">
+            <dxl:ProjElem ColId="22" Alias="ColRef_0022">
               <dxl:DMLAction/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateNotNullCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateNotNullCols.mdp
@@ -328,7 +328,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="6">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="28" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.690272" Rows="8.000000" Width="1"/>
         </dxl:Properties>
@@ -341,17 +341,17 @@
             <dxl:Ident ColId="1" ColName="d" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.17147.1.1" TableName="t">
           <dxl:Columns>
-            <dxl:Column ColId="20" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="21" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="22" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="23" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="24" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="25" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="26" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="27" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="28" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="19" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
@@ -371,8 +371,8 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="19" Alias="ColRef_0019">
-              <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="28" Alias="ColRef_0028">
+              <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -399,8 +399,8 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="19" Alias="ColRef_0019">
-                <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="28" Alias="ColRef_0028">
+                <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:AssertConstraintList>
@@ -412,7 +412,7 @@
                 </dxl:Not>
               </dxl:AssertConstraint>
             </dxl:AssertConstraintList>
-            <dxl:Split DeleteColumns="0,1" InsertColumns="18,9" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+            <dxl:Split DeleteColumns="0,1" InsertColumns="18,9" ActionCol="28" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="862.002045" Rows="16.000000" Width="26"/>
               </dxl:Properties>
@@ -432,7 +432,7 @@
                 <dxl:ProjElem ColId="18" Alias="c">
                   <dxl:Ident ColId="18" ColName="c" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+                <dxl:ProjElem ColId="28" Alias="ColRef_0028">
                   <dxl:DMLAction/>
                 </dxl:ProjElem>
               </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdatePartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdatePartTable.mdp
@@ -198,9 +198,7 @@
       <dxl:ColumnStatistics Mdid="1.224805.1.1.0" Name="........pg.dropped.1........" Width="8.000000"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2" InsertColumns="10,2" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.224805.1.1" TableName="p">
@@ -247,7 +245,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.086114" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -260,17 +258,17 @@
             <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.224805.1.1" TableName="p">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
@@ -290,8 +288,8 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-              <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+              <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -301,7 +299,7 @@
               <dxl:Ident ColId="0" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
-          <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+          <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000107" Rows="2.000000" Width="22"/>
             </dxl:Properties>
@@ -318,7 +316,7 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+              <dxl:ProjElem ColId="19" Alias="ColRef_0019">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateRandomDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateRandomDistr.mdp
@@ -196,7 +196,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.085998" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -209,20 +209,19 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.17027.1.1" TableName="rr">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+        <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="2.000000" Width="22"/>
           </dxl:Properties>
@@ -239,7 +238,7 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+            <dxl:ProjElem ColId="19" Alias="ColRef_0019">
               <dxl:DMLAction/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
@@ -699,9 +699,7 @@
       <dxl:ColumnStatistics Mdid="1.284632.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2" InsertColumns="1,19" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.284632.1.1" TableName="r">
@@ -765,7 +763,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="20">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="23" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="32" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="870.723927" Rows="100.000000" Width="1"/>
         </dxl:Properties>
@@ -778,17 +776,17 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.284632.1.1" TableName="r">
           <dxl:Columns>
-            <dxl:Column ColId="24" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="25" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="26" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="19" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Assert ErrorCode="23502">
@@ -808,8 +806,8 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="23" Alias="ColRef_0023">
-              <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="32" Alias="ColRef_0032">
+              <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:AssertConstraintList>
@@ -821,7 +819,7 @@
               </dxl:Not>
             </dxl:AssertConstraint>
           </dxl:AssertConstraintList>
-          <dxl:Split DeleteColumns="0,1" InsertColumns="0,18" ActionCol="23" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+          <dxl:Split DeleteColumns="0,1" InsertColumns="0,18" ActionCol="32" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="862.127977" Rows="200.000000" Width="22"/>
             </dxl:Properties>
@@ -838,7 +836,7 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+              <dxl:ProjElem ColId="32" Alias="ColRef_0032">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint.mdp
@@ -196,7 +196,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.086070" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -209,17 +209,17 @@
             <dxl:Ident ColId="1" ColName="d" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.17075.1.1" TableName="s">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Sort SortDiscardDuplicates="false">
@@ -239,13 +239,13 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-              <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+              <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:SortingColumnList>
-            <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            <dxl:SortingColumn ColId="19" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
           </dxl:SortingColumnList>
           <dxl:LimitCount/>
           <dxl:LimitOffset/>
@@ -266,8 +266,8 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-                <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+                <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
@@ -277,7 +277,7 @@
                 <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
-            <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+            <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="2.000000" Width="22"/>
               </dxl:Properties>
@@ -294,7 +294,7 @@
                 <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                   <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+                <dxl:ProjElem ColId="19" Alias="ColRef_0019">
                   <dxl:DMLAction/>
                 </dxl:ProjElem>
               </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateVolatileFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateVolatileFunction.mdp
@@ -411,7 +411,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="517.116550" Rows="1000.000000" Width="1"/>
         </dxl:Properties>
@@ -424,17 +424,17 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.66829.1.1" TableName="r">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
@@ -454,8 +454,8 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-              <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+              <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -465,7 +465,7 @@
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
-          <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+          <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.110190" Rows="2000.000000" Width="22"/>
             </dxl:Properties>
@@ -482,7 +482,7 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+              <dxl:ProjElem ColId="19" Alias="ColRef_0019">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>
@@ -498,8 +498,8 @@
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="9" Alias="a">
-                  <dxl:FuncExpr FuncId="0.317.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                    <dxl:FuncExpr FuncId="0.1598.1.0" FuncRetSet="false" TypeMdid="0.701.1.0"/>
+                  <dxl:FuncExpr FuncId="0.317.1.0" FuncRetSet="false" TypeMdid="0.23.1.0" FuncVariadic="false">
+                    <dxl:FuncExpr FuncId="0.1598.1.0" FuncRetSet="false" TypeMdid="0.701.1.0" FuncVariadic="false"/>
                   </dxl:FuncExpr>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="2" Alias="ctid">

--- a/src/backend/gporca/data/dxl/minidump/UpdateWindowGatherMerge.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateWindowGatherMerge.mdp
@@ -629,9 +629,7 @@
       </dxl:GPDBScalarOp>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="19" ColName="i" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2" InsertColumns="19,2" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.251337.1.0" TableName="window_agg_test">
@@ -709,7 +707,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="18">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="28" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="867.779091" Rows="100.000001" Width="1"/>
         </dxl:Properties>
@@ -722,17 +720,16 @@
             <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.251337.1.0" TableName="window_agg_test">
           <dxl:Columns>
-            <dxl:Column ColId="20" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="21" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="22" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="23" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="24" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="25" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="26" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="27" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="28" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RoutedDistributeMotion SegmentIdCol="8" InputSegments="0,1,2" OutputSegments="0,1,2">
@@ -752,13 +749,13 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="19" Alias="ColRef_0019">
-              <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="28" Alias="ColRef_0028">
+              <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
-          <dxl:Split DeleteColumns="0,1" InsertColumns="18,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+          <dxl:Split DeleteColumns="0,1" InsertColumns="18,1" ActionCol="28" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="862.045333" Rows="200.000002" Width="22"/>
             </dxl:Properties>
@@ -775,7 +772,7 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+              <dxl:ProjElem ColId="28" Alias="ColRef_0028">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateWithHashJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateWithHashJoin.mdp
@@ -240,9 +240,7 @@
       </dxl:GPDBScalarOp>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.1043.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2" InsertColumns="1,2" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.32769.1.0" TableName="s">
@@ -301,7 +299,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="6">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="18" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="27" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="867.746299" Rows="100.000000" Width="1"/>
         </dxl:Properties>
@@ -314,20 +312,20 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.32769.1.0" TableName="s">
           <dxl:Columns>
-            <dxl:Column ColId="19" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="4"/>
-            <dxl:Column ColId="20" Attno="2" ColName="b" TypeMdid="0.1043.1.0" ColWidth="4"/>
-            <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="4"/>
+            <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Split DeleteColumns="0,1" InsertColumns="0,1" ActionCol="18" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+        <dxl:Split DeleteColumns="0,1" InsertColumns="0,1" ActionCol="27" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="862.017132" Rows="200.000000" Width="22"/>
           </dxl:Properties>
@@ -344,7 +342,7 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
+            <dxl:ProjElem ColId="27" Alias="ColRef_0027">
               <dxl:DMLAction/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateWithOids.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateWithOids.mdp
@@ -157,9 +157,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2" InsertColumns="11,2" CtidCol="3" SegmentIdCol="10" PreserveOids="true" TupleOidCol="4">
         <dxl:TableDescriptor Mdid="6.199797.1.1" TableName="s">
@@ -208,7 +206,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="11" CtidCol="2" SegmentIdCol="9" PreserveOids="true" TupleOidCol="3">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="21" CtidCol="2" SegmentIdCol="9" PreserveOids="true" TupleOidCol="3">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.101739" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -221,18 +219,18 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.199797.1.1" TableName="s">
           <dxl:Columns>
-            <dxl:Column ColId="12" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="15" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="16" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="17" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="18" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="19" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="20" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="21" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="14" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
@@ -255,8 +253,8 @@
             <dxl:ProjElem ColId="9" Alias="gp_segment_id">
               <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-              <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+              <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -266,7 +264,7 @@
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
-          <dxl:Split DeleteColumns="0,1" InsertColumns="10,1" ActionCol="11" CtidCol="2" SegmentIdCol="9" PreserveOids="true" TupleOidCol="3">
+          <dxl:Split DeleteColumns="0,1" InsertColumns="10,1" ActionCol="21" CtidCol="2" SegmentIdCol="9" PreserveOids="true" TupleOidCol="3">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000095" Rows="2.000000" Width="26"/>
             </dxl:Properties>
@@ -286,7 +284,7 @@
               <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                 <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+              <dxl:ProjElem ColId="21" Alias="ColRef_0021">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateWithTriggers.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateWithTriggers.mdp
@@ -204,7 +204,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1,2" ActionCol="11" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.813202" Rows="8.000000" Width="1"/>
         </dxl:Properties>
@@ -220,21 +220,20 @@
             <dxl:Ident ColId="2" ColName="t3" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.187777.1.1" TableName="t_trig">
           <dxl:Columns>
-            <dxl:Column ColId="12" Attno="1" ColName="t1" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="2" ColName="t2" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="14" Attno="3" ColName="t3" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="15" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="16" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="17" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="18" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="19" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="20" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="21" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="11" Attno="1" ColName="t1" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,10,2" ActionCol="11" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+        <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,10,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000702" Rows="16.000000" Width="26"/>
           </dxl:Properties>
@@ -254,7 +253,7 @@
             <dxl:ProjElem ColId="9" Alias="gp_segment_id">
               <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+            <dxl:ProjElem ColId="21" Alias="ColRef_0021">
               <dxl:DMLAction/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdateZeroRows.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateZeroRows.mdp
@@ -359,9 +359,7 @@
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="11" ColName="y" TypeMdid="0.25.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2,3" InsertColumns="1,11,3" CtidCol="4" SegmentIdCol="10" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.795132.1.1" TableName="insert_tbl">
@@ -410,7 +408,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1,2" ActionCol="11" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="1"/>
         </dxl:Properties>
@@ -426,18 +424,17 @@
             <dxl:Ident ColId="2" ColName="z" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.795132.1.1" TableName="insert_tbl">
           <dxl:Columns>
-            <dxl:Column ColId="12" Attno="1" ColName="x" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="2" ColName="y" TypeMdid="0.25.1.0"/>
-            <dxl:Column ColId="14" Attno="3" ColName="z" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="15" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="16" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="17" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="18" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="19" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="20" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="21" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="11" Attno="1" ColName="x" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
@@ -460,8 +457,8 @@
             <dxl:ProjElem ColId="9" Alias="gp_segment_id">
               <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-              <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+              <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -491,8 +488,8 @@
               <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                 <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-                <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:AssertConstraintList>
@@ -530,7 +527,7 @@
                 </dxl:IsDistinctFrom>
               </dxl:AssertConstraint>
             </dxl:AssertConstraintList>
-            <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,10,2" ActionCol="11" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+            <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,10,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="38"/>
               </dxl:Properties>
@@ -553,7 +550,7 @@
                 <dxl:ProjElem ColId="10" Alias="y">
                   <dxl:Ident ColId="10" ColName="y" TypeMdid="0.25.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+                <dxl:ProjElem ColId="21" Alias="ColRef_0021">
                   <dxl:DMLAction/>
                 </dxl:ProjElem>
               </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdatingDistributionColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdatingDistributionColumn.mdp
@@ -209,9 +209,7 @@
       </dxl:GPDBFunc>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.1043.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2" InsertColumns="10,2" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.32769.1.0" TableName="s">
@@ -270,7 +268,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="434.130997" Rows="40.000000" Width="1"/>
         </dxl:Properties>
@@ -283,17 +281,17 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.32769.1.0" TableName="s">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.1043.1.0" ColWidth="4"/>
-            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
@@ -313,8 +311,8 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-              <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+              <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -324,7 +322,7 @@
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
-          <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+          <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.003493" Rows="80.000000" Width="30"/>
             </dxl:Properties>
@@ -341,7 +339,7 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+              <dxl:ProjElem ColId="19" Alias="ColRef_0019">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>
@@ -358,7 +356,7 @@
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="9" Alias="a">
                   <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
-                    <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                    <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                       <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
                         <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
                       </dxl:Cast>

--- a/src/backend/gporca/data/dxl/minidump/UpdatingMultipleColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdatingMultipleColumn.mdp
@@ -547,10 +547,7 @@
       </dxl:ColumnStatistics>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2" InsertColumns="2,1" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.40985.1.0" TableName="foo">
@@ -584,7 +581,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="9" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="18" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="436.737037" Rows="100.000000" Width="1"/>
         </dxl:Properties>
@@ -597,17 +594,17 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.40985.1.0" TableName="foo">
           <dxl:Columns>
-            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
@@ -627,8 +624,8 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-              <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
+              <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -638,7 +635,7 @@
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
-          <dxl:Split DeleteColumns="0,1" InsertColumns="1,0" ActionCol="9" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+          <dxl:Split DeleteColumns="0,1" InsertColumns="1,0" ActionCol="18" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.003279" Rows="200.000000" Width="22"/>
             </dxl:Properties>
@@ -655,7 +652,7 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+              <dxl:ProjElem ColId="18" Alias="ColRef_0018">
                 <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdatingNonDistColSameTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdatingNonDistColSameTable.mdp
@@ -196,9 +196,7 @@
       </dxl:Type>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="3" ColName="v_varchar1_old" TypeMdid="0.1043.1.0" TypeModifier="14"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2,3" InsertColumns="1,3,3" CtidCol="4" SegmentIdCol="10" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.49159.1.0" TableName="test">
@@ -234,7 +232,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1,2" ActionCol="10" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1,2" ActionCol="20" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.072958" Rows="1.000000" Width="1"/>
         </dxl:Properties>
@@ -250,21 +248,20 @@
             <dxl:Ident ColId="2" ColName="s_varchar_old" TypeMdid="0.1043.1.0" TypeModifier="14"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.49159.1.0" TableName="test">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="v_date_old" TypeMdid="0.1114.1.0" ColWidth="8"/>
-            <dxl:Column ColId="12" Attno="2" ColName="v_varchar1_old" TypeMdid="0.1043.1.0" TypeModifier="14" ColWidth="0"/>
-            <dxl:Column ColId="13" Attno="3" ColName="s_varchar_old" TypeMdid="0.1043.1.0" TypeModifier="14" ColWidth="6"/>
-            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="3" ColName="s_varchar_old" TypeMdid="0.1043.1.0" TypeModifier="14" ColWidth="6"/>
+            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,2,2" ActionCol="10" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+        <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,2,2" ActionCol="20" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="2.000000" Width="28"/>
           </dxl:Properties>
@@ -284,7 +281,7 @@
             <dxl:ProjElem ColId="9" Alias="gp_segment_id">
               <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
               <dxl:DMLAction/>
             </dxl:ProjElem>
           </dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/UpdatingNonDistributionColumnFunc.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdatingNonDistributionColumnFunc.mdp
@@ -188,9 +188,7 @@
       </dxl:GPDBFunc>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="10" ColName="b" TypeMdid="0.1043.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalUpdate DeleteColumns="1,2" InsertColumns="1,10" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:TableDescriptor Mdid="6.40973.1.0" TableName="s">
@@ -239,7 +237,7 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="438.817446" Rows="100.000000" Width="1"/>
         </dxl:Properties>
@@ -252,20 +250,20 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.40973.1.0" TableName="s">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.1043.1.0" ColWidth="4"/>
-            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Split DeleteColumns="0,1" InsertColumns="0,9" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+        <dxl:Split DeleteColumns="0,1" InsertColumns="0,9" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.004946" Rows="200.000000" Width="30"/>
           </dxl:Properties>
@@ -282,7 +280,7 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+            <dxl:ProjElem ColId="19" Alias="ColRef_0019">
               <dxl:DMLAction/>
             </dxl:ProjElem>
           </dxl:ProjList>
@@ -299,7 +297,7 @@
               </dxl:ProjElem>
               <dxl:ProjElem ColId="9" Alias="b">
                 <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
-                  <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                  <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                     <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
                       <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
                     </dxl:Cast>

--- a/src/backend/gporca/data/dxl/minidump/VolatileFunctionsBelowScalarAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/VolatileFunctionsBelowScalarAgg.mdp
@@ -192,9 +192,7 @@
       </dxl:GPDBAgg>
     </dxl:Metadata>
     <dxl:Query>
-      <dxl:OutputColumns>
-        <dxl:Ident ColId="4" ColName="f1" TypeMdid="0.25.1.0"/>
-      </dxl:OutputColumns>
+      <dxl:OutputColumns/>
       <dxl:CTEList/>
       <dxl:LogicalInsert InsertColumns="4">
         <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="src">
@@ -251,9 +249,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="3">
-      <dxl:DMLInsert Columns="3" ActionCol="5" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="3" ActionCol="13" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.015659" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.015659" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -261,16 +259,17 @@
             <dxl:Ident ColId="3" ColName="f1" TypeMdid="0.25.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="src">
           <dxl:Columns>
-            <dxl:Column ColId="6" Attno="1" ColName="f1" TypeMdid="0.25.1.0" ColWidth="18"/>
-            <dxl:Column ColId="7" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-            <dxl:Column ColId="8" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="9" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="10" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-            <dxl:Column ColId="11" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-            <dxl:Column ColId="12" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-            <dxl:Column ColId="13" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="4" Attno="1" ColName="f1" TypeMdid="0.25.1.0" ColWidth="18"/>
+            <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
@@ -281,7 +280,7 @@
             <dxl:ProjElem ColId="3" Alias="f1">
               <dxl:Ident ColId="3" ColName="f1" TypeMdid="0.25.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="5" Alias="ColRef_0005">
+            <dxl:ProjElem ColId="13" Alias="ColRef_0013">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
@@ -323,9 +322,9 @@
                 <dxl:GroupingColumns/>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="2" Alias="sum">
-                    <dxl:AggFunc AggMdid="0.2111.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
+                    <dxl:AggFunc AggMdid="0.2111.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                       <dxl:ValuesList ParamType="aggargs">
-                      <dxl:FuncExpr FuncId="0.1598.1.0" FuncRetSet="false" TypeMdid="0.701.1.0"/>
+                        <dxl:FuncExpr FuncId="0.1598.1.0" FuncRetSet="false" TypeMdid="0.701.1.0" FuncVariadic="false"/>
                       </dxl:ValuesList>
                       <dxl:ValuesList ParamType="aggdirectargs"/>
                       <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/parse_tests/q57-DMLDelete.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/q57-DMLDelete.xml
@@ -14,6 +14,7 @@
           <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
         </dxl:ProjElem>
       </dxl:ProjList>
+      <dxl:ProjList/>
       <dxl:TableDescriptor Mdid="6.899686.1.1" TableName="t">
         <dxl:Columns>
           <dxl:Column ColId="12" Attno="1" ColName="t1" TypeMdid="0.23.1.0"/>

--- a/src/backend/gporca/data/dxl/parse_tests/q58-DMLInsert.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/q58-DMLInsert.xml
@@ -39,6 +39,7 @@
               <dxl:Ident ColId="2" ColName="s3" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
+          <dxl:ProjList/>
           <dxl:TableDescriptor Mdid="6.899686.1.1" TableName="t">
             <dxl:Columns>
               <dxl:Column ColId="12" Attno="1" ColName="t1" TypeMdid="0.23.1.0"/>

--- a/src/backend/gporca/data/dxl/parse_tests/q60-DMLUpdate.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/q60-DMLUpdate.xml
@@ -17,6 +17,7 @@
           <dxl:Ident ColId="2" ColName="t3" TypeMdid="0.23.1.0"/>
         </dxl:ProjElem>
       </dxl:ProjList>
+      <dxl:ProjList/>
       <dxl:TableDescriptor Mdid="6.899686.1.1" TableName="t">
         <dxl:Columns>
           <dxl:Column ColId="13" Attno="1" ColName="t1" TypeMdid="0.23.1.0"/>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDML.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDML.h
@@ -52,6 +52,9 @@ private:
 	// source columns
 	CColRefArray *m_pdrgpcrSource;
 
+	// returning columns
+	CColRefArray *m_pdrgpcrOutput;
+
 	// set of modified columns from the target table
 	CBitSet *m_pbsModified;
 
@@ -81,9 +84,9 @@ public:
 	// ctor
 	CLogicalDML(CMemoryPool *mp, EDMLOperator edmlop,
 				CTableDescriptor *ptabdesc, CColRefArray *colref_array,
-				CBitSet *pbsModified, CColRef *pcrAction, CColRef *pcrCtid,
-				CColRef *pcrSegmentId, CColRef *pcrTupleOid,
-				CColRef *pcrTableOid);
+				CColRefArray *pdrgpcrOutput, CBitSet *pbsModified,
+				CColRef *pcrAction, CColRef *pcrCtid, CColRef *pcrSegmentId,
+				CColRef *pcrTupleOid, CColRef *pcrTableOid);
 
 	// dtor
 	virtual ~CLogicalDML();
@@ -115,6 +118,14 @@ public:
 	{
 		return m_pdrgpcrSource;
 	}
+
+	// output columns
+	CColRefArray *
+	PdrgpcrOutput() const
+	{
+		return m_pdrgpcrOutput;
+	}
+
 
 	// modified columns set
 	CBitSet *

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDelete.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDelete.h
@@ -37,6 +37,9 @@ private:
 	// columns to delete
 	CColRefArray *m_pdrgpcr;
 
+	// returning columns
+	CColRefArray *m_pdrgpcrOutput;
+
 	// ctid column
 	CColRef *m_pcrCtid;
 
@@ -57,6 +60,12 @@ public:
 	CLogicalDelete(CMemoryPool *mp, CTableDescriptor *ptabdesc,
 				   CColRefArray *colref_array, CColRef *pcrCtid,
 				   CColRef *pcrSegmentId, CColRef *pcrTableOid);
+
+	// ctor
+	CLogicalDelete(CMemoryPool *mp, CTableDescriptor *ptabdesc,
+				   CColRefArray *colref_array, CColRefArray *pdrgpcrOutput,
+				   CColRef *pcrCtid, CColRef *pcrSegmentId,
+				   CColRef *pcrTableOid);
 
 	// dtor
 	virtual ~CLogicalDelete();
@@ -80,6 +89,13 @@ public:
 	Pdrgpcr() const
 	{
 		return m_pdrgpcr;
+	}
+
+	// output columns
+	CColRefArray *
+	PdrgpcrOutput() const
+	{
+		return m_pdrgpcrOutput;
 	}
 
 	// ctid column

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalInsert.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalInsert.h
@@ -37,6 +37,9 @@ private:
 	// source columns
 	CColRefArray *m_pdrgpcrSource;
 
+	// returning columns
+	CColRefArray *m_pdrgpcrOutput;
+
 	// private copy ctor
 	CLogicalInsert(const CLogicalInsert &);
 
@@ -47,6 +50,10 @@ public:
 	// ctor
 	CLogicalInsert(CMemoryPool *mp, CTableDescriptor *ptabdesc,
 				   CColRefArray *colref_array);
+
+	// ctor
+	CLogicalInsert(CMemoryPool *mp, CTableDescriptor *ptabdesc,
+				   CColRefArray *colref_array, CColRefArray *pdrgpcrOutput);
 
 	// dtor
 	virtual ~CLogicalInsert();
@@ -70,6 +77,13 @@ public:
 	PdrgpcrSource() const
 	{
 		return m_pdrgpcrSource;
+	}
+
+	// output columns
+	CColRefArray *
+	PdrgpcrOutput() const
+	{
+		return m_pdrgpcrOutput;
 	}
 
 	// return table's descriptor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalUpdate.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalUpdate.h
@@ -40,6 +40,9 @@ private:
 	// columns to insert
 	CColRefArray *m_pdrgpcrInsert;
 
+	// returning columns
+	CColRefArray *m_pdrgpcrOutput;
+
 	// ctid column
 	CColRef *m_pcrCtid;
 
@@ -64,6 +67,13 @@ public:
 				   CColRefArray *pdrgpcrDelete, CColRefArray *pdrgpcrInsert,
 				   CColRef *pcrCtid, CColRef *pcrSegmentId,
 				   CColRef *pcrTupleOid, CColRef *pcrTableOid);
+
+	// ctor
+	CLogicalUpdate(CMemoryPool *mp, CTableDescriptor *ptabdesc,
+				   CColRefArray *pdrgpcrDelete, CColRefArray *pdrgpcrInsert,
+				   CColRefArray *pdrgpcrOutput, CColRef *pcrCtid,
+				   CColRef *pcrSegmentId, CColRef *pcrTupleOid,
+				   CColRef *pcrTableOid);
 
 	// dtor
 	virtual ~CLogicalUpdate();
@@ -94,6 +104,13 @@ public:
 	PdrgpcrInsert() const
 	{
 		return m_pdrgpcrInsert;
+	}
+
+	// output columns
+	CColRefArray *
+	PdrgpcrOutput() const
+	{
+		return m_pdrgpcrOutput;
 	}
 
 	// ctid column

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalDML.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalDML.h
@@ -42,6 +42,9 @@ private:
 	// array of source columns
 	CColRefArray *m_pdrgpcrSource;
 
+	// returning columns
+	CColRefArray *m_pdrgpcrOutput;
+
 	// set of modified columns from the target table
 	CBitSet *m_pbsModified;
 
@@ -67,8 +70,17 @@ private:
 	// required order spec
 	COrderSpec *m_pos;
 
+	// output distribution
+	CDistributionSpec *m_pdsOutput;
+
 	// required columns by local members
 	CColRefSet *m_pcrsRequiredLocal;
+
+	// in case of CTAS dml node will output source columns
+	const BOOL m_isCTAS; 
+
+	// is there any triggers for this kind of dml operation
+	const BOOL m_hasTriggers; 
 
 	// compute required order spec
 	COrderSpec *PosComputeRequired(CMemoryPool *mp, CTableDescriptor *ptabdesc);
@@ -83,9 +95,9 @@ public:
 	// ctor
 	CPhysicalDML(CMemoryPool *mp, CLogicalDML::EDMLOperator edmlop,
 				 CTableDescriptor *ptabdesc, CColRefArray *pdrgpcrSource,
-				 CBitSet *pbsModified, CColRef *pcrAction, CColRef *pcrCtid,
-				 CColRef *pcrSegmentId, CColRef *pcrTupleOid,
-				 CColRef *prcTableOid);
+				 CColRefArray *pdrgpcrOutput, CBitSet *pbsModified,
+				 CColRef *pcrAction, CColRef *pcrCtid, CColRef *pcrSegmentId,
+				 CColRef *pcrTupleOid, CColRef *prcTableOid);
 
 	// dtor
 	virtual ~CPhysicalDML();
@@ -160,6 +172,13 @@ public:
 		return m_pdrgpcrSource;
 	}
 
+	// output columns
+	virtual CColRefArray *
+	PdrgpcrOutput() const
+	{
+		return m_pdrgpcrOutput;
+	}
+
 	// match function
 	virtual BOOL Matches(COperator *pop) const;
 
@@ -171,6 +190,13 @@ public:
 	FInputOrderSensitive() const
 	{
 		return false;
+	}
+
+	// does dml node has corresponding triggers
+	virtual BOOL
+	HasTriggers() const
+	{
+		return m_hasTriggers;
 	}
 
 	//-------------------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -127,11 +127,11 @@ private:
 		ULONG ulOriginOpId, CName *pname, CColRefArray *pdrgpcrOutput);
 
 	typedef CExpression *(PRewrittenIndexPath)(CMemoryPool *mp,
-											   CExpression *pexprIndexCond,
-											   CExpression *pexprResidualCond,
-											   const IMDIndex *pmdindex,
-											   CTableDescriptor *ptabdesc,
-											   COperator *popLogical);
+												CExpression *pexprIndexCond,
+												CExpression *pexprResidualCond,
+												const IMDIndex *pmdindex,
+												CTableDescriptor *ptabdesc,
+												COperator *popLogical);
 
 	// private copy ctor
 	CXformUtils(const CXformUtils &);
@@ -423,13 +423,18 @@ public:
 	static CExpression *PexprLogicalDMLOverProject(
 		CMemoryPool *mp, CExpression *pexprChild,
 		CLogicalDML::EDMLOperator edmlop, CTableDescriptor *ptabdesc,
-		CColRefArray *colref_array, CColRef *pcrCtid, CColRef *pcrSegmentId,
-		CColRef *pcrTableOid);
+		CColRefArray *colref_array, CColRefArray *pdrgpcrOutput,
+		CColRef *pcrCtid, CColRef *pcrSegmentId, CColRef *pcrTableOid);
 
 	// check whether there are any BEFORE or AFTER triggers on the
 	// given table that match the given DML operation
 	static BOOL FTriggersExist(CLogicalDML::EDMLOperator edmlop,
 							   CTableDescriptor *ptabdesc, BOOL fBefore);
+
+	// check whether there are any triggers on the
+	// given table that match the given DML operation
+	static BOOL FTriggersExist(CLogicalDML::EDMLOperator edmlop,
+							   CTableDescriptor *ptabdesc);
 
 	// does the given trigger type match the given logical DML type
 	static BOOL FTriggerApplies(CLogicalDML::EDMLOperator edmlop,

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalInsert.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalInsert.cpp
@@ -30,7 +30,11 @@ using namespace gpopt;
 //
 //---------------------------------------------------------------------------
 CLogicalInsert::CLogicalInsert(CMemoryPool *mp)
-	: CLogical(mp), m_ptabdesc(NULL), m_pdrgpcrSource(NULL)
+	: CLogical(mp),
+	  m_ptabdesc(NULL),
+	  m_pdrgpcrSource(NULL),
+	  m_pdrgpcrOutput(NULL)
+
 {
 	m_fPattern = true;
 }
@@ -45,13 +49,45 @@ CLogicalInsert::CLogicalInsert(CMemoryPool *mp)
 //---------------------------------------------------------------------------
 CLogicalInsert::CLogicalInsert(CMemoryPool *mp, CTableDescriptor *ptabdesc,
 							   CColRefArray *pdrgpcrSource)
-	: CLogical(mp), m_ptabdesc(ptabdesc), m_pdrgpcrSource(pdrgpcrSource)
+	: CLogical(mp),
+	  m_ptabdesc(ptabdesc),
+	  m_pdrgpcrSource(pdrgpcrSource),
+	  m_pdrgpcrOutput(NULL)
+
+{
+	GPOS_ASSERT(NULL != ptabdesc);
+	GPOS_ASSERT(NULL != pdrgpcrSource);
+
+	m_pdrgpcrOutput =
+		PdrgpcrCreateMapping(mp, ptabdesc->Pdrgpcoldesc(), UlOpId());
+
+	m_pcrsLocalUsed->Include(m_pdrgpcrSource);
+	m_pcrsLocalUsed->Include(m_pdrgpcrOutput);
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CLogicalInsert::CLogicalInsert
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CLogicalInsert::CLogicalInsert(CMemoryPool *mp, CTableDescriptor *ptabdesc,
+							   CColRefArray *pdrgpcrSource,
+							   CColRefArray *pdrgpcrOutput)
+	: CLogical(mp),
+	  m_ptabdesc(ptabdesc),
+	  m_pdrgpcrSource(pdrgpcrSource),
+	  m_pdrgpcrOutput(pdrgpcrOutput)
 
 {
 	GPOS_ASSERT(NULL != ptabdesc);
 	GPOS_ASSERT(NULL != pdrgpcrSource);
 
 	m_pcrsLocalUsed->Include(m_pdrgpcrSource);
+	m_pcrsLocalUsed->Include(m_pdrgpcrOutput);
 }
 
 //---------------------------------------------------------------------------
@@ -66,6 +102,7 @@ CLogicalInsert::~CLogicalInsert()
 {
 	CRefCount::SafeRelease(m_ptabdesc);
 	CRefCount::SafeRelease(m_pdrgpcrSource);
+	CRefCount::SafeRelease(m_pdrgpcrOutput);
 }
 
 //---------------------------------------------------------------------------
@@ -87,7 +124,8 @@ CLogicalInsert::Matches(COperator *pop) const
 	CLogicalInsert *popInsert = CLogicalInsert::PopConvert(pop);
 
 	return m_ptabdesc->MDId()->Equals(popInsert->Ptabdesc()->MDId()) &&
-		   m_pdrgpcrSource->Equals(popInsert->PdrgpcrSource());
+		   m_pdrgpcrSource->Equals(popInsert->PdrgpcrSource()) &&
+		   m_pdrgpcrOutput->Equals(popInsert->PdrgpcrOutput());
 }
 
 //---------------------------------------------------------------------------
@@ -105,6 +143,9 @@ CLogicalInsert::HashValue() const
 									   m_ptabdesc->MDId()->HashValue());
 	ulHash =
 		gpos::CombineHashes(ulHash, CUtils::UlHashColArray(m_pdrgpcrSource));
+
+	ulHash =
+		gpos::CombineHashes(ulHash, CUtils::UlHashColArray(m_pdrgpcrOutput));
 
 	return ulHash;
 }
@@ -124,9 +165,22 @@ CLogicalInsert::PopCopyWithRemappedColumns(CMemoryPool *mp,
 {
 	CColRefArray *colref_array =
 		CUtils::PdrgpcrRemap(mp, m_pdrgpcrSource, colref_mapping, must_exist);
+
+	CColRefArray *pdrgpcrOutput = NULL;
+	if (must_exist)
+	{
+		pdrgpcrOutput =
+			CUtils::PdrgpcrRemapAndCreate(mp, m_pdrgpcrOutput, colref_mapping);
+	}
+	else
+	{
+		pdrgpcrOutput = CUtils::PdrgpcrRemap(mp, m_pdrgpcrOutput,
+											 colref_mapping, must_exist);
+	}
 	m_ptabdesc->AddRef();
 
-	return GPOS_NEW(mp) CLogicalInsert(mp, m_ptabdesc, colref_array);
+	return GPOS_NEW(mp)
+		CLogicalInsert(mp, m_ptabdesc, colref_array, pdrgpcrOutput);
 }
 
 //---------------------------------------------------------------------------
@@ -144,6 +198,8 @@ CLogicalInsert::DeriveOutputColumns(CMemoryPool *mp,
 {
 	CColRefSet *pcrsOutput = GPOS_NEW(mp) CColRefSet(mp);
 	pcrsOutput->Include(m_pdrgpcrSource);
+	pcrsOutput->Include(m_pdrgpcrOutput);
+
 	return pcrsOutput;
 }
 
@@ -156,10 +212,13 @@ CLogicalInsert::DeriveOutputColumns(CMemoryPool *mp,
 //
 //---------------------------------------------------------------------------
 CKeyCollection *
-CLogicalInsert::DeriveKeyCollection(CMemoryPool *,	// mp
-									CExpressionHandle &exprhdl) const
+CLogicalInsert::DeriveKeyCollection(CMemoryPool *mp,
+									CExpressionHandle &	 // exprhdl
+) const
 {
-	return PkcDeriveKeysPassThru(exprhdl, 0 /* ulChild */);
+	const CBitSetArray *pdrgpbs = m_ptabdesc->PdrgpbsKeys();
+
+	return CLogical::PkcKeysBaseTable(mp, pdrgpbs, m_pdrgpcrOutput);
 }
 
 //---------------------------------------------------------------------------
@@ -232,6 +291,36 @@ CLogicalInsert::OsPrint(IOstream &os) const
 	os << "), Source Columns: [";
 	CUtils::OsPrintDrgPcr(os, m_pdrgpcrSource);
 	os << "]";
+	os << ", Output Columns: [";
+	CUtils::OsPrintDrgPcr(os, m_pdrgpcrOutput);
+	os << "] Key sets: {";
+
+	const ULONG ulColumns = m_pdrgpcrOutput->Size();
+	const CBitSetArray *pdrgpbsKeys = m_ptabdesc->PdrgpbsKeys();
+	for (ULONG ul = 0; ul < pdrgpbsKeys->Size(); ul++)
+	{
+		CBitSet *pbs = (*pdrgpbsKeys)[ul];
+		if (0 < ul)
+		{
+			os << ", ";
+		}
+		os << "[";
+		ULONG ulPrintedKeys = 0;
+		for (ULONG ulKey = 0; ulKey < ulColumns; ulKey++)
+		{
+			if (pbs->Get(ulKey))
+			{
+				if (0 < ulPrintedKeys)
+				{
+					os << ",";
+				}
+				os << ulKey;
+				ulPrintedKeys++;
+			}
+		}
+		os << "]";
+	}
+	os << "}";
 
 	return os;
 }

--- a/src/backend/gporca/libgpopt/src/xforms/CXformDelete2DML.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformDelete2DML.cpp
@@ -80,6 +80,9 @@ CXformDelete2DML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	CColRefArray *colref_array = popDelete->Pdrgpcr();
 	colref_array->AddRef();
 
+	CColRefArray *pdrgpcrOutput = popDelete->PdrgpcrOutput();
+	pdrgpcrOutput->AddRef();
+
 	CColRef *pcrCtid = popDelete->PcrCtid();
 
 	CColRef *pcrSegmentId = popDelete->PcrSegmentId();
@@ -93,7 +96,7 @@ CXformDelete2DML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	// create logical DML
 	CExpression *pexprAlt = CXformUtils::PexprLogicalDMLOverProject(
 		mp, pexprChild, CLogicalDML::EdmlDelete, ptabdesc, colref_array,
-		pcrCtid, pcrSegmentId, pcrTableOid);
+		pdrgpcrOutput, pcrCtid, pcrSegmentId, pcrTableOid);
 
 	// add alternative to transformation result
 	pxfres->Add(pexprAlt);

--- a/src/backend/gporca/libgpopt/src/xforms/CXformImplementDML.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformImplementDML.cpp
@@ -82,6 +82,8 @@ CXformImplementDML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 
 	CColRefArray *pdrgpcrSource = popDML->PdrgpcrSource();
 	pdrgpcrSource->AddRef();
+	CColRefArray *pdrgpcrOutput = popDML->PdrgpcrOutput();
+	pdrgpcrOutput->AddRef();
 	CBitSet *pbsModified = popDML->PbsModified();
 	pbsModified->AddRef();
 
@@ -98,7 +100,7 @@ CXformImplementDML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	// create physical DML
 	CExpression *pexprAlt = GPOS_NEW(mp) CExpression(
 		mp,
-		GPOS_NEW(mp) CPhysicalDML(mp, edmlop, ptabdesc, pdrgpcrSource,
+		GPOS_NEW(mp) CPhysicalDML(mp, edmlop, ptabdesc, pdrgpcrSource, pdrgpcrOutput,
 								  pbsModified, pcrAction, pcrCtid, pcrSegmentId,
 								  pcrTupleOid, pcrTableOid),
 		pexprChild);

--- a/src/backend/gporca/libgpopt/src/xforms/CXformInsert2DML.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformInsert2DML.cpp
@@ -80,6 +80,9 @@ CXformInsert2DML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	CColRefArray *pdrgpcrSource = popInsert->PdrgpcrSource();
 	pdrgpcrSource->AddRef();
 
+	CColRefArray *pdrgpcrOutput = popInsert->PdrgpcrOutput();
+	pdrgpcrOutput->AddRef();
+
 	// child of insert operator
 	CExpression *pexprChild = (*pexpr)[0];
 	pexprChild->AddRef();
@@ -87,6 +90,7 @@ CXformInsert2DML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	// create logical DML
 	CExpression *pexprAlt = CXformUtils::PexprLogicalDMLOverProject(
 		mp, pexprChild, CLogicalDML::EdmlInsert, ptabdesc, pdrgpcrSource,
+		pdrgpcrOutput,
 		NULL,  //pcrCtid
 		NULL,  //pcrSegmentId
 		NULL   //pcrTable

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUpdate2DML.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUpdate2DML.cpp
@@ -84,6 +84,7 @@ CXformUpdate2DML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	CTableDescriptor *ptabdesc = popUpdate->Ptabdesc();
 	CColRefArray *pdrgpcrDelete = popUpdate->PdrgpcrDelete();
 	CColRefArray *pdrgpcrInsert = popUpdate->PdrgpcrInsert();
+	CColRefArray *pdrgpcrOutput = popUpdate->PdrgpcrOutput();
 	CColRef *pcrCtid = popUpdate->PcrCtid();
 	CColRef *pcrSegmentId = popUpdate->PcrSegmentId();
 	CColRef *pcrTupleOid = popUpdate->PcrTupleOid();
@@ -160,11 +161,12 @@ CXformUpdate2DML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	// create logical DML
 	ptabdesc->AddRef();
 	pdrgpcrDelete->AddRef();
+	pdrgpcrOutput->AddRef();
 	CExpression *pexprDML = GPOS_NEW(mp) CExpression(
 		mp,
 		GPOS_NEW(mp) CLogicalDML(mp, CLogicalDML::EdmlUpdate, ptabdesc,
-								 pdrgpcrDelete, pbsModified, pcrAction, pcrCtid,
-								 pcrSegmentId, pcrTupleOid, pcrTableOid),
+								 pdrgpcrDelete, pdrgpcrOutput, pbsModified, pcrAction, pcrCtid,
+						pcrSegmentId, pcrTupleOid, pcrTableOid),
 		pexprAssertConstraints);
 
 	// TODO:  - Oct 30, 2012; detect and handle AFTER triggers on update

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h
@@ -87,6 +87,13 @@ public:
 	// user id
 	ULONG GetExecuteAsUserId() const;
 
+	// get the column descriptor array
+	const CDXLColDescrArray *
+	GetColumnDescr() const
+	{
+		return m_dxl_column_descr_array;
+	}
+
 	// get the column descriptor at the given position
 	const CDXLColDescr *GetColumnDescrAt(ULONG idx) const;
 

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLPhysicalDML.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLPhysicalDML.cpp
@@ -172,11 +172,14 @@ CDXLPhysicalDML::SerializeToDXL(CXMLSerializer *xml_serializer,
 	// serialize project list
 	(*node)[0]->SerializeToDXL(xml_serializer);
 
+	// serialize project list for returning list
+	(*node)[1]->SerializeToDXL(xml_serializer);
+
 	// serialize table descriptor
 	m_dxl_table_descr->SerializeToDXL(xml_serializer);
 
 	// serialize physical child
-	(*node)[1]->SerializeToDXL(xml_serializer);
+	(*node)[2]->SerializeToDXL(xml_serializer);
 
 	xml_serializer->CloseElement(
 		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix), element_name);
@@ -194,8 +197,8 @@ CDXLPhysicalDML::SerializeToDXL(CXMLSerializer *xml_serializer,
 void
 CDXLPhysicalDML::AssertValid(const CDXLNode *node, BOOL validate_children) const
 {
-	GPOS_ASSERT(2 == node->Arity());
-	CDXLNode *child_dxlnode = (*node)[1];
+	GPOS_ASSERT(3 == node->Arity());
+	CDXLNode *child_dxlnode = (*node)[2];
 	GPOS_ASSERT(EdxloptypePhysical ==
 				child_dxlnode->GetOperator()->GetDXLOperatorType());
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPhysicalDML.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPhysicalDML.cpp
@@ -145,6 +145,13 @@ CParseHandlerPhysicalDML::StartElement(const XMLCh *const,	// element_uri,
 			m_parse_handler_mgr, this);
 	m_parse_handler_mgr->ActivateParseHandler(table_descr_parse_handler);
 
+	// parse handler for the returning proj list
+	CParseHandlerBase *proj_list_output_parse_handler =
+		CParseHandlerFactory::GetParseHandler(
+			m_mp, CDXLTokens::XmlstrToken(EdxltokenScalarProjList),
+			m_parse_handler_mgr, this);
+	m_parse_handler_mgr->ActivateParseHandler(proj_list_output_parse_handler);
+
 	// parse handler for the proj list
 	CParseHandlerBase *proj_list_parse_handler =
 		CParseHandlerFactory::GetParseHandler(
@@ -170,6 +177,7 @@ CParseHandlerPhysicalDML::StartElement(const XMLCh *const,	// element_uri,
 	this->Append(prop_parse_handler);
 	this->Append(direct_dispatch_parse_handler);
 	this->Append(proj_list_parse_handler);
+	this->Append(proj_list_output_parse_handler);
 	this->Append(table_descr_parse_handler);
 	this->Append(child_parse_handler);
 }
@@ -199,7 +207,7 @@ CParseHandlerPhysicalDML::EndElement(const XMLCh *const,  // element_uri,
 				   str->GetBuffer());
 	}
 
-	GPOS_ASSERT(5 == this->Length());
+	GPOS_ASSERT(6 == this->Length());
 
 	CParseHandlerProperties *prop_parse_handler =
 		dynamic_cast<CParseHandlerProperties *>((*this)[0]);
@@ -217,15 +225,20 @@ CParseHandlerPhysicalDML::EndElement(const XMLCh *const,  // element_uri,
 	GPOS_ASSERT(NULL != proj_list_parse_handler);
 	GPOS_ASSERT(NULL != proj_list_parse_handler->CreateDXLNode());
 
+	CParseHandlerProjList *proj_list_output_parse_handler =
+		dynamic_cast<CParseHandlerProjList *>((*this)[3]);
+	GPOS_ASSERT(NULL != proj_list_output_parse_handler);
+	GPOS_ASSERT(NULL != proj_list_output_parse_handler->CreateDXLNode());
+
 	CParseHandlerTableDescr *table_descr_parse_handler =
-		dynamic_cast<CParseHandlerTableDescr *>((*this)[3]);
+		dynamic_cast<CParseHandlerTableDescr *>((*this)[4]);
 	GPOS_ASSERT(NULL != table_descr_parse_handler);
 	GPOS_ASSERT(NULL != table_descr_parse_handler->GetDXLTableDescr());
 	CDXLTableDescr *table_descr = table_descr_parse_handler->GetDXLTableDescr();
 	table_descr->AddRef();
 
 	CParseHandlerPhysicalOp *child_parse_handler =
-		dynamic_cast<CParseHandlerPhysicalOp *>((*this)[4]);
+		dynamic_cast<CParseHandlerPhysicalOp *>((*this)[5]);
 	GPOS_ASSERT(NULL != child_parse_handler);
 	GPOS_ASSERT(NULL != child_parse_handler->CreateDXLNode());
 
@@ -242,6 +255,7 @@ CParseHandlerPhysicalDML::EndElement(const XMLCh *const,  // element_uri,
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 	AddChildFromParseHandler(proj_list_parse_handler);
+	AddChildFromParseHandler(proj_list_output_parse_handler);
 	AddChildFromParseHandler(child_parse_handler);
 
 #ifdef GPOS_DEBUG

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CDMLTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CDMLTest.cpp
@@ -28,6 +28,7 @@ ULONG CDMLTest::m_ulDMLTestCounter = 0;	 // start from first test
 // minidump files
 const CHAR *rgszDMLFileNames[] = {
 	"../data/dxl/minidump/Insert.mdp",
+	"../data/dxl/minidump/InsertIntoReturning.mdp",
 	"../data/dxl/minidump/MultipleUpdateWithJoinOnDistCol.mdp",
 	"../data/dxl/minidump/UpdatingNonDistributionColumnFunc.mdp",
 	"../data/dxl/minidump/UpdatingMultipleColumn.mdp",

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1339,6 +1339,7 @@ _copyDML(const DML *from)
 	COPY_SCALAR_FIELD(tupleoidColIdx);
 	COPY_SCALAR_FIELD(tableoidColIdx);
 	COPY_SCALAR_FIELD(canSetTag);
+	COPY_NODE_FIELD(returningList);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1219,6 +1219,7 @@ _outDML(StringInfo str, const DML *node)
 	WRITE_INT_FIELD(tupleoidColIdx);
 	WRITE_INT_FIELD(tableoidColIdx);
 	WRITE_BOOL_FIELD(canSetTag);
+	WRITE_NODE_FIELD(returningList);
 
 	_outPlanInfo(str, (Plan *) node);
 }

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2240,6 +2240,7 @@ _readDML(void)
 	READ_INT_FIELD(tupleoidColIdx);
 	READ_INT_FIELD(tableoidColIdx);
 	READ_BOOL_FIELD(canSetTag);
+	READ_NODE_FIELD(returningList);
 
 	readPlanInfo((Plan *)local_node);
 

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -248,7 +248,10 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 		}
 
 		if (result)
+		{
+			result->hasReturning = (parse->returningList != NIL);
 			return result;
+		}
 	}
 
 	/*

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -211,6 +211,10 @@ private:
 	// translate an Expr into CDXLNode
 	CDXLNode *TranslateExprToDXL(Expr *expr);
 
+	// translate an Expr into CDXLNode with specified mapping
+	CDXLNode *TranslateExprToDXL(Expr *expr,
+								 CMappingVarColId *var_to_colid_map);
+
 	// translate the JoinExpr (inside FromExpr) into a CDXLLogicalJoin node
 	CDXLNode *TranslateJoinExprInFromToDXL(JoinExpr *join_expr);
 
@@ -296,6 +300,11 @@ private:
 
 	// translate a target list entry or a join alias entry into a project element
 	CDXLNode *TranslateExprToDXLProject(Expr *expr, const CHAR *alias_name,
+										BOOL insist_new_colids = false);
+
+	// translate a target list entry or a join alias entry into a project element using specified mapping
+	CDXLNode *TranslateExprToDXLProject(Expr *expr, const CHAR *alias_name,
+										CMappingVarColId *var_to_colid_map,
 										BOOL insist_new_colids = false);
 
 	// translate a CTE into a DXL logical CTE operator
@@ -422,6 +431,11 @@ private:
 
 	// returns the corresponding ColId for the given system attribute numbber
 	ULONG GetSystemColId(INT attribute_number);
+
+	// Wrap dxl node in logical project with return columns from returningList
+	CDXLNode *ProcessReturningList(
+		CDXLNode *dml_dxlnode, CDXLTableDescr *table_descr,
+		IntToUlongMap *output_attno_to_colid_mapping);
 
 public:
 	// dtor

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1330,6 +1330,7 @@ typedef struct DML
 	AttrNumber	tupleoidColIdx;	/* index of tuple oid column into the target list */
 	AttrNumber	tableoidColIdx; /* index of table oid column into the target list */
 	bool		canSetTag;		/* calculate processed tuples */
+	List	   *returningList;	/* return-values list (of TargetEntry) */
 } DML;
 
 /*


### PR DESCRIPTION
At this time RETURNING operator is unsupported by GPDB-side query-to-dxl translator and ORCA
This PR adds this support

What was made:
- in case of nonempty returning, query's returningList was used to create in dxl query tree LogicalProject node that contains projection rules and Logical dml query node (LogicalInsert, etc)
- OutputColumns field in dxl query for dml queries was changed to contain expressions, requested under RETURNING operator, these expressions should be provided by previously created LogicalProject, in case of no RETURNING it will be empty as in this case it doesnt return anything
- PhysicalDML node's property computing methods were changed to return all modified columns (except CTAS case where behaviour was unchanged), currently it outputs only changed columns
- Another ProjList was added to generated plan in dml node which shows columns that dml node can return to parent node
- Table descriptor in dml node of generated plan was tightened to only include used columns, this was caused by MakeDXLTableDescr function, which was used to include in descriptor columns with the same ColIds as in output columns array
- nodeDML in executor was changed to return modified tuples and set returning projections, similarly to ModifyTable node
- also several edge cases (e.g. dml nodes for CTAS, triggers (which as i understood aren't supported in GPDB but are supported in ORCA), several minor optimizations for empty returning etc) were handled

test samples in gporca were updated, most of edits include: 
- clearing OutputColumns field in Query for dml queries as said above,
- adding ProjList in dml node in plan,
- updating values for colIds and costs (Im not quite sure that it is valid, maybe shuffling plan nodes changed id generator behaviour)

Changes are quite massive but i think it is the most effective way of adding RETURNING support to ORCA