### PR TITLE
Remove orphaned PG_VERSIONSTR macro

### DIFF
--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -78,9 +78,6 @@
 /* Ideally this would be in a .h file, but it hardly seems worth the trouble */
 extern const char *select_default_timezone(const char *share_path);
 
-/* version string we expect back from postgres */
-#define PG_VERSIONSTR "postgres (Greengage Database) " PG_VERSION "\n"
-
 
 static const char *auth_methods_host[] = {
 	"trust", "reject", "scram-sha-256", "md5", "password", "ident", "radius",

--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -50,10 +50,6 @@
 typedef long pgpid_t;
 
 
-/* postgres version ident string */
-#define PM_VERSIONSTR "postgres (Greengage Database) " PG_VERSION "\n"
-
-
 typedef enum
 {
 	SMART_MODE,

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -28,7 +28,6 @@
 #include "pgtime.h"				/* for pg_time_t */
 
 
-#define PG_VERSIONSTR "postgres (Greengage Database) " PG_VERSION "\n"
 #define PG_BACKEND_VERSIONSTR "postgres (Greengage Database) " PG_VERSION "\n"
 
 #define InvalidPid				(-1)


### PR DESCRIPTION
This macro was renamed to PG_BACKEND_VERSIONSTR in 870993e 17th ears ago. 
Greengage still contains it due improperly resolved merge commit.

