### PR TITLE
ADBDEV-7842: Fix gp_default_storage_options affecting reorganize for heap tables

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14786,6 +14786,16 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 			*/
 			cs->options = build_ao_rel_storage_opts(cs->options, rel);
 		}
+		if (!isTmpTableAo)
+		{
+			/*
+			 * Same but for heap tables, we have to manually specify
+			 * appendonly=false to avoid being affected by
+			 * gp_default_storage_options.
+			 */
+			if (!reloptions_has_opt(cs->options, "appendonly"))
+				cs->options = lappend(cs->options, makeDefElem("appendonly", (Node *) makeString(pstrdup("false"))));
+		}
 
 		if (RelationIsAoCols(rel) && useExistingColumnAttributes)
 			col_encs = RelationGetUntransformedAttributeOptions(rel);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14773,7 +14773,17 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 
 		cs->options = opts;
 
-		if (RelationIsAoRows(rel))
+		if (!isTmpTableAo)
+		{
+			/*
+			 * Same but for heap tables, we have to manually specify
+			 * appendonly=false to avoid being affected by
+			 * gp_default_storage_options.
+			 */
+			if (!reloptions_has_opt(cs->options, "appendonly"))
+				cs->options = lappend(cs->options, makeDefElem("appendonly", (Node *) makeString("false")));
+		}
+		else if (RelationIsAoRows(rel))
 		{
 			/*
 			* In order to avoid being affected by the GUC of gp_default_storage_options,
@@ -14785,16 +14795,6 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 			* inconsistent with the original table.
 			*/
 			cs->options = build_ao_rel_storage_opts(cs->options, rel);
-		}
-		if (!isTmpTableAo)
-		{
-			/*
-			 * Same but for heap tables, we have to manually specify
-			 * appendonly=false to avoid being affected by
-			 * gp_default_storage_options.
-			 */
-			if (!reloptions_has_opt(cs->options, "appendonly"))
-				cs->options = lappend(cs->options, makeDefElem("appendonly", (Node *) makeString("false")));
 		}
 
 		if (RelationIsAoCols(rel) && useExistingColumnAttributes)

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14776,9 +14776,9 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 		if (!isTmpTableAo)
 		{
 			/*
-			 * Same but for heap tables, we have to manually specify
-			 * appendonly=false to avoid being affected by
-			 * gp_default_storage_options.
+			 * In order to avoid being affected by gp_default_storage_options,
+			 * we have to manually specify appendonly=false. This prevents
+			 * accidentally changing the access method to AO.
 			 */
 			if (!reloptions_has_opt(cs->options, "appendonly"))
 				cs->options = lappend(cs->options, makeDefElem("appendonly", (Node *) makeString("false")));

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14772,8 +14772,8 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 		{
 			/*
 			 * In order to avoid being affected by gp_default_storage_options,
-			 * we have to manually specify appendonly=false. This prevents
-			 * accidentally changing the access method to AO.
+			 * we have to specify appendonly=false. This prevents accidentally
+			 * changing the access method to AO.
 			 */
 			if (!reloptions_has_opt(cs->options, "appendonly"))
 			{

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14781,7 +14781,11 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 			 * accidentally changing the access method to AO.
 			 */
 			if (!reloptions_has_opt(cs->options, "appendonly"))
-				cs->options = lappend(cs->options, makeDefElem("appendonly", (Node *) makeString("false")));
+			{
+				DefElem *elem = makeDefElem("appendonly",
+											(Node *) makeString("false"));
+				cs->options = lappend(cs->options, elem);
+			}
 		}
 		else if (RelationIsAoRows(rel))
 		{

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14794,7 +14794,7 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 			 * gp_default_storage_options.
 			 */
 			if (!reloptions_has_opt(cs->options, "appendonly"))
-				cs->options = lappend(cs->options, makeDefElem("appendonly", (Node *) makeString(pstrdup("false"))));
+				cs->options = lappend(cs->options, makeDefElem("appendonly", (Node *) makeString("false")));
 		}
 
 		if (RelationIsAoCols(rel) && useExistingColumnAttributes)

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -505,8 +505,7 @@ static void ATExecPartAddInternal(Relation rel, Node *def);
 
 static RangeVar *make_temp_table_name(Relation rel, BackendId id);
 static bool prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro,
-								List *opts, bool isTmpTableAo,
-								bool useExistingColumnAttributes);
+								List *opts, bool useExistingColumnAttributes);
 static void ATPartitionCheck(AlterTableType subtype, Relation rel, bool rejectroot, bool recursing);
 static void ATExternalPartitionCheck(AlterTableType subtype, Relation rel, bool recursing);
 
