### PR TITLE
ADBDEV-8355: Convince the compiler that the variable was initialized

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -620,6 +620,7 @@ CTranslatorDXLToPlStmt::CreateForeignScan(Oid rel_oid, Index scanrelid,
 			break;
 		default:  // Shouldn't happen
 			GPOS_ASSERT(!"Unrecognized locus type");
+			__builtin_unreachable();
 	}
 
 	if (md_rel->GetRelDistribution() != rel_distr_policy_expected)


### PR DESCRIPTION
Convince the compiler that the variable was initialized

GPOS_ASSERT disappears on the build without asserts, and an error will be given:
Ctranslatordxltoplstmt.cpp: 625: 9: Error: ‘Rel_distr_policy_Expected’ May Uninitialized in this Function

It is necessary to add __builtin_unreachable, as is done in other places of the ORCA.

Ticket: ADBDEV-8355