### PR TITLE
Add extra tuple length checks

### DIFF
--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -2878,7 +2878,6 @@ writetup_heap(Tuplesortstate_mk *state, LogicalTape *lt, MKEntry *e)
 	uint32		tuplen = memtuple_get_size(e->ptr);
 	long		ret = tuplen;
 
-	Assert(tuplen > sizeof(uint32));
 	if (tuplen <= sizeof(uint32))
 	{
 		const char *sortMethod = "";


### PR DESCRIPTION
We faced an issue when tuple length read from logical tape happened to be 1 followed by a SIGSEGV. It's not possible to trace down root cause for it, so adding more sanity checks for tuple length value. It should replace SIGSEGV with an error without the need to restart the executor.

Asserts are not enough in this case as the issue happened with a release build. This enhances existing checks in `readtup_heap()` and `writetup_heap()` and should not have measurable impact.