### PR TITLE
ADBDEV-8371: Fix hash join spill file issue when rescanning

### DIFF
--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -1231,11 +1231,38 @@ ExecReScanHashJoin(HashJoinState *node)
 			 */
 			node->hj_OuterNotEmpty = false;
 
+			/*
+			 * Outer batch files have to be cleared before restarting the hash join,
+			 * because they will be written again when batch 0 is processed.
+			 *
+			 * TODO: it might be possible to optimize by saving batch 0 outer file too,
+			 * in which case we might avoid rescanning the outer plan again.
+			 */
+			if (node->hj_HashTable->outerBatchFile)
+			{
+				for (int i = 0; i < node->hj_HashTable->nbatch; i++)
+				{
+					if (node->hj_HashTable->outerBatchFile[i])
+						BufFileClose(node->hj_HashTable->outerBatchFile[i]);
+					node->hj_HashTable->outerBatchFile[i] = NULL;
+				}
+			}
+
 			/* ExecHashJoin can skip the BUILD_HASHTABLE step */
 			node->hj_JoinState = HJ_NEED_NEW_OUTER;
 
 			if (node->hj_HashTable->nbatch > 1)
 			{
+				/*
+				 * If we rescan in the middle of a batch, inner batch file for the current
+				 * batch is actually deleted, its contents only present in the hash table.
+				 * We must spill it to disk to not lose it.
+				 */
+				if (node->reuse_hashtable &&
+					node->hj_HashTable->innerBatchFile[node->hj_HashTable->curbatch] == NULL)
+				{
+					SpillCurrentBatch(node);
+				}
 				/* Force reloading batch 0 upon next ExecHashJoin */
 				node->hj_HashTable->curbatch = -1;
 			}

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -1247,8 +1247,10 @@ ExecReScanHashJoin(HashJoinState *node)
 				for (int i = 0; i < hashtable->nbatch; i++)
 				{
 					if (hashtable->outerBatchFile[i])
+					{
 						BufFileClose(hashtable->outerBatchFile[i]);
-					hashtable->outerBatchFile[i] = NULL;
+						hashtable->outerBatchFile[i] = NULL;
+					}
 				}
 			}
 

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -1197,6 +1197,8 @@ ExecHashJoinGetSavedTuple(HashJoinState *hjstate,
 void
 ExecReScanHashJoin(HashJoinState *node)
 {
+	HashJoinTable hashtable = node->hj_HashTable;  
+
 	/*
 	 * In a multi-batch join, we currently have to do rescans the hard way,
 	 * primarily because batch temp files may have already been released. But
@@ -1204,12 +1206,12 @@ ExecReScanHashJoin(HashJoinState *node)
 	 * inner subnode, then we can just re-use the existing hash table without
 	 * rebuilding it.
 	 */
-	if (node->hj_HashTable != NULL)
+	if (hashtable != NULL)
 	{
-		node->hj_HashTable->first_pass = false;
+		hashtable->first_pass = false;
 
 		if (node->js.ps.righttree->chgParam == NULL &&
-			!node->hj_HashTable->eagerlyReleased)
+			!hashtable->eagerlyReleased)
 		{
 			/*
 			 * Okay to reuse the hash table; needn't rescan inner, either.
@@ -1218,7 +1220,7 @@ ExecReScanHashJoin(HashJoinState *node)
 			 * inner-tuple match flags contained in the table.
 			 */
 			if (HJ_FILL_INNER(node))
-				ExecHashTableResetMatchFlags(node->hj_HashTable);
+				ExecHashTableResetMatchFlags(hashtable);
 
 			/*
 			 * Also, we need to reset our state about the emptiness of the
@@ -1238,20 +1240,20 @@ ExecReScanHashJoin(HashJoinState *node)
 			 * TODO: it might be possible to optimize by saving batch 0 outer file too,
 			 * in which case we might avoid rescanning the outer plan again.
 			 */
-			if (node->hj_HashTable->outerBatchFile)
+			if (hashtable->outerBatchFile)
 			{
-				for (int i = 0; i < node->hj_HashTable->nbatch; i++)
+				for (int i = 0; i < hashtable->nbatch; i++)
 				{
-					if (node->hj_HashTable->outerBatchFile[i])
-						BufFileClose(node->hj_HashTable->outerBatchFile[i]);
-					node->hj_HashTable->outerBatchFile[i] = NULL;
+					if (hashtable->outerBatchFile[i])
+						BufFileClose(hashtable->outerBatchFile[i]);
+					hashtable->outerBatchFile[i] = NULL;
 				}
 			}
 
 			/* ExecHashJoin can skip the BUILD_HASHTABLE step */
 			node->hj_JoinState = HJ_NEED_NEW_OUTER;
 
-			if (node->hj_HashTable->nbatch > 1)
+			if (hashtable->nbatch > 1)
 			{
 				/*
 				 * If we rescan in the middle of a batch, inner batch file for the current
@@ -1259,29 +1261,29 @@ ExecReScanHashJoin(HashJoinState *node)
 				 * We must spill it to disk to not lose it.
 				 */
 				if (node->reuse_hashtable &&
-					node->hj_HashTable->innerBatchFile[node->hj_HashTable->curbatch] == NULL)
+					hashtable->innerBatchFile[hashtable->curbatch] == NULL)
 				{
 					SpillCurrentBatch(node);
 				}
 				/* Force reloading batch 0 upon next ExecHashJoin */
-				node->hj_HashTable->curbatch = -1;
+				hashtable->curbatch = -1;
 			}
 			else
 			{
 				/* MPP-1600: reset the batch number */
-				node->hj_HashTable->curbatch = 0;
+				hashtable->curbatch = 0;
 			}
 		}
 		else
 		{
 			/* must destroy and rebuild hash table */
-			if (!node->hj_HashTable->eagerlyReleased)
+			if (!hashtable->eagerlyReleased)
 			{
 				HashState  *hashState = (HashState *) innerPlanState(node);
 
-				ExecHashTableDestroy(hashState, node->hj_HashTable);
+				ExecHashTableDestroy(hashState, hashtable);
 			}
-			pfree(node->hj_HashTable);
+			pfree(hashtable);
 			node->hj_HashTable = NULL;
 			node->hj_JoinState = HJ_BUILD_HASHTABLE;
 

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -1234,11 +1234,13 @@ ExecReScanHashJoin(HashJoinState *node)
 			node->hj_OuterNotEmpty = false;
 
 			/*
-			 * Outer batch files have to be cleared before restarting the hash join,
-			 * because they will be written again when batch 0 is processed.
+			 * Outer batch files have to be cleared before restarting the hash
+			 * join, because they will be written again when batch 0 is
+			 * processed.
 			 *
-			 * TODO: it might be possible to optimize by saving batch 0 outer file too,
-			 * in which case we might avoid rescanning the outer plan again.
+			 * TODO: it might be possible to optimize by saving batch 0 outer
+			 * file too, in which case we might avoid rescanning the outer
+			 * plan again.
 			 */
 			if (hashtable->outerBatchFile)
 			{
@@ -1256,9 +1258,10 @@ ExecReScanHashJoin(HashJoinState *node)
 			if (hashtable->nbatch > 1)
 			{
 				/*
-				 * If we rescan in the middle of a batch, inner batch file for the current
-				 * batch is actually deleted, its contents only present in the hash table.
-				 * We must spill it to disk to not lose it.
+				 * If we rescan in the middle of a batch, inner batch file for
+				 * the current batch is actually deleted, its contents only
+				 * present in the hash table. We must spill it to disk to not
+				 * lose it.
 				 */
 				if (node->reuse_hashtable &&
 					hashtable->innerBatchFile[hashtable->curbatch] == NULL)

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -1237,10 +1237,6 @@ ExecReScanHashJoin(HashJoinState *node)
 			 * Outer batch files have to be cleared before restarting the hash
 			 * join, because they will be written again when batch 0 is
 			 * processed.
-			 *
-			 * TODO: it might be possible to optimize by saving batch 0 outer
-			 * file too, in which case we might avoid rescanning the outer
-			 * plan again.
 			 */
 			if (hashtable->outerBatchFile)
 			{

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -4177,12 +4177,12 @@ select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b
    1 |   1
 (2 rows)
 
+reset statement_mem;
 reset gp_workfile_compression;
 reset optimizer;
 reset enable_nestloop;
 reset enable_bitmapscan;
 reset enable_seqscan;
-reset statement_mem;
 drop table l_table;
 drop table r_table1;
 drop table r_table2;

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -4177,8 +4177,8 @@ select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b
    1 |   1
 (2 rows)
 
-reset statement_mem;
 reset gp_workfile_compression;
+reset statement_mem;
 reset optimizer;
 reset enable_nestloop;
 reset enable_bitmapscan;

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -4136,7 +4136,7 @@ insert into r_table1 select i%100, i from generate_series(1, 10000) i;
 analyze l_table;
 analyze r_table1;
 set statement_mem="1MB";
-explain analyze select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+explain analyze select * from r_table2 where ra2 in (select ra1 from l_table join r_table1 on b = rb1);
                                                                       QUERY PLAN                                                                      
 ------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)  (cost=30000000473.00..30000001205.61 rows=16 width=8) (actual time=73.649..73.651 rows=2 loops=1)
@@ -4162,7 +4162,7 @@ explain analyze select * from r_table2 where ra2 in ( select ra1 from l_table jo
  Execution time: 74.293 ms
 (21 rows)
 
-select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+select * from r_table2 where ra2 in (select ra1 from l_table join r_table1 on b = rb1);
  ra2 | rb2 
 -----+-----
   11 |  11
@@ -4170,7 +4170,7 @@ select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b
 (2 rows)
 
 set gp_workfile_compression=on;
-select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+select * from r_table2 where ra2 in (select ra1 from l_table join r_table1 on b = rb1);
  ra2 | rb2 
 -----+-----
   11 |  11

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -4127,10 +4127,62 @@ select * from r_table2 where ra2 in ( select a from l_table join r_table1 on b =
    1 |   1
 (1 row)
 
+-- Testcase for hash join rescan clearing batch files for outer subplan
+truncate l_table;
+truncate r_table1;
+insert into l_table select i, i%100 from generate_series(1, 20000) i;
+insert into r_table1 select i%100, i from generate_series(1, 10000) i;
+insert into r_table1 select i%100, i from generate_series(1, 10000) i;
+analyze l_table;
+analyze r_table1;
+set statement_mem="1MB";
+explain analyze select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=30000000473.00..30000001205.61 rows=16 width=8) (actual time=73.649..73.651 rows=2 loops=1)
+   ->  Nested Loop Semi Join  (cost=30000000473.00..30000001205.61 rows=16 width=8) (actual time=29.419..73.334 rows=2 loops=1)
+         Join Filter: (r_table2.ra2 = r_table1.ra1)
+         ->  Seq Scan on r_table2  (cost=10000000000.00..10000000001.02 rows=2 width=8) (actual time=0.003..0.004 rows=2 loops=1)
+         ->  Hash Join  (cost=20000000473.00..20000001196.00 rows=40000 width=4) (actual time=5.144..34.441 rows=20807 loops=2)
+               Hash Cond: (l_table.b = r_table1.rb1)
+               Extra Text: Initial batch 0:
+   Wrote 198K bytes to inner workfile.
+   Wrote 111K bytes to outer workfile.
+ Work file set: 2 files (0 compressed), avg file size 147456, compression buffer size 0 bytes
+ Hash chain length 3.4 avg, 14 max, using 2907 of 4096 buckets.  Skipped 1 empty batches.
+               ->  Seq Scan on l_table  (cost=10000000000.00..10000000223.00 rows=20000 width=4) (actual time=0.007..15.150 rows=20000 loops=2)
+               ->  Hash  (cost=10000000223.00..10000000223.00 rows=6667 width=8) (actual time=10.240..10.240 rows=20000 loops=1)
+                     ->  Seq Scan on r_table1  (cost=10000000000.00..10000000223.00 rows=20000 width=8) (actual time=0.013..3.960 rows=20000 loops=1)
+ Planning time: 1.497 ms
+   (slice0)    Executor memory: 123K bytes.
+ * (slice1)    Executor memory: 1228K bytes (seg2).  Work_mem: 525K bytes max, 575K bytes wanted.
+ Memory used:  1024kB
+ Memory wanted:  1174kB
+ Optimizer: Postgres query optimizer
+ Execution time: 74.293 ms
+(21 rows)
+
+select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+ ra2 | rb2 
+-----+-----
+  11 |  11
+   1 |   1
+(2 rows)
+
+set gp_workfile_compression=on;
+select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+ ra2 | rb2 
+-----+-----
+  11 |  11
+   1 |   1
+(2 rows)
+
+reset gp_workfile_compression;
 reset optimizer;
 reset enable_nestloop;
 reset enable_bitmapscan;
 reset enable_seqscan;
+reset statement_mem;
 drop table l_table;
 drop table r_table1;
 drop table r_table2;

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -4118,10 +4118,62 @@ select * from r_table2 where ra2 in ( select a from l_table join r_table1 on b =
    1 |   1
 (1 row)
 
+-- Testcase for hash join rescan clearing batch files for outer subplan
+truncate l_table;
+truncate r_table1;
+insert into l_table select i, i%100 from generate_series(1, 20000) i;
+insert into r_table1 select i%100, i from generate_series(1, 10000) i;
+insert into r_table1 select i%100, i from generate_series(1, 10000) i;
+analyze l_table;
+analyze r_table1;
+set statement_mem="1MB";
+explain analyze select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=30000000473.00..30000001205.61 rows=16 width=8) (actual time=73.649..73.651 rows=2 loops=1)
+   ->  Nested Loop Semi Join  (cost=30000000473.00..30000001205.61 rows=16 width=8) (actual time=29.419..73.334 rows=2 loops=1)
+         Join Filter: (r_table2.ra2 = r_table1.ra1)
+         ->  Seq Scan on r_table2  (cost=10000000000.00..10000000001.02 rows=2 width=8) (actual time=0.003..0.004 rows=2 loops=1)
+         ->  Hash Join  (cost=20000000473.00..20000001196.00 rows=40000 width=4) (actual time=5.144..34.441 rows=20807 loops=2)
+               Hash Cond: (l_table.b = r_table1.rb1)
+               Extra Text: Initial batch 0:
+   Wrote 198K bytes to inner workfile.
+   Wrote 111K bytes to outer workfile.
+ Work file set: 2 files (0 compressed), avg file size 147456, compression buffer size 0 bytes
+ Hash chain length 3.4 avg, 14 max, using 2907 of 4096 buckets.  Skipped 1 empty batches.
+               ->  Seq Scan on l_table  (cost=10000000000.00..10000000223.00 rows=20000 width=4) (actual time=0.007..15.150 rows=20000 loops=2)
+               ->  Hash  (cost=10000000223.00..10000000223.00 rows=6667 width=8) (actual time=10.240..10.240 rows=20000 loops=1)
+                     ->  Seq Scan on r_table1  (cost=10000000000.00..10000000223.00 rows=20000 width=8) (actual time=0.013..3.960 rows=20000 loops=1)
+ Planning time: 1.497 ms
+   (slice0)    Executor memory: 123K bytes.
+ * (slice1)    Executor memory: 1228K bytes (seg2).  Work_mem: 525K bytes max, 575K bytes wanted.
+ Memory used:  1024kB
+ Memory wanted:  1174kB
+ Optimizer: Postgres query optimizer
+ Execution time: 74.293 ms
+(21 rows)
+
+select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+ ra2 | rb2 
+-----+-----
+  11 |  11
+   1 |   1
+(2 rows)
+
+set gp_workfile_compression=on;
+select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+ ra2 | rb2 
+-----+-----
+  11 |  11
+   1 |   1
+(2 rows)
+
+reset gp_workfile_compression;
 reset optimizer;
 reset enable_nestloop;
 reset enable_bitmapscan;
 reset enable_seqscan;
+reset statement_mem;
 drop table l_table;
 drop table r_table1;
 drop table r_table2;

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -4127,7 +4127,7 @@ insert into r_table1 select i%100, i from generate_series(1, 10000) i;
 analyze l_table;
 analyze r_table1;
 set statement_mem="1MB";
-explain analyze select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+explain analyze select * from r_table2 where ra2 in (select ra1 from l_table join r_table1 on b = rb1);
                                                                       QUERY PLAN                                                                      
 ------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)  (cost=30000000473.00..30000001205.61 rows=16 width=8) (actual time=73.649..73.651 rows=2 loops=1)
@@ -4153,7 +4153,7 @@ explain analyze select * from r_table2 where ra2 in ( select ra1 from l_table jo
  Execution time: 74.293 ms
 (21 rows)
 
-select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+select * from r_table2 where ra2 in (select ra1 from l_table join r_table1 on b = rb1);
  ra2 | rb2 
 -----+-----
   11 |  11
@@ -4161,7 +4161,7 @@ select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b
 (2 rows)
 
 set gp_workfile_compression=on;
-select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+select * from r_table2 where ra2 in (select ra1 from l_table join r_table1 on b = rb1);
  ra2 | rb2 
 -----+-----
   11 |  11

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -4169,11 +4169,11 @@ select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b
 (2 rows)
 
 reset gp_workfile_compression;
+reset statement_mem;
 reset optimizer;
 reset enable_nestloop;
 reset enable_bitmapscan;
 reset enable_seqscan;
-reset statement_mem;
 drop table l_table;
 drop table r_table1;
 drop table r_table2;

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -585,11 +585,11 @@ analyze l_table;
 analyze r_table1;
 
 set statement_mem="1MB";
-explain analyze select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
-select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+explain analyze select * from r_table2 where ra2 in (select ra1 from l_table join r_table1 on b = rb1);
+select * from r_table2 where ra2 in (select ra1 from l_table join r_table1 on b = rb1);
 
 set gp_workfile_compression=on;
-select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+select * from r_table2 where ra2 in (select ra1 from l_table join r_table1 on b = rb1);
 reset gp_workfile_compression;
 reset statement_mem;
 

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -575,10 +575,28 @@ set enable_seqscan=off;
 explain select * from r_table2 where ra2 in ( select a from l_table join r_table1 on b = rb1);
 select * from r_table2 where ra2 in ( select a from l_table join r_table1 on b = rb1);
 
+-- Testcase for hash join rescan clearing batch files for outer subplan
+truncate l_table;
+truncate r_table1;
+insert into l_table select i, i%100 from generate_series(1, 20000) i;
+insert into r_table1 select i%100, i from generate_series(1, 10000) i;
+insert into r_table1 select i%100, i from generate_series(1, 10000) i;
+analyze l_table;
+analyze r_table1;
+
+set statement_mem="1MB";
+explain analyze select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+
+set gp_workfile_compression=on;
+select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
+reset gp_workfile_compression;
+
 reset optimizer;
 reset enable_nestloop;
 reset enable_bitmapscan;
 reset enable_seqscan;
+reset statement_mem;
 drop table l_table;
 drop table r_table1;
 drop table r_table2;

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -591,12 +591,12 @@ select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b
 set gp_workfile_compression=on;
 select * from r_table2 where ra2 in ( select ra1 from l_table join r_table1 on b = rb1);
 reset gp_workfile_compression;
+reset statement_mem;
 
 reset optimizer;
 reset enable_nestloop;
 reset enable_bitmapscan;
 reset enable_seqscan;
-reset statement_mem;
 drop table l_table;
 drop table r_table1;
 drop table r_table2;


### PR DESCRIPTION
Fix hash join spill file issue when rescanning

Previously in some cases when rescanning a hash join was required, and the
hash join was executed in multiple batches that were spilled to disk, several
issues occurred when rescan happened in the middle of a batch:
1. Outer batch files (which contain outer tuples for all the next batches)
were never cleared, and after rescan they were filled again. When
gp_workfile_compression is enabled, this caused a BufFile to be in an
unexpected state (reading instead of writing), causing an error.
2. When inner batch file is read into the in-memory hash table, it is deleted.
After processing the batch, the hash table is spilled again into the batch
file in case rescan is possible. However, if rescan happens in the middle of a
batch, the hash table was never spilled and its contents were lost, resulting
in missing data in the output.

To fix these issues, when rescan is executed without rebuilding the whole hash
table, clear all the outer batch files and also spill the current batch to an
inner batch file.