### PR TITLE
ADBDEV-8178: Fix behave to version 1.3.1

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -31,7 +31,7 @@ RUN yum makecache && \
     # repository can no longer update itself.
     curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python && \
     pip install psi pytest==3.10.1 && \
-    pip install allure-behave==2.4.0 && \
+    pip install behave==1.3.1 allure-behave==2.4.0 && \
     yum clean all
 
 # setup ssh configuration

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -20,7 +20,7 @@ RUN set -eux; \
         apt install -y krb5-kdc krb5-admin-server fakeroot sudo python-pip \
             openjdk-11-jdk protobuf-compiler python3-dev; \
 # Install allure-behave for behave tests
-    pip2 install allure-behave==2.4.0; \
+    pip2 install behave==1.3.1 allure-behave==2.4.0; \
     pip2 cache purge;
 
 WORKDIR /home/gpadmin


### PR DESCRIPTION
Fix behave to version 1.3.1

'behave' broke compatibility with Python 2 on version 1.3.2. This breaks our
CI pipeline, so fix the version to the latest working one, 1.3.1.