### PR TITLE
Add extra tuple length checks

### DIFF
--- a/src/backend/utils/sort/test/Makefile
+++ b/src/backend/utils/sort/test/Makefile
@@ -2,6 +2,6 @@ subdir=src/backend/utils/sort
 top_builddir=../../../../..
 include $(top_builddir)/src/Makefile.global
 
-TARGETS=string_wrapper
+TARGETS=string_wrapper tuplesort_mk
 
 include $(top_builddir)/src/backend/mock.mk

--- a/src/backend/utils/sort/test/tuplesort_mk_test.c
+++ b/src/backend/utils/sort/test/tuplesort_mk_test.c
@@ -48,15 +48,18 @@ test_tuplesort_mk_readtup_heap_fail_len(void **test_state)
 		.tapeRange = 468
 	};
 
-	const char *expected_message = "invalid tuple len 0. Sort method: external sort, space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, memAllowed=68719476736, maxTapes=42, tapeRange=468";
+	const char *expected_message = 
+		"invalid tuple len 0. Sort method: external sort, space type: Disk, "
+		"space used: 1376256, sort nkeys=42, randomAccess=0, "
+		"memAllowed=68719476736, maxTapes=42, tapeRange=468";
 	char	   *message = NULL;
 	bool		error_thrown = false;
 
 	/* Check zero length */
 	PG_TRY();
 	{
-		readtup_heap(&state, 0 /* pos */ , NULL /* stup */ , NULL /* tape */ , 0		/* len, too small and no
-					   * flag */ );
+		readtup_heap(&state, 0 /* pos */ , NULL /* stup */ , 
+			NULL /* tape */ , 0		/* len, too small and no flag */ );
 	}
 	PG_CATCH();
 	{
@@ -76,7 +79,10 @@ test_tuplesort_mk_readtup_heap_fail_len(void **test_state)
 	}
 	assert_true(error_thrown);
 
-	expected_message = "invalid tuple len 2147483652. Sort method: external sort, space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, memAllowed=68719476736, maxTapes=42, tapeRange=468";
+	expected_message = 
+		"invalid tuple len 2147483652. Sort method: external sort, "
+		"space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, "
+		"memAllowed=68719476736, maxTapes=42, tapeRange=468";
 	message = NULL;
 	error_thrown = false;
 	state.sortcontext = CurrentMemoryContext;
