### PR TITLE
Enable target repo secrets for pull-requests

### DIFF
--- a/.github/workflows/greengage-abi-tests.yml
+++ b/.github/workflows/greengage-abi-tests.yml
@@ -2,7 +2,7 @@ name: Greengage ABI Tests
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     paths:
       - 'concourse/scripts/**'
       - 'src/**'

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -7,7 +7,7 @@ env:
 on:
   push:
     tags: ['6.*']   # Trigger on tags for versioned releases
-  pull_request:
+  pull_request_target:
     branches: ['*'] # Trigger on pull requests for all branches
 
 jobs:


### PR DESCRIPTION
ATTENTION!

- Allows external users access to GitHub Actions secrets during workflow execution.
- Uses `pull_request_target` to run workflow in the target repo context.
- Requires mandatory approval for all PRs from external repos for security.
- Approval requirement for all external PRs already enabled for target repo.