### PR TITLE
Fix behave version to 1.2.6

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -31,7 +31,7 @@ RUN yum makecache && \
     # repository can no longer update itself.
     curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python && \
     pip install psi pytest==3.10.1 && \
-    pip install allure-behave==2.4.0 && \
+    pip install behave==1.2.6 allure-behave==2.4.0 && \
     yum clean all
 
 # setup ssh configuration

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -20,7 +20,7 @@ RUN set -eux; \
         apt install -y krb5-kdc krb5-admin-server fakeroot sudo python-pip \
             openjdk-11-jdk protobuf-compiler python3-dev; \
 # Install allure-behave for behave tests
-    pip2 install allure-behave==2.4.0; \
+    pip2 install behave==1.2.6 allure-behave==2.4.0; \
     pip2 cache purge;
 
 WORKDIR /home/gpadmin


### PR DESCRIPTION
Downgrade behave version to 1.2.6 (#36)

The later versions have compatibility issue with existing test
infrastructure. At least, there are issues with removing shortcut versions of
flags `--no-source`, `--no-skipped` and passing arguments to scripts from
sceneries. E.g. Greengage specific script pid_background_script.py get test
working dir instead of temporary file.