### PR TITLE
Replace shortcut behave flags with the full one

### DIFF
--- a/gpMgmt/Makefile.behave
+++ b/gpMgmt/Makefile.behave
@@ -7,9 +7,9 @@ behave:
 	@which behave || (echo "behave not found" && exit 1)
 	@echo "Running behave on management scripts..."
 	@if [ -n """$(flags)""" ]; then \
-		PYTHONPATH=$$PYTHONPATH:$(PEXPECT_LIB):$(TEST_DIR) behave $(CURDIR)/test/behave/* -s -k $(flags) 2>&1 ; \
+		PYTHONPATH=$$PYTHONPATH:$(PEXPECT_LIB):$(TEST_DIR) behave $(CURDIR)/test/behave/* --no-source --no-skipped $(flags) 2>&1 ; \
 	elif [ -n """$(tags)""" ]; then \
-		PYTHONPATH=$$PYTHONPATH:$(PEXPECT_LIB):$(TEST_DIR) behave $(CURDIR)/test/behave/* -s -k --tags=$(tags) 2>&1 ; \
+		PYTHONPATH=$$PYTHONPATH:$(PEXPECT_LIB):$(TEST_DIR) behave $(CURDIR)/test/behave/* --no-source --no-skipped --tags=$(tags) 2>&1 ; \
 	else \
 		echo "Please specify tags=tagname or flags=[behave flags]"; \
 		exit 1; \


### PR DESCRIPTION
Shortcut flags were removed in behave 1.2.7

https://github.com/behave/behave/blob/main/CHANGES.rst#version-127-part-of-130