### PR TITLE
ADBDEV-7975: Make VACUUM fix inconsistency in AO segment stats between QD/QE

### DIFF
--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -1296,7 +1296,7 @@ gp_aoseg_history(PG_FUNCTION_ARGS)
 	SRF_RETURN_DONE(funcctx);
 }
 
-static int64
+int64
 gp_update_aorow_master_stats_internal(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot)
 {
 	StringInfoData sqlstmt;

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -825,6 +825,38 @@ vacuumStatement_Relation(VacuumStmt *vacstmt, Oid relid,
 		List	   *compactedSegmentFileList = NIL;
 		List	   *insertedSegmentFileList = NIL;
 
+		/*
+		 * We have to synchronize master and segment AO statistics
+		 * in case they have been broken.
+		 */
+		if (Gp_role == GP_ROLE_DISPATCH)
+		{
+			Snapshot appendOnlyMetaDataSnapshot = RegisterSnapshot(GetLatestSnapshot());
+			if (RelationIsAoRows(onerel))
+				gp_update_aorow_master_stats_internal(onerel, appendOnlyMetaDataSnapshot);
+			else
+			{
+				Assert(RelationIsAoCols(onerel));
+				gp_update_aocol_master_stats_internal(onerel, appendOnlyMetaDataSnapshot);
+			}
+			UnregisterSnapshot(appendOnlyMetaDataSnapshot);
+
+			relation_close(onerel, lmode);
+
+			/* Statistics will only be updated after the transaction is commited */
+			PopActiveSnapshot();
+			CommitTransactionCommand();
+			StartTransactionCommand();
+			PushActiveSnapshot(GetTransactionSnapshot());
+
+			/* Remove the AO hash table entry to make sure it will be updated too */
+			LWLockAcquire(AOSegFileLock, LW_EXCLUSIVE);
+			AORelRemoveHashEntry(relid);
+			LWLockRelease(AOSegFileLock);
+
+			onerel = try_relation_open(relid, lmode, false /* dontwait */);
+		}
+
 		vacstmt->appendonly_compaction_segno = NIL;
 		vacstmt->appendonly_compaction_insert_segno = NIL;
 		vacstmt->appendonly_relation_empty = false;

--- a/src/include/access/aosegfiles.h
+++ b/src/include/access/aosegfiles.h
@@ -170,6 +170,7 @@ extern int64 GetAOTotalBytes(Relation parentrel, Snapshot appendOnlyMetaDataSnap
 extern void FreeAllSegFileInfo(FileSegInfo **allSegInfo,
 				   int totalSegFiles);
 
+extern int64 gp_update_aorow_master_stats_internal(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot);
 extern Datum gp_update_ao_master_stats(PG_FUNCTION_ARGS);
 extern Datum get_ao_distribution(PG_FUNCTION_ARGS);
 extern Datum get_ao_compression_ratio(PG_FUNCTION_ARGS);

--- a/src/test/isolation2/input/uao/vacuum_aoseg_repair.source
+++ b/src/test/isolation2/input/uao/vacuum_aoseg_repair.source
@@ -1,0 +1,53 @@
+-- @Description Ensures that aoseg statistics are correctly repaired if
+-- there is an inconsistency between master and segments.
+--
+CREATE TABLE vacuum_aoseg_repair_@orientation@ (a INT, b INT) WITH (appendonly=true, orientation=@orientation@);
+1: BEGIN;
+2: BEGIN;
+3: BEGIN;
+1: INSERT INTO vacuum_aoseg_repair_@orientation@ SELECT i as a, i as b FROM generate_series(1, 10000) AS i;
+2: INSERT INTO vacuum_aoseg_repair_@orientation@ SELECT i as a, i as b FROM generate_series(1, 10000) AS i;
+3: INSERT INTO vacuum_aoseg_repair_@orientation@ SELECT i as a, i as b FROM generate_series(1, 10000) AS i;
+1: COMMIT;
+2: COMMIT;
+3: COMMIT;
+DELETE FROM vacuum_aoseg_repair_@orientation@ WHERE a <= 9000;
+
+-- Corrupt statistics on master
+4: BEGIN;
+4: SELECT segno, tupcount, state FROM gp_ao_or_aocs_seg('vacuum_aoseg_repair_@orientation@'::regclass);
+
+-- We have to use dynamic SQL because we don't know table's OID in advance
+4: CREATE FUNCTION pg_temp.tmpfunc() returns void as $$
+declare
+	table_oid oid;	/* in func */
+  relstorage_var char;	/* in func */
+  aoseg_name text;	/* in func */
+begin
+  select 'vacuum_aoseg_repair_@orientation@'::regclass::oid into table_oid;	/* in func */
+  select relstorage into relstorage_var from pg_class where oid = table_oid;	/* in func */
+  if relstorage_var = 'c' then
+    select 'pg_aoseg.pg_aocsseg_' || table_oid into aoseg_name;	/* in func */
+  else
+    select 'pg_aoseg.pg_aoseg_' || table_oid into aoseg_name;	/* in func */
+  end if;	/* in func */
+
+  set local allow_system_table_mods = on;	/* in func */
+  execute 'UPDATE ' || aoseg_name || ' SET tupcount = 0 WHERE segno = 3';	/* in func */
+	set local allow_system_table_mods = off;	/* in func */
+end;	/* in func */
+$$ language plpgsql;
+4: SELECT pg_temp.tmpfunc();
+
+4: SELECT segno, tupcount, state FROM gp_ao_or_aocs_seg('vacuum_aoseg_repair_@orientation@'::regclass);
+4: COMMIT;
+
+-- Make sure hash table is updated with corrupted statistics
+SELECT gp_toolkit.__gp_remove_ao_entry_from_cache('vacuum_aoseg_repair_@orientation@'::regclass);
+
+-- This VACUUM should fix it
+VACUUM vacuum_aoseg_repair_@orientation@;
+
+-- Check statistics
+SELECT segno, tupcount, state FROM gp_ao_or_aocs_seg('vacuum_aoseg_repair_@orientation@'::regclass);
+SELECT segno, total_tupcount, state FROM gp_toolkit.__gp_get_ao_entry_from_cache('vacuum_aoseg_repair_@orientation@'::regclass) WHERE total_tupcount > 0 ORDER BY segno;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -169,6 +169,7 @@ test: uao/vacuum_while_insert_row
 test: uao/vacuum_while_vacuum_row
 test: uao/vacuum_cleanup_row
 test: uao/vacuum_index_stats_row
+test: uao/vacuum_aoseg_repair_row
 test: uao/insert_should_not_use_awaiting_drop_row
 test: uao/bitmapindex_rescan_row
 test: uao/create_index_allows_readonly_row
@@ -230,6 +231,7 @@ test: uao/vacuum_while_insert_column
 test: uao/vacuum_while_vacuum_column
 test: uao/vacuum_cleanup_column
 test: uao/vacuum_index_stats_column
+test: uao/vacuum_aoseg_repair_column
 test: uao/insert_should_not_use_awaiting_drop_column
 test: uao/bitmapindex_rescan_column
 test: uao/create_index_allows_readonly_column

--- a/src/test/isolation2/output/uao/vacuum_aoseg_repair.source
+++ b/src/test/isolation2/output/uao/vacuum_aoseg_repair.source
@@ -1,0 +1,86 @@
+-- @Description Ensures that aoseg statistics are correctly repaired if
+-- there is an inconsistency between master and segments.
+--
+CREATE TABLE vacuum_aoseg_repair_@orientation@ (a INT, b INT) WITH (appendonly=true, orientation=@orientation@);
+CREATE
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+3: BEGIN;
+BEGIN
+1: INSERT INTO vacuum_aoseg_repair_@orientation@ SELECT i as a, i as b FROM generate_series(1, 10000) AS i;
+INSERT 10000
+2: INSERT INTO vacuum_aoseg_repair_@orientation@ SELECT i as a, i as b FROM generate_series(1, 10000) AS i;
+INSERT 10000
+3: INSERT INTO vacuum_aoseg_repair_@orientation@ SELECT i as a, i as b FROM generate_series(1, 10000) AS i;
+INSERT 10000
+1: COMMIT;
+COMMIT
+2: COMMIT;
+COMMIT
+3: COMMIT;
+COMMIT
+DELETE FROM vacuum_aoseg_repair_@orientation@ WHERE a <= 9000;
+DELETE 27000
+
+-- Corrupt statistics on master
+4: BEGIN;
+BEGIN
+4: SELECT segno, tupcount, state FROM gp_ao_or_aocs_seg('vacuum_aoseg_repair_@orientation@'::regclass);
+ segno | tupcount | state 
+-------+----------+-------
+ 1     | 10000    | 1     
+ 2     | 10000    | 1     
+ 3     | 10000    | 1     
+(3 rows)
+
+-- We have to use dynamic SQL because we don't know table's OID in advance
+4: CREATE FUNCTION pg_temp.tmpfunc() returns void as $$ declare table_oid oid;	/* in func */ relstorage_var char;	/* in func */ aoseg_name text;	/* in func */ begin select 'vacuum_aoseg_repair_@orientation@'::regclass::oid into table_oid;	/* in func */ select relstorage into relstorage_var from pg_class where oid = table_oid;	/* in func */ if relstorage_var = 'c' then select 'pg_aoseg.pg_aocsseg_' || table_oid into aoseg_name;	/* in func */ else select 'pg_aoseg.pg_aoseg_' || table_oid into aoseg_name;	/* in func */ end if;	/* in func */ 
+set local allow_system_table_mods = on;	/* in func */ execute 'UPDATE ' || aoseg_name || ' SET tupcount = 0 WHERE segno = 3';	/* in func */ set local allow_system_table_mods = off;	/* in func */ end;	/* in func */ $$ language plpgsql;
+CREATE
+4: SELECT pg_temp.tmpfunc();
+ tmpfunc 
+---------
+         
+(1 row)
+
+4: SELECT segno, tupcount, state FROM gp_ao_or_aocs_seg('vacuum_aoseg_repair_@orientation@'::regclass);
+ segno | tupcount | state 
+-------+----------+-------
+ 1     | 10000    | 1     
+ 2     | 10000    | 1     
+ 3     | 0        | 1     
+(3 rows)
+4: COMMIT;
+COMMIT
+
+-- Make sure hash table is updated with corrupted statistics
+SELECT gp_toolkit.__gp_remove_ao_entry_from_cache('vacuum_aoseg_repair_@orientation@'::regclass);
+ __gp_remove_ao_entry_from_cache 
+---------------------------------
+                                 
+(1 row)
+
+-- This VACUUM should fix it
+VACUUM vacuum_aoseg_repair_@orientation@;
+VACUUM
+
+-- Check statistics
+SELECT segno, tupcount, state FROM gp_ao_or_aocs_seg('vacuum_aoseg_repair_@orientation@'::regclass);
+ segno | tupcount | state 
+-------+----------+-------
+ 1     | 0        | 1     
+ 2     | 0        | 1     
+ 3     | 0        | 1     
+ 4     | 1000     | 1     
+ 5     | 1000     | 1     
+ 6     | 1000     | 1     
+(6 rows)
+SELECT segno, total_tupcount, state FROM gp_toolkit.__gp_get_ao_entry_from_cache('vacuum_aoseg_repair_@orientation@'::regclass) WHERE total_tupcount > 0 ORDER BY segno;
+ segno | total_tupcount | state 
+-------+----------------+-------
+ 4     | 1000           | 1     
+ 5     | 1000           | 1     
+ 6     | 1000           | 1     
+(3 rows)


### PR DESCRIPTION
Make VACUUM fix inconsistency in AO segment stats between QD/QE

Under some circumstances involving a crash during a VACUUM, AO segment
statistics might have a mismatch between QD and QEs. Performing VACUUM after
this did not repair the statistics. There is a function called
gp_update_ao_master_stats which is able to repair them, but it would be better
if VACUUM is able to do it automatically. To do so, add a call to
gp_update_ao_master_stats before vacuuming AO tables.

Performance considerations:
Internally, gp_update_ao_master_stats performs one SQL query through SPI to
retrieve the statistics from QEs. It then updates only those statistics that
have a mismatch. Therefore, the performance impact of adding
gp_update_ao_master_stats is equivalent to that single SQL query. However, we
already unconditionally perform a similar query for 0th segment inside
SetSegnoForCompaction, so the performance impact of it is not big.