### PR TITLE
Fix SIGSEGV when running the 'execute on initplan' function

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -7241,7 +7241,14 @@ append_initplan_for_function_scan(PlannerInfo *root, Path *best_path, Plan *plan
 	subroot = (PlannerInfo *) palloc(sizeof(PlannerInfo));
 	memcpy(subroot, root, sizeof(PlannerInfo));
 	subroot->query_level++;
-	subroot->parent_root = root;
+	/*
+	 * We set parent_root to NULL here in order to isolate the initplan
+	 * from all params ('plan_params') of outer queries. Otherwise, we may
+	 * recognize the parameter of the initplan function, referring to the
+	 * outer query, as an eligible param. We will set it to 'root'
+	 * after SS_make_initplan_from_plan().
+	 */
+	subroot->parent_root = NULL;
 	/* reset subplan-related stuff */
 	subroot->plan_params = NIL;
 	subroot->init_plans = NIL;
@@ -7265,6 +7272,8 @@ append_initplan_for_function_scan(PlannerInfo *root, Path *best_path, Plan *plan
 	 * result rows in tuplestore instead of a scalar param
 	 */
 	prm = SS_make_initplan_from_plan(subroot, (Plan *)initplan, InvalidOid, -1, InvalidOid, true);
+
+	subroot->parent_root = root;
 
 	fsplan->param = prm;
 	fsplan->resultInTupleStore = true;

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -7273,8 +7273,6 @@ append_initplan_for_function_scan(PlannerInfo *root, Path *best_path, Plan *plan
 	 */
 	prm = SS_make_initplan_from_plan(subroot, (Plan *)initplan, InvalidOid, -1, InvalidOid, true);
 
-	subroot->parent_root = root;
-
 	fsplan->param = prm;
 	fsplan->resultInTupleStore = true;
 

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -7245,8 +7245,7 @@ append_initplan_for_function_scan(PlannerInfo *root, Path *best_path, Plan *plan
 	 * We set parent_root to NULL here in order to isolate the initplan
 	 * from all params ('plan_params') of outer queries. Otherwise, we may
 	 * recognize the parameter of the initplan function, referring to the
-	 * outer query, as an eligible param. We will set it to 'root'
-	 * after SS_make_initplan_from_plan().
+	 * outer query, as an eligible param.
 	 */
 	subroot->parent_root = NULL;
 	/* reset subplan-related stuff */

--- a/src/test/regress/expected/function_extensions.out
+++ b/src/test/regress/expected/function_extensions.out
@@ -751,3 +751,32 @@ select count(*) from (select * from (select pg_catalog.gp_acquire_sample_rows('t
 (1 row)
 
 drop table test_ao3;
+-- Test initplan function referring the outer query.
+-- The query below previously led to a SIGSEGV.
+-- start_matchsubs
+-- m/ \(subselect\.c:.*\)/
+-- s/ \(subselect\.c:.*\)//
+-- end_matchsubs
+create table test_table_cte(a text, b text);
+insert into test_table_cte values('-', '-');
+create table test_table(a int, b text);
+create or replace function test_function(param_text_in text, param_int_in int4) returns
+table (param_text_out text, param_int_out int4) as
+$function$
+begin
+return query
+with
+-- though cte1 is not used, we need it here to reproduce the SIGSEGV,
+-- without it the query below failed with 'invalid Datum pointer' error.
+cte1 as (select hostname from gp_segment_configuration),
+cte2 as (select a from test_table_cte where b = param_text_in)
+select param_text_in::text, param_int_in::int4 from cte2;
+end;
+$function$
+language plpgsql execute on initplan;
+create table tnew as
+select * from test_table l join test_function(l.b, 1) r on l.a = r.param_int_out;
+ERROR:  plan should not reference subplan's variable
+drop function test_function(param_text_in text, param_int_in int4);
+drop table test_table_cte;
+drop table test_table;

--- a/src/test/regress/expected/function_extensions.out
+++ b/src/test/regress/expected/function_extensions.out
@@ -763,17 +763,14 @@ create table test_table(a int, b text);
 create function test_function(param_text_in text, param_int_in int4) returns
 table (param_text_out text, param_int_out int4) as
 $function$
-begin
-return query
 with
 -- though cte1 is not used, we need it here to reproduce the SIGSEGV,
 -- without it the query below failed with 'invalid Datum pointer' error.
 cte1 as (select hostname from gp_segment_configuration),
 cte2 as (select a from test_table_cte where b = param_text_in)
 select param_text_in::text, param_int_in::int4 from cte2;
-end;
 $function$
-language plpgsql execute on initplan;
+language sql execute on initplan;
 create table tnew as
 select * from test_table l join test_function(l.b, 1) r on l.a = r.param_int_out;
 ERROR:  plan should not reference subplan's variable

--- a/src/test/regress/expected/function_extensions.out
+++ b/src/test/regress/expected/function_extensions.out
@@ -760,7 +760,7 @@ drop table test_ao3;
 create table test_table_cte(a text, b text);
 insert into test_table_cte values('-', '-');
 create table test_table(a int, b text);
-create or replace function test_function(param_text_in text, param_int_in int4) returns
+create function test_function(param_text_in text, param_int_in int4) returns
 table (param_text_out text, param_int_out int4) as
 $function$
 begin

--- a/src/test/regress/expected/function_extensions.out
+++ b/src/test/regress/expected/function_extensions.out
@@ -757,23 +757,15 @@ drop table test_ao3;
 -- m/ \(subselect\.c:.*\)/
 -- s/ \(subselect\.c:.*\)//
 -- end_matchsubs
-create table test_table_cte(a text, b text);
-insert into test_table_cte values('-', '-');
-create table test_table(a int, b text);
-create function test_function(param_text_in text, param_int_in int4) returns
-table (param_text_out text, param_int_out int4) as
+create table test_table(a text);
+create function test_function(param_in text) returns
+table (param_out text) as
 $function$
-with
--- though cte1 is not used, we need it here to reproduce the SIGSEGV,
--- without it the query below failed with 'invalid Datum pointer' error.
-cte1 as (select hostname from gp_segment_configuration),
-cte2 as (select a from test_table_cte where b = param_text_in)
-select param_text_in::text, param_int_in::int4 from cte2;
+select param_in;
 $function$
 language sql execute on initplan;
 create table tnew as
-select * from test_table l join test_function(l.b, 1) r on l.a = r.param_int_out;
+select * from test_table l join test_function(l.a) r on l.a = r.param_out;
 ERROR:  plan should not reference subplan's variable
-drop function test_function(param_text_in text, param_int_in int4);
-drop table test_table_cte;
+drop function test_function(param_in text);
 drop table test_table;

--- a/src/test/regress/expected/function_extensions_optimizer.out
+++ b/src/test/regress/expected/function_extensions_optimizer.out
@@ -765,17 +765,14 @@ create table test_table(a int, b text);
 create function test_function(param_text_in text, param_int_in int4) returns
 table (param_text_out text, param_int_out int4) as
 $function$
-begin
-return query
 with
 -- though cte1 is not used, we need it here to reproduce the SIGSEGV,
 -- without it the query below failed with 'invalid Datum pointer' error.
 cte1 as (select hostname from gp_segment_configuration),
 cte2 as (select a from test_table_cte where b = param_text_in)
 select param_text_in::text, param_int_in::int4 from cte2;
-end;
 $function$
-language plpgsql execute on initplan;
+language sql execute on initplan;
 create table tnew as
 select * from test_table l join test_function(l.b, 1) r on l.a = r.param_int_out;
 ERROR:  plan should not reference subplan's variable

--- a/src/test/regress/expected/function_extensions_optimizer.out
+++ b/src/test/regress/expected/function_extensions_optimizer.out
@@ -759,23 +759,15 @@ drop table test_ao3;
 -- m/ \(subselect\.c:.*\)/
 -- s/ \(subselect\.c:.*\)//
 -- end_matchsubs
-create table test_table_cte(a text, b text);
-insert into test_table_cte values('-', '-');
-create table test_table(a int, b text);
-create function test_function(param_text_in text, param_int_in int4) returns
-table (param_text_out text, param_int_out int4) as
+create table test_table(a text);
+create function test_function(param_in text) returns
+table (param_out text) as
 $function$
-with
--- though cte1 is not used, we need it here to reproduce the SIGSEGV,
--- without it the query below failed with 'invalid Datum pointer' error.
-cte1 as (select hostname from gp_segment_configuration),
-cte2 as (select a from test_table_cte where b = param_text_in)
-select param_text_in::text, param_int_in::int4 from cte2;
+select param_in;
 $function$
 language sql execute on initplan;
 create table tnew as
-select * from test_table l join test_function(l.b, 1) r on l.a = r.param_int_out;
+select * from test_table l join test_function(l.a) r on l.a = r.param_out;
 ERROR:  plan should not reference subplan's variable
-drop function test_function(param_text_in text, param_int_in int4);
-drop table test_table_cte;
+drop function test_function(param_in text);
 drop table test_table;

--- a/src/test/regress/expected/function_extensions_optimizer.out
+++ b/src/test/regress/expected/function_extensions_optimizer.out
@@ -753,3 +753,32 @@ select count(*) from (select * from (select pg_catalog.gp_acquire_sample_rows('t
 (1 row)
 
 drop table test_ao3;
+-- Test initplan function referring the outer query.
+-- The query below previously led to a SIGSEGV.
+-- start_matchsubs
+-- m/ \(subselect\.c:.*\)/
+-- s/ \(subselect\.c:.*\)//
+-- end_matchsubs
+create table test_table_cte(a text, b text);
+insert into test_table_cte values('-', '-');
+create table test_table(a int, b text);
+create or replace function test_function(param_text_in text, param_int_in int4) returns
+table (param_text_out text, param_int_out int4) as
+$function$
+begin
+return query
+with
+-- though cte1 is not used, we need it here to reproduce the SIGSEGV,
+-- without it the query below failed with 'invalid Datum pointer' error.
+cte1 as (select hostname from gp_segment_configuration),
+cte2 as (select a from test_table_cte where b = param_text_in)
+select param_text_in::text, param_int_in::int4 from cte2;
+end;
+$function$
+language plpgsql execute on initplan;
+create table tnew as
+select * from test_table l join test_function(l.b, 1) r on l.a = r.param_int_out;
+ERROR:  plan should not reference subplan's variable
+drop function test_function(param_text_in text, param_int_in int4);
+drop table test_table_cte;
+drop table test_table;

--- a/src/test/regress/expected/function_extensions_optimizer.out
+++ b/src/test/regress/expected/function_extensions_optimizer.out
@@ -762,7 +762,7 @@ drop table test_ao3;
 create table test_table_cte(a text, b text);
 insert into test_table_cte values('-', '-');
 create table test_table(a int, b text);
-create or replace function test_function(param_text_in text, param_int_in int4) returns
+create function test_function(param_text_in text, param_int_in int4) returns
 table (param_text_out text, param_int_out int4) as
 $function$
 begin

--- a/src/test/regress/sql/function_extensions.sql
+++ b/src/test/regress/sql/function_extensions.sql
@@ -417,3 +417,41 @@ insert into test_ao3 values(1,2),(2,3),(3,4);
 select count(*) from (select * from (select pg_catalog.gp_acquire_sample_rows('test_ao3'::regclass, 400, 'f')) ss limit 1) ss1;
 
 drop table test_ao3;
+
+-- Test initplan function referring the outer query.
+-- The query below previously led to a SIGSEGV.
+-- start_matchsubs
+-- m/ \(subselect\.c:.*\)/
+-- s/ \(subselect\.c:.*\)//
+-- end_matchsubs
+
+-- start_ignore
+drop table if exists test_table_cte;
+drop table if exists test_table;
+-- end_ignore
+
+create table test_table_cte(a text, b text);
+insert into test_table_cte values('-', '-');
+create table test_table(a int, b text);
+
+create or replace function test_function(param_text_in text, param_int_in int4) returns
+table (param_text_out text, param_int_out int4) as
+$function$
+begin
+return query
+with
+-- though cte1 is not used, we need it here to reproduce the SIGSEGV,
+-- without it the query below failed with 'invalid Datum pointer' error.
+cte1 as (select hostname from gp_segment_configuration),
+cte2 as (select a from test_table_cte where b = param_text_in)
+select param_text_in::text, param_int_in::int4 from cte2;
+end;
+$function$
+language plpgsql execute on initplan;
+
+create table tnew as
+select * from test_table l join test_function(l.b, 1) r on l.a = r.param_int_out;
+
+drop function test_function(param_text_in text, param_int_in int4);
+drop table test_table_cte;
+drop table test_table;

--- a/src/test/regress/sql/function_extensions.sql
+++ b/src/test/regress/sql/function_extensions.sql
@@ -438,17 +438,14 @@ create table test_table(a int, b text);
 create function test_function(param_text_in text, param_int_in int4) returns
 table (param_text_out text, param_int_out int4) as
 $function$
-begin
-return query
 with
 -- though cte1 is not used, we need it here to reproduce the SIGSEGV,
 -- without it the query below failed with 'invalid Datum pointer' error.
 cte1 as (select hostname from gp_segment_configuration),
 cte2 as (select a from test_table_cte where b = param_text_in)
 select param_text_in::text, param_int_in::int4 from cte2;
-end;
 $function$
-language plpgsql execute on initplan;
+language sql execute on initplan;
 
 create table tnew as
 select * from test_table l join test_function(l.b, 1) r on l.a = r.param_int_out;

--- a/src/test/regress/sql/function_extensions.sql
+++ b/src/test/regress/sql/function_extensions.sql
@@ -426,30 +426,21 @@ drop table test_ao3;
 -- end_matchsubs
 
 -- start_ignore
-drop table if exists test_table_cte;
 drop table if exists test_table;
-drop function if exists test_function(param_text_in text, param_int_in int4);
+drop function if exists test_function(param_in text);
 -- end_ignore
 
-create table test_table_cte(a text, b text);
-insert into test_table_cte values('-', '-');
-create table test_table(a int, b text);
+create table test_table(a text);
 
-create function test_function(param_text_in text, param_int_in int4) returns
-table (param_text_out text, param_int_out int4) as
+create function test_function(param_in text) returns
+table (param_out text) as
 $function$
-with
--- though cte1 is not used, we need it here to reproduce the SIGSEGV,
--- without it the query below failed with 'invalid Datum pointer' error.
-cte1 as (select hostname from gp_segment_configuration),
-cte2 as (select a from test_table_cte where b = param_text_in)
-select param_text_in::text, param_int_in::int4 from cte2;
+select param_in;
 $function$
 language sql execute on initplan;
 
 create table tnew as
-select * from test_table l join test_function(l.b, 1) r on l.a = r.param_int_out;
+select * from test_table l join test_function(l.a) r on l.a = r.param_out;
 
-drop function test_function(param_text_in text, param_int_in int4);
-drop table test_table_cte;
+drop function test_function(param_in text);
 drop table test_table;

--- a/src/test/regress/sql/function_extensions.sql
+++ b/src/test/regress/sql/function_extensions.sql
@@ -428,13 +428,14 @@ drop table test_ao3;
 -- start_ignore
 drop table if exists test_table_cte;
 drop table if exists test_table;
+drop function if exists test_function(param_text_in text, param_int_in int4);
 -- end_ignore
 
 create table test_table_cte(a text, b text);
 insert into test_table_cte values('-', '-');
 create table test_table(a int, b text);
 
-create or replace function test_function(param_text_in text, param_int_in int4) returns
+create function test_function(param_text_in text, param_int_in int4) returns
 table (param_text_out text, param_int_out int4) as
 $function$
 begin


### PR DESCRIPTION
Fix SIGSEGV when running the 'execute on initplan' function

Problem description:
A query with an 'execute on initplan' function having a parameter that refers
the other relation in the query caused SIGSEGV during execution.

Root cause:
As the function was executed in the initplan, during the execution the value
of the parameter was not yet defined, as the initplan is processed before the
main plan.

Fix:
When appending an initplan node for the function scan, set the subplan's
'parent_root' to NULL, isolating it from plan params of outer querie's.
Now all such params don't get into the valid parameter list in
SS_finalize_plan(), and the planner emits an error for such a query.