@@ -14567,7 +14566,6 @@ build_ctas_with_dist(Relation rel, DistributedBy *dist_clause,
 
 	pre_built = prebuild_temp_table(rel, tmprel, dist_clause,
 									storage_opts,
-									RelationIsAppendOptimized(rel),
 									useExistingColumnAttributes);
 	if (pre_built)
 	{
@@ -14710,13 +14708,10 @@ make_temp_table_name(Relation rel, BackendId id)
  * If we need to do it, but fail, issue an error. (See make_type.)
  *
  * Specifically for build_ctas_with_dist.
- *
- * Note that the caller should guarantee that isTmpTableAo has
- * a value that matches 'opts'.
  */
 static bool
 prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List *opts,
-					bool isTmpTableAo, bool useExistingColumnAttributes)
+					bool useExistingColumnAttributes)
 {
 	bool need_rebuild = false;
 	int attno = 0;
@@ -14749,7 +14744,7 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 	 * important to create the block directory to support the reindex
 	 * later. See MPP-9545 for more info.
 	 */
-	if (isTmpTableAo &&
+	if (RelationIsAppendOptimized(rel) &&
 		rel->rd_rel->relhasindex)
 		need_rebuild = true;
 
@@ -14767,13 +14762,13 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 		cs->tablespacename = get_tablespace_name(rel->rd_rel->reltablespace);
 		cs->buildAoBlkdir = false;
 
-		if (isTmpTableAo &&
+		if (RelationIsAppendOptimized(rel) &&
 			rel->rd_rel->relhasindex)
 			cs->buildAoBlkdir = true;
 
 		cs->options = opts;
 
-		if (!isTmpTableAo)
+		if (!RelationIsAppendOptimized(rel))
 		{
 			/*
 			 * In order to avoid being affected by gp_default_storage_options,

--- a/src/test/regress/expected/alter_table_set.out
+++ b/src/test/regress/expected/alter_table_set.out
@@ -52,3 +52,113 @@ select count(*) > 0 as has_different_distribution from
  t
 (1 row)
 
+-- ALTER TABLE SET also shouldn't change table access method because of
+-- changes in gp_default_storage_options.
+-- Heap -> AOCO
+create table tb_heap(id int, s1 text, s2 text);
+insert into tb_heap select v, v::text, v::text FROM generate_series(1, 100) v;
+alter table tb_heap drop column s1;
+set gp_default_storage_options = 'appendonly=true, orientation=column';
+alter table tb_heap set with (reorganize = true);
+select max(id) from tb_heap;
+ max 
+-----
+ 100
+(1 row)
+
+select relstorage from pg_class where relname = 'tb_heap';
+ relstorage 
+------------
+ h
+(1 row)
+
+-- Heap -> AO
+alter table tb_heap drop column s2;
+set gp_default_storage_options = 'appendonly=true, orientation=row';
+alter table tb_heap set with (reorganize = true);
+select max(id) from tb_heap;
+ max 
+-----
+ 100
+(1 row)
+
+select relstorage from pg_class where relname = 'tb_heap';
+ relstorage 
+------------
+ h
+(1 row)
+
+-- AOCO -> Heap
+set gp_default_storage_options = 'appendonly=true, orientation=column';
+create table tb_aoco(id int, s1 text, s2 text);
+insert into tb_aoco select v, v::text, v::text FROM generate_series(1, 100) v;
+alter table tb_aoco drop column s1;
+set gp_default_storage_options = 'appendonly=false';
+alter table tb_aoco set with (reorganize = true);
+select max(id) from tb_aoco;
+ max 
+-----
+ 100
+(1 row)
+
+select relstorage from pg_class where relname = 'tb_aoco';
+ relstorage 
+------------
+ c
+(1 row)
+
+-- AOCO -> AO
+alter table tb_aoco drop column s2;
+set gp_default_storage_options = 'appendonly=true, orientation=row';
+alter table tb_aoco set with (reorganize = true);
+select max(id) from tb_aoco;
+ max 
+-----
+ 100
+(1 row)
+
+select relstorage from pg_class where relname = 'tb_aoco';
+ relstorage 
+------------
+ c
+(1 row)
+
+-- AO -> Heap
+set gp_default_storage_options = 'appendonly=true, orientation=row';
+create table tb_ao(id int, s1 text, s2 text);
+insert into tb_ao select v, v::text, v::text FROM generate_series(1, 100) v;
+alter table tb_ao drop column s1;
+set gp_default_storage_options = 'appendonly=false';
+alter table tb_ao set with (reorganize = true);
+select max(id) from tb_ao;
+ max 
+-----
+ 100
+(1 row)
+
+select relstorage from pg_class where relname = 'tb_ao';
+ relstorage 
+------------
+ a
+(1 row)
+
+-- AO -> AOCO
+alter table tb_ao drop column s2;
+set gp_default_storage_options = 'appendonly=true, orientation=column';
+alter table tb_ao set with (reorganize = true);
+select max(id) from tb_ao;
+ max 
+-----
+ 100
+(1 row)
+
+select relstorage from pg_class where relname = 'tb_ao';
+ relstorage 
+------------
+ a
+(1 row)
+
+-- Cleanup
+drop table tb_heap;
+drop table tb_aoco;
+drop table tb_ao;

--- a/src/test/regress/expected/alter_table_set.out
+++ b/src/test/regress/expected/alter_table_set.out
@@ -159,6 +159,4 @@ select relstorage from pg_class where relname = 'tb_ao';
 (1 row)
 
 -- Cleanup
-drop table tb_heap;
-drop table tb_aoco;
-drop table tb_ao;
+drop table tb_heap, tb_aoco, tb_ao;

--- a/src/test/regress/sql/alter_table_set.sql
+++ b/src/test/regress/sql/alter_table_set.sql
@@ -37,3 +37,70 @@ select count(*) > 0 as has_different_distribution from
 select count(*) > 0 as has_different_distribution from
 (select gp_segment_id, * from ats_dist_by_d except
 	select gp_segment_id, * from ats_expected_by_d) t;
+
+-- ALTER TABLE SET also shouldn't change table access method because of
+-- changes in gp_default_storage_options.
+
+-- Heap -> AOCO
+create table tb_heap(id int, s1 text, s2 text);
+insert into tb_heap select v, v::text, v::text FROM generate_series(1, 100) v;
+
+alter table tb_heap drop column s1;
+set gp_default_storage_options = 'appendonly=true, orientation=column';
+alter table tb_heap set with (reorganize = true);
+
+select max(id) from tb_heap;
+select relstorage from pg_class where relname = 'tb_heap';
+
+-- Heap -> AO
+alter table tb_heap drop column s2;
+set gp_default_storage_options = 'appendonly=true, orientation=row';
+alter table tb_heap set with (reorganize = true);
+
+select max(id) from tb_heap;
+select relstorage from pg_class where relname = 'tb_heap';
+
+-- AOCO -> Heap
+set gp_default_storage_options = 'appendonly=true, orientation=column';
+create table tb_aoco(id int, s1 text, s2 text);
+insert into tb_aoco select v, v::text, v::text FROM generate_series(1, 100) v;
+
+alter table tb_aoco drop column s1;
+set gp_default_storage_options = 'appendonly=false';
+alter table tb_aoco set with (reorganize = true);
+
+select max(id) from tb_aoco;
+select relstorage from pg_class where relname = 'tb_aoco';
+
+-- AOCO -> AO
+alter table tb_aoco drop column s2;
+set gp_default_storage_options = 'appendonly=true, orientation=row';
+alter table tb_aoco set with (reorganize = true);
+
+select max(id) from tb_aoco;
+select relstorage from pg_class where relname = 'tb_aoco';
+
+-- AO -> Heap
+set gp_default_storage_options = 'appendonly=true, orientation=row';
+create table tb_ao(id int, s1 text, s2 text);
+insert into tb_ao select v, v::text, v::text FROM generate_series(1, 100) v;
+
+alter table tb_ao drop column s1;
+set gp_default_storage_options = 'appendonly=false';
+alter table tb_ao set with (reorganize = true);
+
+select max(id) from tb_ao;
+select relstorage from pg_class where relname = 'tb_ao';
+
+-- AO -> AOCO
+alter table tb_ao drop column s2;
+set gp_default_storage_options = 'appendonly=true, orientation=column';
+alter table tb_ao set with (reorganize = true);
+
+select max(id) from tb_ao;
+select relstorage from pg_class where relname = 'tb_ao';
+
+-- Cleanup
+drop table tb_heap;
+drop table tb_aoco;
+drop table tb_ao;

--- a/src/test/regress/sql/alter_table_set.sql
+++ b/src/test/regress/sql/alter_table_set.sql
@@ -101,6 +101,4 @@ select max(id) from tb_ao;
 select relstorage from pg_class where relname = 'tb_ao';
 
 -- Cleanup
-drop table tb_heap;
-drop table tb_aoco;
-drop table tb_ao;
+drop table tb_heap, tb_aoco, tb_ao;


### PR DESCRIPTION
Fix gp_default_storage_options affecting reorganize for heap tables

If appendonly option is not present in ALTER TABLE ... SET WITH (reorganize =
true), its default value was taken from gp_default_storage_options. If
gp_default_storage_options contains appendonly=true, and the original table
was heap, ALTER TABLE might change the table access method under some
conditions (for example if a column was previously deleted). However,
auxiliary tables weren't created properly, so the newly created table became
unreadable.

Add appendonly=false to options if the original table is heap to prevent
unexpected access method change.

Add tests for various combinations of access method and
gp_default_storage_options to ensure reorganize never changes the access
method.