### PR TITLE
[ADBDEV-8475] Accept vacuum operations in XactLockTableWait assertion

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -4880,7 +4880,7 @@ LocalXidGetDistributedXid(TransactionId xid)
 	{
 		DistributedLog_GetDistributedXid(xid, &tstamp, &gxid);
 		AssertImply(gxid != InvalidDistributedTransactionId,
-					tstamp == MyTmGxact->distribTimeStamp);
+					(tstamp == MyTmGxact->distribTimeStamp || MyTmGxact->distribTimeStamp == 0));
 	}
 
 	return gxid;

--- a/src/test/isolation2/expected/intra-grant-inplace-db.out
+++ b/src/test/isolation2/expected/intra-grant-inplace-db.out
@@ -46,3 +46,63 @@ DROP
 1q: ... <quitting>
 2q: ... <quitting>
 3q: ... <quitting>
+
+-- Same test as the above, except the GRANT transaction commits before the
+-- second transaction check the wait gxid, it should get the gxid from
+-- pg_distributedlog instead of the procarray.
+CREATE ROLE regress_temp_grantee;
+CREATE
+
+3: CREATE TEMPORARY TABLE frozen_witness (x xid) distributed by (x);
+CREATE
+-- observe datfrozenxid
+3: INSERT INTO frozen_witness SELECT datfrozenxid FROM pg_database WHERE datname = current_catalog;
+INSERT 1
+1: BEGIN;
+BEGIN
+-- heap_update(pg_database)
+1: GRANT TEMP ON DATABASE isolation2test TO regress_temp_grantee;
+GRANT
+-- suspend before get 'wait gxid'
+2: SELECT gp_inject_fault('before_get_distributed_xid', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- inplace update
+2&: VACUUM (FREEZE);  <waiting ...>
+3: SELECT gp_wait_until_triggered_fault('before_get_distributed_xid', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+1: COMMIT;
+COMMIT
+3: INSERT INTO frozen_witness SELECT datfrozenxid FROM pg_database WHERE datname = current_catalog;
+INSERT 1
+3: SELECT gp_inject_fault('before_get_distributed_xid', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+2<:  <... completed>
+VACUUM
+-- Save the result in an environment variable.
+-- We get the raw xid to be sure that the age in the next query will be executed on the coordinator.
+3: @post_run 'TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo ""' : SELECT min(x::varchar::int) FROM frozen_witness;
+
+-- observe datfrozenxid
+3: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SELECT 'datfrozenxid retreated' FROM pg_database WHERE datname = current_catalog AND age(datfrozenxid) > age('@TOKEN'::xid);
+ ?column? 
+----------
+(0 rows)
+
+REVOKE ALL ON DATABASE isolation2test FROM regress_temp_grantee;
+REVOKE
+DROP ROLE regress_temp_grantee;
+DROP
+
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>

--- a/src/test/isolation2/sql/intra-grant-inplace-db.sql
+++ b/src/test/isolation2/sql/intra-grant-inplace-db.sql
@@ -31,3 +31,37 @@ DROP ROLE regress_temp_grantee;
 1q:
 2q:
 3q:
+
+-- Same test as the above, except the GRANT transaction commits before the
+-- second transaction check the wait gxid, it should get the gxid from
+-- pg_distributedlog instead of the procarray.
+CREATE ROLE regress_temp_grantee;
+
+3: CREATE TEMPORARY TABLE frozen_witness (x xid) distributed by (x);
+-- observe datfrozenxid
+3: INSERT INTO frozen_witness SELECT datfrozenxid FROM pg_database WHERE datname = current_catalog;
+1: BEGIN;
+-- heap_update(pg_database)
+1: GRANT TEMP ON DATABASE isolation2test TO regress_temp_grantee;
+-- suspend before get 'wait gxid'
+2: SELECT gp_inject_fault('before_get_distributed_xid', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+-- inplace update
+2&: VACUUM (FREEZE);
+3: SELECT gp_wait_until_triggered_fault('before_get_distributed_xid', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+1: COMMIT;
+3: INSERT INTO frozen_witness SELECT datfrozenxid FROM pg_database WHERE datname = current_catalog;
+3: SELECT gp_inject_fault('before_get_distributed_xid', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+
+2<:
+-- Save the result in an environment variable.
+-- We get the raw xid to be sure that the age in the next query will be executed on the coordinator.
+3: @post_run 'TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo ""' : SELECT min(x::varchar::int) FROM frozen_witness;
+-- observe datfrozenxid
+3: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SELECT 'datfrozenxid retreated' FROM pg_database WHERE datname = current_catalog AND age(datfrozenxid) > age('@TOKEN'::xid);
+
+REVOKE ALL ON DATABASE isolation2test FROM regress_temp_grantee;
+DROP ROLE regress_temp_grantee;
+
+1q:
+2q:
+3q:


### PR DESCRIPTION
Accept vacuum operations in XactLockTableWait assertion
Function XactLockTableWait() calls LocalXidGetDistributedXid() which
may get gxid corresponding to local wait xid from distributed clog in
case if the dtx (which we are waiting for) managed to commit by that time we
access its gxid. And for such case there is an assertion introduced by
commit https://github.com/GreengageDB/greengage/commit/13a1f66ffcc16a5369f02273addfb4b0a7bba033. The assert indicates that the commited transaction was
just running in parallel with current one, meaning there is no other
reason to access distributed transaction history. If the transaction was
commited long time ago the XactLockTableWait() would never be called.

However, there is a case when we can't compare the timestamps:
vacuum operation, which performs in-place update of pg_database
(or pg_class) without being in distributed transaction. For this
case this patch extends the assertion by allowing current timestamp to
have zero value.

The new test related to this case is added to file https://github.com/GreengageDB/greengage/commit/2c2753a071443667e5253cf0b56c5ac4bdb6b7a7.