@@ -84,8 +90,8 @@ test_tuplesort_mk_readtup_heap_fail_len(void **test_state)
 	/* Check uint32 length */
 	PG_TRY();
 	{
-		readtup_heap(&state, 0 /* pos */ , NULL /* stup */ , NULL /* tape */ , sizeof(uint32) | MEMTUP_LEAD_BIT /* len, too small but
-					   * with flag */ );
+		readtup_heap(&state, 0 /* pos */ , NULL /* stup */ , NULL /* tape */ , 
+			sizeof(uint32) | MEMTUP_LEAD_BIT /* len, too small but with flag */);
 	}
 	PG_CATCH();
 	{
@@ -112,7 +118,7 @@ test_tuplesort_mk_writetup_heap_fail_len(void **test_state)
 {
 	gp_debug_linger = 0;
 
-	elog(LOG, "Running test: readtup_heap_fail_len");
+	elog(LOG, "Running test: writetup_heap_fail_len");
 
 	struct LogicalTapeSet lts = {.nFileBlocks = 42 * 1024};
 
@@ -127,7 +133,10 @@ test_tuplesort_mk_writetup_heap_fail_len(void **test_state)
 		.tapeRange = 468
 	};
 
-	const char *expected_message = "invalid tuple len 0. Sort method: external sort, space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, memAllowed=68719476736, maxTapes=42, tapeRange=468";
+	const char *expected_message = 
+		"invalid tuple len 0. Sort method: external sort, space type: Disk, "
+		"space used: 1376256, sort nkeys=42, randomAccess=0, "
+		"memAllowed=68719476736, maxTapes=42, tapeRange=468";
 	char	   *message = NULL;
 	bool		error_thrown = false;
 
@@ -163,7 +172,10 @@ test_tuplesort_mk_writetup_heap_fail_len(void **test_state)
 	assert_true(error_thrown);
 
 	mtup.PRIVATE_mt_len = MEMTUP_LEAD_BIT | sizeof(uint32);
-	expected_message = "invalid tuple len 0. Sort method: external sort, space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, memAllowed=68719476736, maxTapes=42, tapeRange=468";
+	expected_message = 
+		"invalid tuple len 0. Sort method: external sort, space type: Disk, "
+		"space used: 1376256, sort nkeys=42, randomAccess=0, "
+		"memAllowed=68719476736, maxTapes=42, tapeRange=468";
 	message = NULL;
 	error_thrown = false;
 	state.sortcontext = CurrentMemoryContext;

--- a/src/backend/utils/sort/test/tuplesort_mk_test.c
+++ b/src/backend/utils/sort/test/tuplesort_mk_test.c
@@ -17,7 +17,8 @@ struct LogicalTapeSet
 {
 	BufFile    *pfile;			/* underlying file for whole tape set */
 	long		nFileBlocks;	/* # of blocks used in underlying file */
-	bool 		forgetFreeSpace; /* if we need to keep track of free space */
+	bool		forgetFreeSpace;		/* if we need to keep track of free
+										 * space */
 	bool		blocksSorted;	/* is freeBlocks[] currently in order? */
 	long	   *freeBlocks;		/* resizable array */
 	long		nFreeBlocks;	/* # of currently free blocks */
@@ -30,72 +31,78 @@ struct LogicalTapeSet
 static void
 test_tuplesort_mk_readtup_heap_fail_len(void **test_state)
 {
-    gp_debug_linger = 0;
+	gp_debug_linger = 0;
 
-    elog(LOG, "Running test: readtup_heap_fail_len");
+	elog(LOG, "Running test: readtup_heap_fail_len");
 
-    struct LogicalTapeSet lts = {.nFileBlocks = 42 * 1024};
+	struct LogicalTapeSet lts = {.nFileBlocks = 42 * 1024};
 
-    Tuplesortstate_mk state = {
-        .sortcontext = CurrentMemoryContext,
-        .status = TSS_SORTEDONTAPE,
-        .tapeset = &lts,
-        .nKeys = 42,
-        .randomAccess = false,
-        .memAllowed = 64LL * 1024 * 1024 * 1024,
-        .maxTapes = 42,
-        .tapeRange = 468
-    };
+	Tuplesortstate_mk state = {
+		.sortcontext = CurrentMemoryContext,
+		.status = TSS_SORTEDONTAPE,
+		.tapeset = &lts,
+		.nKeys = 42,
+		.randomAccess = false,
+		.memAllowed = 64LL * 1024 * 1024 * 1024,
+		.maxTapes = 42,
+		.tapeRange = 468
+	};
 
-    const char *expected_message = "invalid tuple len 0. Sort method: external sort, space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, memAllowed=68719476736, maxTapes=42, tapeRange=468";
-    char* message = NULL;
-	bool error_thrown = false;
+	const char *expected_message = "invalid tuple len 0. Sort method: external sort, space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, memAllowed=68719476736, maxTapes=42, tapeRange=468";
+	char	   *message = NULL;
+	bool		error_thrown = false;
 
-    // Check zero length
+	/* Check zero length */
 	PG_TRY();
 	{
-		readtup_heap(&state, 0 /* pos */, NULL /* stup */, NULL /* tape */, 0 /* len, too small and no flag */);
+		readtup_heap(&state, 0 /* pos */ , NULL /* stup */ , NULL /* tape */ , 0		/* len, too small and no
+					   * flag */ );
 	}
 	PG_CATCH();
 	{
 		message = elog_message();
-                
-		if (message != NULL) {
+
+		if (message != NULL)
+		{
 			error_thrown = true;
 		}
 	}
 	PG_END_TRY();
 
-    assert_true(message != NULL);
-    if (message != NULL) {
-        assert_string_equal(message, expected_message);    
-    }
+	assert_true(message != NULL);
+	if (message != NULL)
+	{
+		assert_string_equal(message, expected_message);
+	}
 	assert_true(error_thrown);
 
-    expected_message = "invalid tuple len 2147483652. Sort method: external sort, space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, memAllowed=68719476736, maxTapes=42, tapeRange=468";
-    message = NULL;
+	expected_message = "invalid tuple len 2147483652. Sort method: external sort, space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, memAllowed=68719476736, maxTapes=42, tapeRange=468";
+	message = NULL;
 	error_thrown = false;
-    state.sortcontext = CurrentMemoryContext;
+	state.sortcontext = CurrentMemoryContext;
 
-    // Check uint32 length
+	/* Check uint32 length */
 	PG_TRY();
 	{
-		readtup_heap(&state, 0 /* pos */, NULL /* stup */, NULL /* tape */, sizeof(uint32) | MEMTUP_LEAD_BIT /* len, too small but with flag */);
+		readtup_heap(&state, 0 /* pos */ , NULL /* stup */ , NULL /* tape */ , sizeof(uint32) | MEMTUP_LEAD_BIT /* len, too small but
+					   * with flag */ );
 	}
 	PG_CATCH();
 	{
 		message = elog_message();
-                
-		if (message != NULL) {
+
+		if (message != NULL)
+		{
 			error_thrown = true;
 		}
 	}
 	PG_END_TRY();
 
-    assert_true(message != NULL);
-    if (message != NULL) {
-        assert_string_equal(message, expected_message);    
-    }
+	assert_true(message != NULL);
+	if (message != NULL)
+	{
+		assert_string_equal(message, expected_message);
+	}
 	assert_true(error_thrown);
 
 }
@@ -103,36 +110,36 @@ test_tuplesort_mk_readtup_heap_fail_len(void **test_state)
 static void
 test_tuplesort_mk_writetup_heap_fail_len(void **test_state)
 {
-    gp_debug_linger = 0;
+	gp_debug_linger = 0;
 
-    elog(LOG, "Running test: readtup_heap_fail_len");
+	elog(LOG, "Running test: readtup_heap_fail_len");
 
-    struct LogicalTapeSet lts = {.nFileBlocks = 42 * 1024};
+	struct LogicalTapeSet lts = {.nFileBlocks = 42 * 1024};
 
-    Tuplesortstate_mk state = {
-        .sortcontext = CurrentMemoryContext,
-        .status = TSS_SORTEDONTAPE,
-        .tapeset = &lts,
-        .nKeys = 42,
-        .randomAccess = false,
-        .memAllowed = 64LL * 1024 * 1024 * 1024,
-        .maxTapes = 42,
-        .tapeRange = 468
-    };
+	Tuplesortstate_mk state = {
+		.sortcontext = CurrentMemoryContext,
+		.status = TSS_SORTEDONTAPE,
+		.tapeset = &lts,
+		.nKeys = 42,
+		.randomAccess = false,
+		.memAllowed = 64LL * 1024 * 1024 * 1024,
+		.maxTapes = 42,
+		.tapeRange = 468
+	};
 
-    const char *expected_message = "invalid tuple len 0. Sort method: external sort, space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, memAllowed=68719476736, maxTapes=42, tapeRange=468";
-    char* message = NULL;
-	bool error_thrown = false;
+	const char *expected_message = "invalid tuple len 0. Sort method: external sort, space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, memAllowed=68719476736, maxTapes=42, tapeRange=468";
+	char	   *message = NULL;
+	bool		error_thrown = false;
 
-    MemTupleData mtup = {
-        .PRIVATE_mt_len = MEMTUP_LEAD_BIT | 0
-    };
-    
-    MKEntry entry = {
-        .ptr = &mtup
-    };
+	MemTupleData mtup = {
+		.PRIVATE_mt_len = MEMTUP_LEAD_BIT | 0
+	};
 
-    // Check zero length
+	MKEntry		entry = {
+		.ptr = &mtup
+	};
+
+	/* Check zero length */
 	PG_TRY();
 	{
 		writetup_heap(&state, 0, &entry);
@@ -140,26 +147,28 @@ test_tuplesort_mk_writetup_heap_fail_len(void **test_state)
 	PG_CATCH();
 	{
 		message = elog_message();
-                
-		if (message != NULL) {
+
+		if (message != NULL)
+		{
 			error_thrown = true;
 		}
 	}
 	PG_END_TRY();
 
-    assert_true(message != NULL);
-    if (message != NULL) {
-        assert_string_equal(message, expected_message);    
-    }
+	assert_true(message != NULL);
+	if (message != NULL)
+	{
+		assert_string_equal(message, expected_message);
+	}
 	assert_true(error_thrown);
 
-    mtup.PRIVATE_mt_len = MEMTUP_LEAD_BIT | sizeof(uint32);
-    expected_message = "invalid tuple len 0. Sort method: external sort, space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, memAllowed=68719476736, maxTapes=42, tapeRange=468";
-    message = NULL;
+	mtup.PRIVATE_mt_len = MEMTUP_LEAD_BIT | sizeof(uint32);
+	expected_message = "invalid tuple len 0. Sort method: external sort, space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, memAllowed=68719476736, maxTapes=42, tapeRange=468";
+	message = NULL;
 	error_thrown = false;
-    state.sortcontext = CurrentMemoryContext;
+	state.sortcontext = CurrentMemoryContext;
 
-    // Check uint32 length
+	/* Check uint32 length */
 	PG_TRY();
 	{
 		writetup_heap(&state, 0, &entry);
@@ -167,29 +176,31 @@ test_tuplesort_mk_writetup_heap_fail_len(void **test_state)
 	PG_CATCH();
 	{
 		message = elog_message();
-                
-		if (message != NULL) {
+
+		if (message != NULL)
+		{
 			error_thrown = true;
 		}
 	}
 	PG_END_TRY();
 
-    assert_true(message != NULL);
-    if (message != NULL) {
-        assert_string_equal(message, expected_message);    
-    }
+	assert_true(message != NULL);
+	if (message != NULL)
+	{
+		assert_string_equal(message, expected_message);
+	}
 	assert_true(error_thrown);
 }
 
 
 int
-main(int argc, char* argv[])
+main(int argc, char *argv[])
 {
 	cmockery_parse_arguments(argc, argv);
 
-	const UnitTest tests[] = {
+	const		UnitTest tests[] = {
 		unit_test(test_tuplesort_mk_readtup_heap_fail_len),
-        unit_test(test_tuplesort_mk_writetup_heap_fail_len)
+		unit_test(test_tuplesort_mk_writetup_heap_fail_len)
 	};
 
 	MemoryContextInit();

--- a/src/backend/utils/sort/test/tuplesort_mk_test.c
+++ b/src/backend/utils/sort/test/tuplesort_mk_test.c
@@ -110,7 +110,6 @@ test_tuplesort_mk_readtup_heap_fail_len(void **test_state)
 		assert_string_equal(message, expected_message);
 	}
 	assert_true(error_thrown);
-
 }
 
 static void
@@ -203,7 +202,6 @@ test_tuplesort_mk_writetup_heap_fail_len(void **test_state)
 	}
 	assert_true(error_thrown);
 }
-
 
 int
 main(int argc, char *argv[])

--- a/src/backend/utils/sort/test/tuplesort_mk_test.c
+++ b/src/backend/utils/sort/test/tuplesort_mk_test.c
@@ -1,0 +1,198 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+
+#include "cmockery.h"
+
+#include "postgres.h"
+#include "utils/elog.h"
+#include "utils/tuplesort.h"
+#include "utils/tuplesort_mk.h"
+
+#undef USE_ASSERT_CHECKING
+#include "../tuplesort_mk.c"
+
+
+struct LogicalTapeSet
+{
+	BufFile    *pfile;			/* underlying file for whole tape set */
+	long		nFileBlocks;	/* # of blocks used in underlying file */
+	bool 		forgetFreeSpace; /* if we need to keep track of free space */
+	bool		blocksSorted;	/* is freeBlocks[] currently in order? */
+	long	   *freeBlocks;		/* resizable array */
+	long		nFreeBlocks;	/* # of currently free blocks */
+	long		freeBlocksLen;	/* current allocated length of freeBlocks[] */
+
+	int			nTapes;			/* # of logical tapes in set */
+};
+
+
+static void
+test_tuplesort_mk_readtup_heap_fail_len(void **test_state)
+{
+    gp_debug_linger = 0;
+
+    elog(LOG, "Running test: readtup_heap_fail_len");
+
+    struct LogicalTapeSet lts = {.nFileBlocks = 42 * 1024};
+
+    Tuplesortstate_mk state = {
+        .sortcontext = CurrentMemoryContext,
+        .status = TSS_SORTEDONTAPE,
+        .tapeset = &lts,
+        .nKeys = 42,
+        .randomAccess = false,
+        .memAllowed = 64LL * 1024 * 1024 * 1024,
+        .maxTapes = 42,
+        .tapeRange = 468
+    };
+
+    const char *expected_message = "invalid tuple len 0. Sort method: external sort, space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, memAllowed=68719476736, maxTapes=42, tapeRange=468";
+    char* message = NULL;
+	bool error_thrown = false;
+
+    // Check zero length
+	PG_TRY();
+	{
+		readtup_heap(&state, 0 /* pos */, NULL /* stup */, NULL /* tape */, 0 /* len, too small and no flag */);
+	}
+	PG_CATCH();
+	{
+		message = elog_message();
+                
+		if (message != NULL) {
+			error_thrown = true;
+		}
+	}
+	PG_END_TRY();
+
+    assert_true(message != NULL);
+    if (message != NULL) {
+        assert_string_equal(message, expected_message);    
+    }
+	assert_true(error_thrown);
+
+    expected_message = "invalid tuple len 2147483652. Sort method: external sort, space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, memAllowed=68719476736, maxTapes=42, tapeRange=468";
+    message = NULL;
+	error_thrown = false;
+    state.sortcontext = CurrentMemoryContext;
+
+    // Check uint32 length
+	PG_TRY();
+	{
+		readtup_heap(&state, 0 /* pos */, NULL /* stup */, NULL /* tape */, sizeof(uint32) | MEMTUP_LEAD_BIT /* len, too small but with flag */);
+	}
+	PG_CATCH();
+	{
+		message = elog_message();
+                
+		if (message != NULL) {
+			error_thrown = true;
+		}
+	}
+	PG_END_TRY();
+
+    assert_true(message != NULL);
+    if (message != NULL) {
+        assert_string_equal(message, expected_message);    
+    }
+	assert_true(error_thrown);
+
+}
+
+static void
+test_tuplesort_mk_writetup_heap_fail_len(void **test_state)
+{
+    gp_debug_linger = 0;
+
+    elog(LOG, "Running test: readtup_heap_fail_len");
+
+    struct LogicalTapeSet lts = {.nFileBlocks = 42 * 1024};
+
+    Tuplesortstate_mk state = {
+        .sortcontext = CurrentMemoryContext,
+        .status = TSS_SORTEDONTAPE,
+        .tapeset = &lts,
+        .nKeys = 42,
+        .randomAccess = false,
+        .memAllowed = 64LL * 1024 * 1024 * 1024,
+        .maxTapes = 42,
+        .tapeRange = 468
+    };
+
+    const char *expected_message = "invalid tuple len 0. Sort method: external sort, space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, memAllowed=68719476736, maxTapes=42, tapeRange=468";
+    char* message = NULL;
+	bool error_thrown = false;
+
+    MemTupleData mtup = {
+        .PRIVATE_mt_len = MEMTUP_LEAD_BIT | 0
+    };
+    
+    MKEntry entry = {
+        .ptr = &mtup
+    };
+
+    // Check zero length
+	PG_TRY();
+	{
+		writetup_heap(&state, 0, &entry);
+	}
+	PG_CATCH();
+	{
+		message = elog_message();
+                
+		if (message != NULL) {
+			error_thrown = true;
+		}
+	}
+	PG_END_TRY();
+
+    assert_true(message != NULL);
+    if (message != NULL) {
+        assert_string_equal(message, expected_message);    
+    }
+	assert_true(error_thrown);
+
+    mtup.PRIVATE_mt_len = MEMTUP_LEAD_BIT | sizeof(uint32);
+    expected_message = "invalid tuple len 0. Sort method: external sort, space type: Disk, space used: 1376256, sort nkeys=42, randomAccess=0, memAllowed=68719476736, maxTapes=42, tapeRange=468";
+    message = NULL;
+	error_thrown = false;
+    state.sortcontext = CurrentMemoryContext;
+
+    // Check uint32 length
+	PG_TRY();
+	{
+		writetup_heap(&state, 0, &entry);
+	}
+	PG_CATCH();
+	{
+		message = elog_message();
+                
+		if (message != NULL) {
+			error_thrown = true;
+		}
+	}
+	PG_END_TRY();
+
+    assert_true(message != NULL);
+    if (message != NULL) {
+        assert_string_equal(message, expected_message);    
+    }
+	assert_true(error_thrown);
+}
+
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+		unit_test(test_tuplesort_mk_readtup_heap_fail_len),
+        unit_test(test_tuplesort_mk_writetup_heap_fail_len)
+	};
+
+	MemoryContextInit();
+
+	return run_tests(tests);
+}

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -2910,7 +2910,6 @@ freetup_heap(MKEntry *e)
 	e->ptr = NULL;
 }
 
-
 static void
 readtup_heap(Tuplesortstate_mk *state, TuplesortPos_mk *pos, MKEntry *e, LogicalTape *lt, uint32 len)
 {
@@ -2919,7 +2918,7 @@ readtup_heap(Tuplesortstate_mk *state, TuplesortPos_mk *pos, MKEntry *e, Logical
 
 	Assert(is_under_sort_or_exec_ctxt(state));
 	
-	if (!is_len_memtuplen(len) && (memtuple_size_from_uint32(len) < sizeof(uint32))) 
+	if (!is_len_memtuplen(len) || (memtuple_size_from_uint32(len) <= sizeof(uint32))) 
 	{
 		const char *sortMethod = "";
 		const char *sortSpaceType = "";

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -2930,7 +2930,7 @@ readtup_heap(Tuplesortstate_mk *state, TuplesortPos_mk *pos, MKEntry *e, Logical
 		tuplesort_get_stats_mk(state, &sortMethod, &sortSpaceType, &sortSpaceUsed);
 		elog(ERROR, "invalid tuple len %u. Sort method: %s, space type: %s, space used: %ld, "
 			"sort nkeys=%d, randomAccess=%d, memAllowed=" INT64_FORMAT ", maxTapes=%d, tapeRange=%d",
-			len, sortMethod, sortSpaceType, sortSpaceUsed,			
+			len, sortMethod, sortSpaceType, sortSpaceUsed,
 			state->nKeys,  state->randomAccess, state->memAllowed, state->maxTapes,
 			state->tapeRange);
 	}

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -2885,8 +2885,11 @@ writetup_heap(Tuplesortstate_mk *state, LogicalTape *lt, MKEntry *e)
 		long sortSpaceUsed = 0;
 		
 		tuplesort_get_stats_mk(state, &sortMethod, &sortSpaceType, &sortSpaceUsed);
-		elog(ERROR, "invalid tuple len %u. Sort method: %s, space type: %s, space used: %ld	",
-			tuplen, sortMethod, sortSpaceType, sortSpaceUsed);
+		elog(ERROR, "invalid tuple len %u. Sort method: %s, space type: %s, space used: %ld, "
+			"sort nkeys=%d, randomAccess=%d, memAllowed=" INT64_FORMAT ", maxTapes=%d, tapeRange=%d",
+			tuplen, sortMethod, sortSpaceType, sortSpaceUsed,
+			state->nKeys,  state->randomAccess, state->memAllowed, state->maxTapes,
+			state->tapeRange);
 	}
 
 	LogicalTapeWrite(state->tapeset, lt, e->ptr, tuplen);
@@ -2925,8 +2928,11 @@ readtup_heap(Tuplesortstate_mk *state, TuplesortPos_mk *pos, MKEntry *e, Logical
 		long sortSpaceUsed = 0;
 		
 		tuplesort_get_stats_mk(state, &sortMethod, &sortSpaceType, &sortSpaceUsed);
-		elog(ERROR, "invalid tuple len %u. Sort method: %s, space type: %s, space used: %ld	",
-			len, sortMethod, sortSpaceType, sortSpaceUsed);
+		elog(ERROR, "invalid tuple len %u. Sort method: %s, space type: %s, space used: %ld, "
+			"sort nkeys=%d, randomAccess=%d, memAllowed=" INT64_FORMAT ", maxTapes=%d, tapeRange=%d",
+			len, sortMethod, sortSpaceType, sortSpaceUsed,			
+			state->nKeys,  state->randomAccess, state->memAllowed, state->maxTapes,
+			state->tapeRange);
 	}
 
 	MemSet(e, 0, sizeof(MKEntry));

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -2878,6 +2878,18 @@ writetup_heap(Tuplesortstate_mk *state, LogicalTape *lt, MKEntry *e)
 	uint32		tuplen = memtuple_get_size(e->ptr);
 	long		ret = tuplen;
 
+	Assert(tuplen > sizeof(uint32));
+	if (tuplen <= sizeof(uint32))
+	{
+		const char *sortMethod = "";
+		const char *sortSpaceType = "";
+		long sortSpaceUsed = 0;
+		
+		tuplesort_get_stats_mk(state, &sortMethod, &sortSpaceType, &sortSpaceUsed);
+		elog(ERROR, "invalid tuple len %u. Sort method: %s, space type: %s, space used: %ld	",
+			tuplen, sortMethod, sortSpaceType, sortSpaceUsed);
+	}
+
 	LogicalTapeWrite(state->tapeset, lt, e->ptr, tuplen);
 
 	if (state->randomAccess)	/* need trailing length word? */
@@ -2899,6 +2911,7 @@ freetup_heap(MKEntry *e)
 	e->ptr = NULL;
 }
 
+
 static void
 readtup_heap(Tuplesortstate_mk *state, TuplesortPos_mk *pos, MKEntry *e, LogicalTape *lt, uint32 len)
 {
@@ -2906,6 +2919,17 @@ readtup_heap(Tuplesortstate_mk *state, TuplesortPos_mk *pos, MKEntry *e, Logical
 	size_t		readSize;
 
 	Assert(is_under_sort_or_exec_ctxt(state));
+	
+	if (!is_len_memtuplen(len) && (memtuple_size_from_uint32(len) < sizeof(uint32))) 
+	{
+		const char *sortMethod = "";
+		const char *sortSpaceType = "";
+		long sortSpaceUsed = 0;
+		
+		tuplesort_get_stats_mk(state, &sortMethod, &sortSpaceType, &sortSpaceUsed);
+		elog(ERROR, "invalid tuple len %u. Sort method: %s, space type: %s, space used: %ld	",
+			len, sortMethod, sortSpaceType, sortSpaceUsed);
+	}
 
 	MemSet(e, 0, sizeof(MKEntry));
 	e->ptr = palloc(memtuple_size_from_uint32(len));

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -2878,7 +2878,6 @@ writetup_heap(Tuplesortstate_mk *state, LogicalTape *lt, MKEntry *e)
 	uint32		tuplen = memtuple_get_size(e->ptr);
 	long		ret = tuplen;
 
-	Assert(tuplen > sizeof(uint32));
 	if (tuplen <= sizeof(uint32))
 	{
 		const char *sortMethod = "";

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -2875,10 +2875,7 @@ copytup_heap(Tuplesortstate_mk *state, MKEntry *e, void *tup)
 static long
 writetup_heap(Tuplesortstate_mk *state, LogicalTape *lt, MKEntry *e)
 {
-	uint32		tuplen = memtuple_get_size(e->ptr);
-	long		ret = tuplen;
-
-	if (tuplen <= sizeof(uint32))
+	if (!memtuple_lead_bit_set(e->ptr) || memtuple_get_size(e->ptr) <= sizeof(uint32))
 	{
 		const char *sortMethod = "";
 		const char *sortSpaceType = "";
@@ -2887,10 +2884,13 @@ writetup_heap(Tuplesortstate_mk *state, LogicalTape *lt, MKEntry *e)
 		tuplesort_get_stats_mk(state, &sortMethod, &sortSpaceType, &sortSpaceUsed);
 		elog(ERROR, "invalid tuple len %u. Sort method: %s, space type: %s, space used: %ld, "
 			"sort nkeys=%d, randomAccess=%d, memAllowed=" INT64_FORMAT ", maxTapes=%d, tapeRange=%d",
-			tuplen, sortMethod, sortSpaceType, sortSpaceUsed,
+			memtuple_get_size(e->ptr), sortMethod, sortSpaceType, sortSpaceUsed,
 			state->nKeys,  state->randomAccess, state->memAllowed, state->maxTapes,
 			state->tapeRange);
 	}
+
+	uint32		tuplen = memtuple_get_size(e->ptr);
+	long		ret = tuplen;
 
 	LogicalTapeWrite(state->tapeset, lt, e->ptr, tuplen);
 


### PR DESCRIPTION
Add extra tuple length checks

We faced an issue when tuple length read from logical tape happened to be 1 
followed by a SIGSEGV. It's not possible to trace down root cause for it, 
so adding more sanity checks for tuple length value. It should replace SIGSEGV 
with an error without the need to restart the executor.

Asserts are not enough in this case as the issue happened with a release build. 
This enhances existing checks in readtup_heap() and writetup_heap() and should
not have measurable impact.