### PR TITLE
ADBDEV-7148: Allow multiple params in the child nodes of <dxl:TestExpr>

### DIFF
--- a/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
@@ -81,6 +81,34 @@ CMappingColIdVarPlStmt::GetOutputContext()
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CMappingColIdVarPlStmt::GetChildContexts
+//
+//	@doc:
+//		Returns the child contexts
+//
+//---------------------------------------------------------------------------
+CDXLTranslationContextArray *
+CMappingColIdVarPlStmt::GetChildContexts()
+{
+	return m_child_contexts;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CMappingColIdVarPlStmt::GetBaseTableContext
+//
+//	@doc:
+//		Returns the base table context
+//
+//---------------------------------------------------------------------------
+const CDXLTranslateContextBaseTable *
+CMappingColIdVarPlStmt::GetBaseTableContext()
+{
+	return m_base_table_context;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
 //		CMappingColIdVarPlStmt::ParamFromDXLNodeScId
 //
 //	@doc:

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -646,6 +646,9 @@ private:
 	// helper to build a Result expression with project list restricted to required columns
 	CDXLNode *PdxlnRestrictResult(CDXLNode *dxlnode, const CColRefSet *colrefs);
 
+	// helper to build a projected DXLColRefs of Result node
+	CDXLColRefArray *GetResultProjectedColRefArray(CDXLNode *dxlProjectNode);
+
 	//	helper to build subplans from correlated LOJ
 	void BuildSubplansForCorrelatedLOJ(
 		CExpression *pexprCorrelatedLOJ, CDXLColRefArray *dxl_colref_array,

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarSubPlan.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarSubPlan.h
@@ -14,6 +14,7 @@
 
 #include "gpos/base.h"
 
+#include "gpopt/base/CColRefSetIter.h"
 #include "naucrates/dxl/operators/CDXLColRef.h"
 #include "naucrates/dxl/operators/CDXLScalar.h"
 
@@ -63,8 +64,10 @@ private:
 	// test expression -- not null if quantified/existential subplan
 	CDXLNode *m_dxlnode_test_expr;
 
-	// does test expression contain outer param
-	BOOL m_outer_param;
+	// Test expression params array - the columns refs of the inner
+	// node of the subplan.
+	// Params are not serialized, so it is not visible in DXL minidump.
+	CDXLColRefArray *m_test_expr_params;
 
 public:
 	CDXLScalarSubPlan(CDXLScalarSubPlan &) = delete;
@@ -73,7 +76,8 @@ public:
 	CDXLScalarSubPlan(CMemoryPool *mp, IMDId *first_col_type_mdid,
 					  CDXLColRefArray *dxl_colref_array,
 					  EdxlSubPlanType dxl_subplan_type,
-					  CDXLNode *dxlnode_test_expr, BOOL outer_param = false);
+					  CDXLNode *dxlnode_test_expr,
+					  CDXLColRefArray *test_expr_params = nullptr);
 
 	~CDXLScalarSubPlan() override;
 
@@ -111,10 +115,11 @@ public:
 		return m_dxlnode_test_expr;
 	}
 
-	BOOL
-	FOuterParam() const
+	// return test expression params
+	CDXLColRefArray *
+	GetTestExprParams() const
 	{
-		return m_outer_param;
+		return m_test_expr_params;
 	}
 
 	// serialize operator in DXL format

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLScalarSubPlan.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLScalarSubPlan.cpp
@@ -34,13 +34,13 @@ CDXLScalarSubPlan::CDXLScalarSubPlan(CMemoryPool *mp,
 									 CDXLColRefArray *dxl_colref_array,
 									 EdxlSubPlanType dxl_subplan_type,
 									 CDXLNode *dxlnode_test_expr,
-									 BOOL outer_param)
+									 CDXLColRefArray *test_expr_params)
 	: CDXLScalar(mp),
 	  m_first_col_type_mdid(first_col_type_mdid),
 	  m_dxl_colref_array(dxl_colref_array),
 	  m_dxl_subplan_type(dxl_subplan_type),
 	  m_dxlnode_test_expr(dxlnode_test_expr),
-	  m_outer_param(outer_param)
+	  m_test_expr_params(test_expr_params)
 {
 	GPOS_ASSERT(EdxlSubPlanTypeSentinel > dxl_subplan_type);
 	GPOS_ASSERT_IMP(EdxlSubPlanTypeAny == dxl_subplan_type ||
@@ -60,6 +60,7 @@ CDXLScalarSubPlan::~CDXLScalarSubPlan()
 {
 	m_first_col_type_mdid->Release();
 	m_dxl_colref_array->Release();
+	CRefCount::SafeRelease(m_test_expr_params);
 	CRefCount::SafeRelease(m_dxlnode_test_expr);
 }
 

--- a/src/include/gpopt/translate/CMappingColIdVarPlStmt.h
+++ b/src/include/gpopt/translate/CMappingColIdVarPlStmt.h
@@ -73,6 +73,12 @@ public:
 	// get the output translator context
 	CDXLTranslateContext *GetOutputContext();
 
+	// get the array of child translator contexts
+	CDXLTranslationContextArray *GetChildContexts();
+
+	// get the base table context
+	const CDXLTranslateContextBaseTable *GetBaseTableContext();
+
 	// return the context of the DXL->PlStmt translation
 	CContextDXLToPlStmt *GetDXLToPlStmtContext();
 };

--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -154,21 +154,13 @@ private:
 	// translate subplan test expression
 	Expr *TranslateDXLSubplanTestExprToScalar(CDXLNode *test_expr_node,
 											  SubLinkType slink,
-											  CMappingColIdVar *colid_var,
-											  BOOL has_outer_refs,
-											  List **param_ids_list);
+											  CMappingColIdVar *colid_var);
 
 	// translate subplan parameters
 	void TranslateSubplanParams(SubPlan *sub_plan,
 								CDXLTranslateContext *dxl_translator_ctxt,
 								const CDXLColRefArray *outer_refs,
 								CMappingColIdVar *colid_var);
-
-	// translate subplan test expression parameters
-	void TranslateDXLTestExprScalarIdentToExpr(CDXLNode *child_node,
-											   Param *param,
-											   CDXLScalarIdent **ident,
-											   Expr **expr);
 
 	CHAR *GetSubplanAlias(ULONG plan_id);
 

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -2222,3 +2222,56 @@ select * from table1 where table1.j >
 (1 row)
 
 drop table table1, table2;
+-- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
+create temp table te1 as select 0 as i1;
+create temp table te2 as select 0 as i2;
+create temp table te3 as select i3 from (values (0), (1)) as s(i3);
+-- The first query generates a DXL with <dxl:TestExpr>, the left node (inside Comparison)
+-- of which contains a deep tree and only params (see DXL in output).
+-- The simplified  DXL is printed here because the Explain command does not display TestExpr,
+-- but we need to check what TestExpr contains and how it is processed in the DXL to Plan
+-- Statement stage. With the Postgres optimizer, this check does not matter.
+-- This testcase aims to verify that <dxl:TestExpr> with a deep tree and params in the
+-- left node is handled correctly during the DXL to Plan Statement stage.
+-- Рay attention to the Ident nodes with ColId 26 and 28. They appear from an internal
+-- subplan node.
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+set optimizer_trace_fallback=on;
+set optimizer_minidump=always;
+select * from te1 where
+  (i1 in (select i2 from te2)) in (select i3 = 1 from te3) order by i1;
+ i1 
+----
+  0
+(1 row)
+
+reset optimizer_minidump;
+reset optimizer_trace_fallback;
+-- Output DXL plan without unimportant properties.
+select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '        <', '<');
+ERROR:  could not open file "minidumps/pretty.xml" for reading: No such file or directory
+insert into te1 values (1);
+analyze te1;
+-- After adding data, the ORCA physical plan changes and DXL changes too.
+-- The outer <dxl:TestExpr> is empty. The second <dxl:TestExpr> (nested) does not contain a
+-- deep tree. The left node contains an attribute (Ident ColId="0") that is not present
+-- in the inner <dxl:SubPlan> node. Such attributes in <dxl:TestExpr> are treated as Vars.
+-- The previous case contained only params (attributes contained in the
+-- inner <dxl:SubPlan> node). This test aims to verify that <dxl:TestExpr> with params and
+-- Vars simultaneously is handled correctly during the DXL to Plan Statement stage.
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+set optimizer_trace_fallback=on;
+set optimizer_minidump=always;
+select * from te1 where
+  (i1 in (select i2 from te2)) in (select i3 = 1 from te3) order by i1;
+ i1 
+----
+  0
+  1
+(2 rows)
+
+reset optimizer_minidump;
+reset optimizer_trace_fallback;
+select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '          <', '<');
+ERROR:  could not open file "minidumps/pretty.xml" for reading: No such file or directory
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -2314,3 +2314,636 @@ select * from table1 where table1.j >
 (1 row)
 
 drop table table1, table2;
+-- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
+create temp table te1 as select 0 as i1;
+create temp table te2 as select 0 as i2;
+create temp table te3 as select i3 from (values (0), (1)) as s(i3);
+-- The first query generates a DXL with <dxl:TestExpr>, the left node (inside Comparison)
+-- of which contains a deep tree and only params (see DXL in output).
+-- The simplified  DXL is printed here because the Explain command does not display TestExpr,
+-- but we need to check what TestExpr contains and how it is processed in the DXL to Plan
+-- Statement stage. With the Postgres optimizer, this check does not matter.
+-- This testcase aims to verify that <dxl:TestExpr> with a deep tree and params in the
+-- left node is handled correctly during the DXL to Plan Statement stage.
+-- Рay attention to the Ident nodes with ColId 26 and 28. They appear from an internal
+-- subplan node.
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+set optimizer_trace_fallback=on;
+set optimizer_minidump=always;
+select * from te1 where
+  (i1 in (select i2 from te2)) in (select i3 = 1 from te3) order by i1;
+ i1 
+----
+  0
+(1 row)
+
+reset optimizer_minidump;
+reset optimizer_trace_fallback;
+-- Output DXL plan without unimportant properties.
+-- start_ignore
+\! mv $MASTER_DATA_DIRECTORY/minidumps/*.mdp $MASTER_DATA_DIRECTORY/minidumps/dump.mdp
+\! echo "import xml.dom.minidom" > $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "dom = xml.dom.minidom.parse('$MASTER_DATA_DIRECTORY/minidumps/dump.mdp')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "pretty_xml = dom.toprettyxml(indent='   ')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "with open('$MASTER_DATA_DIRECTORY/minidumps/pretty.xml', 'w') as file:" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "\tfile.write(pretty_xml)" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! python3 $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! sed -i '/Cost\|Properties\|ValuesList/d' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/TypeMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/AggMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/SortOperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/OperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+-- end_ignore
+select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '        <', '<');
+                                                       replace                                                       
+---------------------------------------------------------------------------------------------------------------------
+ {"<Plan Id=\"0\" SpaceSize=\"0\">                                                                                  +
+  <Sort SortDiscardDuplicates=\"false\">                                                                            +
+     <ProjList>                                                                                                     +
+        <ProjElem ColId=\"0\" Alias=\"i1\">                                                                         +
+           <Ident ColId=\"0\" ColName=\"i1\"/>                                                                      +
+        </ProjElem>                                                                                                 +
+     </ProjList>                                                                                                    +
+     <Filter/>                                                                                                      +
+     <SortingColumnList>                                                                                            +
+        <SortingColumn ColId=\"0\"/>                                                                                +
+     </SortingColumnList>                                                                                           +
+     <LimitCount/>                                                                                                  +
+     <LimitOffset/>                                                                                                 +
+     <Result>                                                                                                       +
+        <ProjList>                                                                                                  +
+           <ProjElem ColId=\"0\" Alias=\"i1\">                                                                      +
+              <Ident ColId=\"0\" ColName=\"i1\"/>                                                                   +
+           </ProjElem>                                                                                              +
+        </ProjList>                                                                                                 +
+        <Filter>                                                                                                    +
+           <SubPlan>                                                                                                +
+              <TestExpr>                                                                                            +
+                 <Comparison ComparisonOperator=\"=\">                                                              +
+                    <If>                                                                                            +
+                       <Comparison ComparisonOperator=\"&gt;\">                                                     +
+                          <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                             +
+                          <ConstValue/>                                                                             +
+                       </Comparison>                                                                                +
+                       <If>                                                                                         +
+                          <Comparison ComparisonOperator=\"=\">                                                     +
+                             <Ident ColId=\"28\" ColName=\"ColRef_0028\"/>                                          +
+                             <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                          +
+                          </Comparison>                                                                             +
+                          <ConstValue/>                                                                             +
+                          <ConstValue/>                                                                             +
+                       </If>                                                                                        +
+                       <ConstValue/>                                                                                +
+                    </If>                                                                                           +
+                    <Ident ColId=\"16\" ColName=\"?column?\"/>                                                      +
+                 </Comparison>                                                                                      +
+              </TestExpr>                                                                                           +
+              <ParamList>                                                                                           +
+                 <Param ColId=\"0\" ColName=\"i1\"/>                                                                +
+              </ParamList>                                                                                          +
+              <Result>                                                                                              +
+                 <ProjList>                                                                                         +
+                    <ProjElem ColId=\"26\" Alias=\"ColRef_0026\">                                                   +
+                       <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                                +
+                    </ProjElem>                                                                                     +
+                    <ProjElem ColId=\"28\" Alias=\"ColRef_0028\">                                                   +
+                       <Ident ColId=\"28\" ColName=\"ColRef_0028\"/>                                                +
+                    </ProjElem>                                                                                     +
+                    <ProjElem ColId=\"16\" Alias=\"?column?\">                                                      +
+                       <Ident ColId=\"16\" ColName=\"?column?\"/>                                                   +
+                    </ProjElem>                                                                                     +
+                 </ProjList>                                                                                        +
+                 <Filter/>                                                                                          +
+                 <OneTimeFilter/>                                                                                   +
+                 <Aggregate AggregationStrategy=\"Sorted\" StreamSafe=\"false\">                                    +
+                    <GroupingColumns>                                                                               +
+                       <GroupingColumn ColId=\"8\"/>                                                                +
+                       <GroupingColumn ColId=\"9\"/>                                                                +
+                       <GroupingColumn ColId=\"15\"/>                                                               +
+                       <GroupingColumn ColId=\"16\"/>                                                               +
+                    </GroupingColumns>                                                                              +
+                    <ProjList>                                                                                      +
+                       <ProjElem ColId=\"26\" Alias=\"ColRef_0026\">                                                +
+                          <AggFunc>                                                                                 +
+                                <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                       +
+                          </AggFunc>                                                                                +
+                       </ProjElem>                                                                                  +
+                       <ProjElem ColId=\"28\" Alias=\"ColRef_0028\">                                                +
+                          <AggFunc>                                                                                 +
+                                <Ident ColId=\"27\" ColName=\"ColRef_0027\"/>                                       +
+                          </AggFunc>                                                                                +
+                       </ProjElem>                                                                                  +
+                       <ProjElem ColId=\"16\" Alias=\"?column?\">                                                   +
+                          <Ident ColId=\"16\" ColName=\"?column?\"/>                                                +
+                       </ProjElem>                                                                                  +
+                       <ProjElem ColId=\"8\" Alias=\"i3\">                                                          +
+                          <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
+                       </ProjElem>                                                                                  +
+                       <ProjElem ColId=\"9\" Alias=\"ctid\">                                                        +
+                          <Ident ColId=\"9\" ColName=\"ctid\"/>                                                     +
+                       </ProjElem>                                                                                  +
+                       <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                              +
+                          <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                           +
+                       </ProjElem>                                                                                  +
+                    </ProjList>                                                                                     +
+                    <Filter/>                                                                                       +
+                    <Sort SortDiscardDuplicates=\"false\">                                                          +
+                       <ProjList>                                                                                   +
+                          <ProjElem ColId=\"16\" Alias=\"?column?\">                                                +
+                             <Ident ColId=\"16\" ColName=\"?column?\"/>                                             +
+                          </ProjElem>                                                                               +
+                          <ProjElem ColId=\"27\" Alias=\"ColRef_0027\">                                             +
+                             <Ident ColId=\"27\" ColName=\"ColRef_0027\"/>                                          +
+                          </ProjElem>                                                                               +
+                          <ProjElem ColId=\"8\" Alias=\"i3\">                                                       +
+                             <Ident ColId=\"8\" ColName=\"i3\"/>                                                    +
+                          </ProjElem>                                                                               +
+                          <ProjElem ColId=\"9\" Alias=\"ctid\">                                                     +
+                             <Ident ColId=\"9\" ColName=\"ctid\"/>                                                  +
+                          </ProjElem>                                                                               +
+                          <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                           +
+                             <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                        +
+                          </ProjElem>                                                                               +
+                          <ProjElem ColId=\"25\" Alias=\"ColRef_0025\">                                             +
+                             <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                          +
+                          </ProjElem>                                                                               +
+                       </ProjList>                                                                                  +
+                       <Filter/>                                                                                    +
+                       <SortingColumnList>                                                                          +
+                          <SortingColumn ColId=\"8\"/>                                                              +
+                          <SortingColumn ColId=\"9\"/>                                                              +
+                          <SortingColumn ColId=\"15\"/>                                                             +
+                          <SortingColumn ColId=\"16\"/>                                                             +
+                       </SortingColumnList>                                                                         +
+                       <LimitCount/>                                                                                +
+                       <LimitOffset/>                                                                               +
+                       <Result>                                                                                     +
+                          <ProjList>                                                                                +
+                             <ProjElem ColId=\"16\" Alias=\"?column?\">                                             +
+                                <Comparison ComparisonOperator=\"=\">                                               +
+                                   <Ident ColId=\"8\" ColName=\"i3\"/>                                              +
+                                   <ConstValue/>                                                                    +
+                                </Comparison>                                                                       +
+                             </ProjElem>                                                                            +
+                             <ProjElem ColId=\"27\" Alias=\"ColRef_0027\">                                          +
+                                <If>                                                                                +
+                                   <IsNull>                                                                         +
+                                      <Comparison ComparisonOperator=\"=\">                                         +
+                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                        +
+                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                       +
+                                      </Comparison>                                                                 +
+                                   </IsNull>                                                                        +
+                                   <ConstValue/>                                                                    +
+                                   <ConstValue/>                                                                    +
+                                </If>                                                                               +
+                             </ProjElem>                                                                            +
+                             <ProjElem ColId=\"8\" Alias=\"i3\">                                                    +
+                                <Ident ColId=\"8\" ColName=\"i3\"/>                                                 +
+                             </ProjElem>                                                                            +
+                             <ProjElem ColId=\"9\" Alias=\"ctid\">                                                  +
+                                <Ident ColId=\"9\" ColName=\"ctid\"/>                                               +
+                             </ProjElem>                                                                            +
+                             <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                        +
+                                <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                     +
+                             </ProjElem>                                                                            +
+                             <ProjElem ColId=\"25\" Alias=\"ColRef_0025\">                                          +
+                                <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                       +
+                             </ProjElem>                                                                            +
+                          </ProjList>                                                                               +
+                          <Filter/>                                                                                 +
+                          <OneTimeFilter/>                                                                          +
+                          <NestedLoopJoin JoinType=\"Left\" IndexNestedLoopJoin=\"false\" OuterRefAsParam=\"false\">+
+                             <ProjList>                                                                             +
+                                <ProjElem ColId=\"8\" Alias=\"i3\">                                                 +
+                                   <Ident ColId=\"8\" ColName=\"i3\"/>                                              +
+                                </ProjElem>                                                                         +
+                                <ProjElem ColId=\"9\" Alias=\"ctid\">                                               +
+                                   <Ident ColId=\"9\" ColName=\"ctid\"/>                                            +
+                                </ProjElem>                                                                         +
+                                <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                     +
+                                   <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                  +
+                                </ProjElem>                                                                         +
+                                <ProjElem ColId=\"17\" Alias=\"i2\">                                                +
+                                   <Ident ColId=\"17\" ColName=\"i2\"/>                                             +
+                                </ProjElem>                                                                         +
+                                <ProjElem ColId=\"25\" Alias=\"ColRef_0025\">                                       +
+                                   <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                    +
+                                </ProjElem>                                                                         +
+                             </ProjList>                                                                            +
+                             <Filter/>                                                                              +
+                             <JoinFilter>                                                                           +
+                                <ConstValue/>                                                                       +
+                             </JoinFilter>                                                                          +
+                             <Materialize Eager=\"false\">                                                          +
+                                <ProjList>                                                                          +
+                                   <ProjElem ColId=\"8\" Alias=\"i3\">                                              +
+                                      <Ident ColId=\"8\" ColName=\"i3\"/>                                           +
+                                   </ProjElem>                                                                      +
+                                   <ProjElem ColId=\"9\" Alias=\"ctid\">                                            +
+                                      <Ident ColId=\"9\" ColName=\"ctid\"/>                                         +
+                                   </ProjElem>                                                                      +
+                                   <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                  +
+                                      <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                               +
+                                   </ProjElem>                                                                      +
+                                </ProjList>                                                                         +
+                                <Filter/>                                                                           +
+                                <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                        +
+                                   <ProjList>                                                                       +
+                                      <ProjElem ColId=\"8\" Alias=\"i3\">                                           +
+                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                        +
+                                      </ProjElem>                                                                   +
+                                      <ProjElem ColId=\"9\" Alias=\"ctid\">                                         +
+                                         <Ident ColId=\"9\" ColName=\"ctid\"/>                                      +
+                                      </ProjElem>                                                                   +
+                                      <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                               +
+                                         <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                            +
+                                      </ProjElem>                                                                   +
+                                   </ProjList>                                                                      +
+                                   <Filter/>                                                                        +
+                                   <SortingColumnList/>                                                             +
+                                   <TableScan>                                                                      +
+                                      <ProjList>                                                                    +
+                                         <ProjElem ColId=\"8\" Alias=\"i3\">                                        +
+                                            <Ident ColId=\"8\" ColName=\"i3\"/>                                     +
+                                         </ProjElem>                                                                +
+                                         <ProjElem ColId=\"9\" Alias=\"ctid\">                                      +
+                                            <Ident ColId=\"9\" ColName=\"ctid\"/>                                   +
+                                         </ProjElem>                                                                +
+                                         <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                            +
+                                            <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                         +
+                                         </ProjElem>                                                                +
+                                      </ProjList>                                                                   +
+                                      <Filter/>                                                                     +
+                                      <TableDescriptor>                                                             +
+                                         <Columns>                                                                  +
+                                            <Column ColId=\"8\" Attno=\"1\" ColName=\"i3\"/>                        +
+                                            <Column ColId=\"9\" Attno=\"-1\" ColName=\"ctid\"/>                     +
+                                            <Column ColId=\"10\" Attno=\"-2\" ColName=\"xmin\"/>                    +
+                                            <Column ColId=\"11\" Attno=\"-3\" ColName=\"cmin\"/>                    +
+                                            <Column ColId=\"12\" Attno=\"-4\" ColName=\"xmax\"/>                    +
+                                            <Column ColId=\"13\" Attno=\"-5\" ColName=\"cmax\"/>                    +
+                                            <Column ColId=\"14\" Attno=\"-6\" ColName=\"tableoid\"/>                +
+                                            <Column ColId=\"15\" Attno=\"-7\" ColName=\"gp_segment_id\"/>           +
+                                         </Columns>                                                                 +
+                                      </TableDescriptor>                                                            +
+                                   </TableScan>                                                                     +
+                                </GatherMotion>                                                                     +
+                             </Materialize>                                                                         +
+                             <Materialize Eager=\"true\">                                                           +
+                                <ProjList>                                                                          +
+                                   <ProjElem ColId=\"25\" Alias=\"ColRef_0025\">                                    +
+                                      <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                 +
+                                   </ProjElem>                                                                      +
+                                   <ProjElem ColId=\"17\" Alias=\"i2\">                                             +
+                                      <Ident ColId=\"17\" ColName=\"i2\"/>                                          +
+                                   </ProjElem>                                                                      +
+                                </ProjList>                                                                         +
+                                <Filter/>                                                                           +
+                                <Result>                                                                            +
+                                   <ProjList>                                                                       +
+                                      <ProjElem ColId=\"25\" Alias=\"ColRef_0025\">                                 +
+                                         <ConstValue/>                                                              +
+                                      </ProjElem>                                                                   +
+                                      <ProjElem ColId=\"17\" Alias=\"i2\">                                          +
+                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                       +
+                                      </ProjElem>                                                                   +
+                                   </ProjList>                                                                      +
+                                   <Filter/>                                                                        +
+                                   <OneTimeFilter/>                                                                 +
+                                   <Result>                                                                         +
+                                      <ProjList>                                                                    +
+                                         <ProjElem ColId=\"17\" Alias=\"i2\">                                       +
+                                            <Ident ColId=\"17\" ColName=\"i2\"/>                                    +
+                                         </ProjElem>                                                                +
+                                      </ProjList>                                                                   +
+                                      <Filter>                                                                      +
+                                         <IsNotFalse>                                                               +
+                                            <Comparison ComparisonOperator=\"=\">                                   +
+                                               <Ident ColId=\"0\" ColName=\"i1\"/>                                  +
+                                               <Ident ColId=\"17\" ColName=\"i2\"/>                                 +
+                                            </Comparison>                                                           +
+                                         </IsNotFalse>                                                              +
+                                      </Filter>                                                                     +
+                                      <OneTimeFilter/>                                                              +
+                                      <Materialize Eager=\"false\">                                                 +
+                                         <ProjList>                                                                 +
+                                            <ProjElem ColId=\"17\" Alias=\"i2\">                                    +
+                                               <Ident ColId=\"17\" ColName=\"i2\"/>                                 +
+                                            </ProjElem>                                                             +
+                                         </ProjList>                                                                +
+                                         <Filter/>                                                                  +
+                                         <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">               +
+                                            <ProjList>                                                              +
+                                               <ProjElem ColId=\"17\" Alias=\"i2\">                                 +
+                                                  <Ident ColId=\"17\" ColName=\"i2\"/>                              +
+                                               </ProjElem>                                                          +
+                                            </ProjList>                                                             +
+                                            <Filter/>                                                               +
+                                            <SortingColumnList/>                                                    +
+                                            <TableScan>                                                             +
+                                               <ProjList>                                                           +
+                                                  <ProjElem ColId=\"17\" Alias=\"i2\">                              +
+                                                     <Ident ColId=\"17\" ColName=\"i2\"/>                           +
+                                                  </ProjElem>                                                       +
+                                               </ProjList>                                                          +
+                                               <Filter/>                                                            +
+                                               <TableDescriptor>                                                    +
+                                                  <Columns>                                                         +
+                                                     <Column ColId=\"17\" Attno=\"1\" ColName=\"i2\"/>              +
+                                                     <Column ColId=\"18\" Attno=\"-1\" ColName=\"ctid\"/>           +
+                                                     <Column ColId=\"19\" Attno=\"-2\" ColName=\"xmin\"/>           +
+                                                     <Column ColId=\"20\" Attno=\"-3\" ColName=\"cmin\"/>           +
+                                                     <Column ColId=\"21\" Attno=\"-4\" ColName=\"xmax\"/>           +
+                                                     <Column ColId=\"22\" Attno=\"-5\" ColName=\"cmax\"/>           +
+                                                     <Column ColId=\"23\" Attno=\"-6\" ColName=\"tableoid\"/>       +
+                                                     <Column ColId=\"24\" Attno=\"-7\" ColName=\"gp_segment_id\"/>  +
+                                                  </Columns>                                                        +
+                                               </TableDescriptor>                                                   +
+                                            </TableScan>                                                            +
+                                         </GatherMotion>                                                            +
+                                      </Materialize>                                                                +
+                                   </Result>                                                                        +
+                                </Result>                                                                           +
+                             </Materialize>                                                                         +
+                          </NestedLoopJoin>                                                                         +
+                       </Result>                                                                                    +
+                    </Sort>                                                                                         +
+                 </Aggregate>                                                                                       +
+              </Result>                                                                                             +
+           </SubPlan>                                                                                               +
+        </Filter>                                                                                                   +
+        <OneTimeFilter/>                                                                                            +
+        <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                +
+           <ProjList>                                                                                               +
+              <ProjElem ColId=\"0\" Alias=\"i1\">                                                                   +
+                 <Ident ColId=\"0\" ColName=\"i1\"/>                                                                +
+              </ProjElem>                                                                                           +
+           </ProjList>                                                                                              +
+           <Filter/>                                                                                                +
+           <SortingColumnList/>                                                                                     +
+           <TableScan>                                                                                              +
+              <ProjList>                                                                                            +
+                 <ProjElem ColId=\"0\" Alias=\"i1\">                                                                +
+                    <Ident ColId=\"0\" ColName=\"i1\"/>                                                             +
+                 </ProjElem>                                                                                        +
+              </ProjList>                                                                                           +
+              <Filter/>                                                                                             +
+              <TableDescriptor>                                                                                     +
+                 <Columns>                                                                                          +
+                    <Column ColId=\"0\" Attno=\"1\" ColName=\"i1\"/>                                                +
+                    <Column ColId=\"1\" Attno=\"-1\" ColName=\"ctid\"/>                                             +
+                    <Column ColId=\"2\" Attno=\"-2\" ColName=\"xmin\"/>                                             +
+                    <Column ColId=\"3\" Attno=\"-3\" ColName=\"cmin\"/>                                             +
+                    <Column ColId=\"4\" Attno=\"-4\" ColName=\"xmax\"/>                                             +
+                    <Column ColId=\"5\" Attno=\"-5\" ColName=\"cmax\"/>                                             +
+                    <Column ColId=\"6\" Attno=\"-6\" ColName=\"tableoid\"/>                                         +
+                    <Column ColId=\"7\" Attno=\"-7\" ColName=\"gp_segment_id\"/>                                    +
+                 </Columns>                                                                                         +
+              </TableDescriptor>                                                                                    +
+           </TableScan>                                                                                             +
+        </GatherMotion>                                                                                             +
+     </Result>                                                                                                      +
+  </Sort>                                                                                                           +
+       </Plan>"}
+(1 row)
+
+insert into te1 values (1);
+analyze te1;
+-- After adding data, the ORCA physical plan changes and DXL changes too.
+-- The outer <dxl:TestExpr> is empty. The second <dxl:TestExpr> (nested) does not contain a
+-- deep tree. The left node contains an attribute (Ident ColId="0") that is not present
+-- in the inner <dxl:SubPlan> node. Such attributes in <dxl:TestExpr> are treated as Vars.
+-- The previous case contained only params (attributes contained in the
+-- inner <dxl:SubPlan> node). This test aims to verify that <dxl:TestExpr> with params and
+-- Vars simultaneously is handled correctly during the DXL to Plan Statement stage.
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+set optimizer_trace_fallback=on;
+set optimizer_minidump=always;
+select * from te1 where
+  (i1 in (select i2 from te2)) in (select i3 = 1 from te3) order by i1;
+ i1 
+----
+  0
+  1
+(2 rows)
+
+reset optimizer_minidump;
+reset optimizer_trace_fallback;
+-- start_ignore
+\! mv $MASTER_DATA_DIRECTORY/minidumps/*.mdp $MASTER_DATA_DIRECTORY/minidumps/dump.mdp
+\! echo "import xml.dom.minidom" > $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "dom = xml.dom.minidom.parse('$MASTER_DATA_DIRECTORY/minidumps/dump.mdp')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "pretty_xml = dom.toprettyxml(indent='    ')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "with open('$MASTER_DATA_DIRECTORY/minidumps/pretty.xml', 'w') as file:" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "\tfile.write(pretty_xml)" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! python3 $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! sed -i '/Cost\|Properties\|ValuesList/d' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/TypeMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/AggMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/SortOperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/OperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+-- end_ignore
+select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '          <', '<');
+                                                             replace                                                             
+---------------------------------------------------------------------------------------------------------------------------------
+ {"<Plan Id=\"0\" SpaceSize=\"0\">                                                                                              +
+   <Sort SortDiscardDuplicates=\"false\">                                                                                       +
+       <ProjList>                                                                                                               +
+           <ProjElem ColId=\"0\" Alias=\"i1\">                                                                                  +
+               <Ident ColId=\"0\" ColName=\"i1\"/>                                                                              +
+           </ProjElem>                                                                                                          +
+       </ProjList>                                                                                                              +
+       <Filter/>                                                                                                                +
+       <SortingColumnList>                                                                                                      +
+           <SortingColumn ColId=\"0\"/>                                                                                         +
+       </SortingColumnList>                                                                                                     +
+       <LimitCount/>                                                                                                            +
+       <LimitOffset/>                                                                                                           +
+       <Result>                                                                                                                 +
+           <ProjList>                                                                                                           +
+               <ProjElem ColId=\"0\" Alias=\"i1\">                                                                              +
+                   <Ident ColId=\"0\" ColName=\"i1\"/>                                                                          +
+               </ProjElem>                                                                                                      +
+           </ProjList>                                                                                                          +
+           <Filter>                                                                                                             +
+               <SubPlan>                                                                                                        +
+                   <TestExpr>                                                                                                   +
+                       <ConstValue/>                                                                                            +
+                   </TestExpr>                                                                                                  +
+                   <ParamList>                                                                                                  +
+                       <Param ColId=\"0\" ColName=\"i1\"/>                                                                      +
+                   </ParamList>                                                                                                 +
+                   <Result>                                                                                                     +
+                       <ProjList>                                                                                               +
+                           <ProjElem ColId=\"16\" Alias=\"?column?\">                                                           +
+                               <Ident ColId=\"16\" ColName=\"?column?\"/>                                                       +
+                           </ProjElem>                                                                                          +
+                       </ProjList>                                                                                              +
+                       <Filter>                                                                                                 +
+                           <Comparison ComparisonOperator=\"=\">                                                                +
+                               <Ident ColId=\"29\" ColName=\"ColRef_0029\"/>                                                    +
+                               <Ident ColId=\"16\" ColName=\"?column?\"/>                                                       +
+                           </Comparison>                                                                                        +
+                       </Filter>                                                                                                +
+                       <OneTimeFilter/>                                                                                         +
+                       <Result>                                                                                                 +
+                           <ProjList>                                                                                           +
+                               <ProjElem ColId=\"16\" Alias=\"?column?\">                                                       +
+                                   <Comparison ComparisonOperator=\"=\">                                                        +
+                                       <Ident ColId=\"8\" ColName=\"i3\"/>                                                      +
+                                       <ConstValue/>                                                                            +
+                                   </Comparison>                                                                                +
+                               </ProjElem>                                                                                      +
+                               <ProjElem ColId=\"29\" Alias=\"ColRef_0029\">                                                    +
+                                   <SubPlan>                                                                                    +
+                                       <TestExpr>                                                                               +
+                                           <Comparison ComparisonOperator=\"=\">                                                +
+                                               <Ident ColId=\"0\" ColName=\"i1\"/>                                              +
+                                               <Ident ColId=\"17\" ColName=\"i2\"/>                                             +
+                                           </Comparison>                                                                        +
+                                       </TestExpr>                                                                              +
+                                       <ParamList/>                                                                             +
+                                       <Result>                                                                                 +
+                                           <ProjList>                                                                           +
+                                               <ProjElem ColId=\"17\" Alias=\"i2\">                                             +
+                                                   <Ident ColId=\"17\" ColName=\"i2\"/>                                         +
+                                               </ProjElem>                                                                      +
+                                           </ProjList>                                                                          +
+                                           <Filter/>                                                                            +
+                                           <OneTimeFilter/>                                                                     +
+                                           <Result>                                                                             +
+                                               <ProjList>                                                                       +
+                                                   <ProjElem ColId=\"29\" Alias=\"ColRef_0029\">                                +
+                                                       <ConstValue/>                                                            +
+                                                   </ProjElem>                                                                  +
+                                                   <ProjElem ColId=\"17\" Alias=\"i2\">                                         +
+                                                       <Ident ColId=\"17\" ColName=\"i2\"/>                                     +
+                                                   </ProjElem>                                                                  +
+                                               </ProjList>                                                                      +
+                                               <Filter/>                                                                        +
+                                               <OneTimeFilter/>                                                                 +
+                                               <Materialize Eager=\"true\">                                                     +
+                                                   <ProjList>                                                                   +
+                                                       <ProjElem ColId=\"17\" Alias=\"i2\">                                     +
+                                                           <Ident ColId=\"17\" ColName=\"i2\"/>                                 +
+                                                       </ProjElem>                                                              +
+                                                   </ProjList>                                                                  +
+                                                   <Filter/>                                                                    +
+                                                   <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                 +
+                                                       <ProjList>                                                               +
+                                                           <ProjElem ColId=\"17\" Alias=\"i2\">                                 +
+                                                               <Ident ColId=\"17\" ColName=\"i2\"/>                             +
+                                                           </ProjElem>                                                          +
+                                                       </ProjList>                                                              +
+                                                       <Filter/>                                                                +
+                                                       <SortingColumnList/>                                                     +
+                                                       <TableScan>                                                              +
+                                                           <ProjList>                                                           +
+                                                               <ProjElem ColId=\"17\" Alias=\"i2\">                             +
+                                                                   <Ident ColId=\"17\" ColName=\"i2\"/>                         +
+                                                               </ProjElem>                                                      +
+                                                           </ProjList>                                                          +
+                                                           <Filter/>                                                            +
+                                                           <TableDescriptor>                                                    +
+                                                               <Columns>                                                        +
+                                                                   <Column ColId=\"17\" Attno=\"1\" ColName=\"i2\"/>            +
+                                                                   <Column ColId=\"18\" Attno=\"-1\" ColName=\"ctid\"/>         +
+                                                                   <Column ColId=\"19\" Attno=\"-2\" ColName=\"xmin\"/>         +
+                                                                   <Column ColId=\"20\" Attno=\"-3\" ColName=\"cmin\"/>         +
+                                                                   <Column ColId=\"21\" Attno=\"-4\" ColName=\"xmax\"/>         +
+                                                                   <Column ColId=\"22\" Attno=\"-5\" ColName=\"cmax\"/>         +
+                                                                   <Column ColId=\"23\" Attno=\"-6\" ColName=\"tableoid\"/>     +
+                                                                   <Column ColId=\"24\" Attno=\"-7\" ColName=\"gp_segment_id\"/>+
+                                                               </Columns>                                                       +
+                                                           </TableDescriptor>                                                   +
+                                                       </TableScan>                                                             +
+                                                   </GatherMotion>                                                              +
+                                               </Materialize>                                                                   +
+                                           </Result>                                                                            +
+                                       </Result>                                                                                +
+                                   </SubPlan>                                                                                   +
+                               </ProjElem>                                                                                      +
+                           </ProjList>                                                                                          +
+                           <Filter/>                                                                                            +
+                           <OneTimeFilter/>                                                                                     +
+                           <Materialize Eager=\"true\">                                                                         +
+                               <ProjList>                                                                                       +
+                                   <ProjElem ColId=\"8\" Alias=\"i3\">                                                          +
+                                       <Ident ColId=\"8\" ColName=\"i3\"/>                                                      +
+                                   </ProjElem>                                                                                  +
+                               </ProjList>                                                                                      +
+                               <Filter/>                                                                                        +
+                               <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                     +
+                                   <ProjList>                                                                                   +
+                                       <ProjElem ColId=\"8\" Alias=\"i3\">                                                      +
+                                           <Ident ColId=\"8\" ColName=\"i3\"/>                                                  +
+                                       </ProjElem>                                                                              +
+                                   </ProjList>                                                                                  +
+                                   <Filter/>                                                                                    +
+                                   <SortingColumnList/>                                                                         +
+                                   <TableScan>                                                                                  +
+                                       <ProjList>                                                                               +
+                                           <ProjElem ColId=\"8\" Alias=\"i3\">                                                  +
+                                               <Ident ColId=\"8\" ColName=\"i3\"/>                                              +
+                                           </ProjElem>                                                                          +
+                                       </ProjList>                                                                              +
+                                       <Filter/>                                                                                +
+                                       <TableDescriptor>                                                                        +
+                                           <Columns>                                                                            +
+                                               <Column ColId=\"8\" Attno=\"1\" ColName=\"i3\"/>                                 +
+                                               <Column ColId=\"9\" Attno=\"-1\" ColName=\"ctid\"/>                              +
+                                               <Column ColId=\"10\" Attno=\"-2\" ColName=\"xmin\"/>                             +
+                                               <Column ColId=\"11\" Attno=\"-3\" ColName=\"cmin\"/>                             +
+                                               <Column ColId=\"12\" Attno=\"-4\" ColName=\"xmax\"/>                             +
+                                               <Column ColId=\"13\" Attno=\"-5\" ColName=\"cmax\"/>                             +
+                                               <Column ColId=\"14\" Attno=\"-6\" ColName=\"tableoid\"/>                         +
+                                               <Column ColId=\"15\" Attno=\"-7\" ColName=\"gp_segment_id\"/>                    +
+                                           </Columns>                                                                           +
+                                       </TableDescriptor>                                                                       +
+                                   </TableScan>                                                                                 +
+                               </GatherMotion>                                                                                  +
+                           </Materialize>                                                                                       +
+                       </Result>                                                                                                +
+                   </Result>                                                                                                    +
+               </SubPlan>                                                                                                       +
+           </Filter>                                                                                                            +
+           <OneTimeFilter/>                                                                                                     +
+           <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                         +
+               <ProjList>                                                                                                       +
+                   <ProjElem ColId=\"0\" Alias=\"i1\">                                                                          +
+                       <Ident ColId=\"0\" ColName=\"i1\"/>                                                                      +
+                   </ProjElem>                                                                                                  +
+               </ProjList>                                                                                                      +
+               <Filter/>                                                                                                        +
+               <SortingColumnList/>                                                                                             +
+               <TableScan>                                                                                                      +
+                   <ProjList>                                                                                                   +
+                       <ProjElem ColId=\"0\" Alias=\"i1\">                                                                      +
+                           <Ident ColId=\"0\" ColName=\"i1\"/>                                                                  +
+                       </ProjElem>                                                                                              +
+                   </ProjList>                                                                                                  +
+                   <Filter/>                                                                                                    +
+                   <TableDescriptor>                                                                                            +
+                       <Columns>                                                                                                +
+                           <Column ColId=\"0\" Attno=\"1\" ColName=\"i1\"/>                                                     +
+                           <Column ColId=\"1\" Attno=\"-1\" ColName=\"ctid\"/>                                                  +
+                           <Column ColId=\"2\" Attno=\"-2\" ColName=\"xmin\"/>                                                  +
+                           <Column ColId=\"3\" Attno=\"-3\" ColName=\"cmin\"/>                                                  +
+                           <Column ColId=\"4\" Attno=\"-4\" ColName=\"xmax\"/>                                                  +
+                           <Column ColId=\"5\" Attno=\"-5\" ColName=\"cmax\"/>                                                  +
+                           <Column ColId=\"6\" Attno=\"-6\" ColName=\"tableoid\"/>                                              +
+                           <Column ColId=\"7\" Attno=\"-7\" ColName=\"gp_segment_id\"/>                                         +
+                       </Columns>                                                                                               +
+                   </TableDescriptor>                                                                                           +
+               </TableScan>                                                                                                     +
+           </GatherMotion>                                                                                                      +
+       </Result>                                                                                                                +
+   </Sort>                                                                                                                      +
+         </Plan>"}
+(1 row)
+
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -1108,3 +1108,86 @@ select * from table1 where table1.j >
     (select i from table2, (values (1), (2), (3)) k (a) where a > table1.i limit 1);
 
 drop table table1, table2;
+
+-- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
+create temp table te1 as select 0 as i1;
+create temp table te2 as select 0 as i2;
+create temp table te3 as select i3 from (values (0), (1)) as s(i3);
+
+-- The first query generates a DXL with <dxl:TestExpr>, the left node (inside Comparison)
+-- of which contains a deep tree and only params (see DXL in output).
+-- The simplified  DXL is printed here because the Explain command does not display TestExpr,
+-- but we need to check what TestExpr contains and how it is processed in the DXL to Plan
+-- Statement stage. With the Postgres optimizer, this check does not matter.
+-- This testcase aims to verify that <dxl:TestExpr> with a deep tree and params in the
+-- left node is handled correctly during the DXL to Plan Statement stage.
+-- Рay attention to the Ident nodes with ColId 26 and 28. They appear from an internal
+-- subplan node.
+
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+
+set optimizer_trace_fallback=on;
+set optimizer_minidump=always;
+select * from te1 where
+  (i1 in (select i2 from te2)) in (select i3 = 1 from te3) order by i1;
+reset optimizer_minidump;
+reset optimizer_trace_fallback;
+
+-- Output DXL plan without unimportant properties.
+-- start_ignore
+\! mv $MASTER_DATA_DIRECTORY/minidumps/*.mdp $MASTER_DATA_DIRECTORY/minidumps/dump.mdp
+\! echo "import xml.dom.minidom" > $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "dom = xml.dom.minidom.parse('$MASTER_DATA_DIRECTORY/minidumps/dump.mdp')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "pretty_xml = dom.toprettyxml(indent='   ')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "with open('$MASTER_DATA_DIRECTORY/minidumps/pretty.xml', 'w') as file:" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "\tfile.write(pretty_xml)" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! python3 $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! sed -i '/Cost\|Properties\|ValuesList/d' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/TypeMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/AggMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/SortOperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/OperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+-- end_ignore
+
+select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '        <', '<');
+
+insert into te1 values (1);
+analyze te1;
+-- After adding data, the ORCA physical plan changes and DXL changes too.
+-- The outer <dxl:TestExpr> is empty. The second <dxl:TestExpr> (nested) does not contain a
+-- deep tree. The left node contains an attribute (Ident ColId="0") that is not present
+-- in the inner <dxl:SubPlan> node. Such attributes in <dxl:TestExpr> are treated as Vars.
+-- The previous case contained only params (attributes contained in the
+-- inner <dxl:SubPlan> node). This test aims to verify that <dxl:TestExpr> with params and
+-- Vars simultaneously is handled correctly during the DXL to Plan Statement stage.
+
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+
+set optimizer_trace_fallback=on;
+set optimizer_minidump=always;
+select * from te1 where
+  (i1 in (select i2 from te2)) in (select i3 = 1 from te3) order by i1;
+reset optimizer_minidump;
+reset optimizer_trace_fallback;
+
+-- start_ignore
+\! mv $MASTER_DATA_DIRECTORY/minidumps/*.mdp $MASTER_DATA_DIRECTORY/minidumps/dump.mdp
+\! echo "import xml.dom.minidom" > $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "dom = xml.dom.minidom.parse('$MASTER_DATA_DIRECTORY/minidumps/dump.mdp')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "pretty_xml = dom.toprettyxml(indent='    ')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "with open('$MASTER_DATA_DIRECTORY/minidumps/pretty.xml', 'w') as file:" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "\tfile.write(pretty_xml)" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! python3 $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! sed -i '/Cost\|Properties\|ValuesList/d' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/TypeMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/AggMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/SortOperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/OperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+-- end_ignore
+
+select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '          <', '<');
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps


### PR DESCRIPTION
Allow multiple params in the child nodes of <dxl:TestExpr> (#92)

Problem definition:
When processing a query with a subquery (example in the test), the "Attribute
number ... not found in project list" error could be output. This happened in
the DXL to Plan Statement stage because the attribute was not found in the
list of column references (CMappingColIdVar) when processing the left node of
<dxl:TestExpr>. <dxl:TestExpr> is part of the <dxl:SubPlan> node and the
TestExpr acts as a filter when a tuple is returned from SubPlan at execution
(see ExecScanSubPlan()).
<dxl:TestExpr> is processed by TranslateDXLSubplanTestExprToScalar(). The
left node was processed depending on the flag "has_outer_refs". If it was true,
the TranslateDXLTestExprScalarIdentToExpr() was called to read one <dxl:Ident>
and then convert it to a param. If it was false, the function of handling the
DXL tree was called without taking the param into account. In our case, the
"has_outer_refs" flag was false.
"has_outer_refs" was defined at the DXL generation stage in
PdxlnQuantifiedSubplan(). The params of TestExpr are the common columns of
the scalar and the inner part of PhysicalCorrelated***NLJoin node (see the
physical plan).
As it turns out, the left node can contain more than one param, and at this
stage we need to save the list of attributes that act as TestExpr params,
because in further processing we will not be able to determine them. So
instead of a flag "has_outer_refs", we need to form a list of TestExpr params.
However, if I fixed the determination of the TestExpr params, another error
occurred - "Unsupported subplan test expression", since the left node
contained a tree, but TranslateDXLSubplanTestExprToScalar() only supported
id and cast(id). Also, this function read the TestExpr param directly from
the <dxl:Ident> node (without using CMappingColIdVar).
Therefore, the tree processing function (TranslateDXLToScalar) is used to
process the left node of TestExpr. In order for this function to correctly
process the TestExpr params, the corresponding list of column references
(CMappingColIdVar) is initialized.

Problem summary:
The <dxl:TestExpr> handler could output errors:
"Attribute number ... not found in project list" and "Unsupported subplan
test expression".
The first error occurred if a reference to an attribute processed as a TestExpr
param (don't confuse with subplan params <dxl:ParamList>) was not found. This
occurred due to incorrect detection of the presence of TestExpr params
(m_outer_param flag) at the DXL generation stage in the
PdxlnQuantifiedSubplan function and the lack of adding TestExpr params to the
list of references to attributes (CMappingColIdVar) at the <dxl:TestExpr>
transforming stage.
The second error occurred if the left node <dxl:TestExpr> contained a tree with
the TestExpr param, since only id and cast(id) were supported (the param was
read directly from the node).
See the minidump for more information, but keep in mind that the TestExpr param
presence flag (m_outer_param) is not serialized.
Support for one param in the left node of TestExpr was added in ac6ce1a.

Possible solutions:
The "Unsupported subplan test expression" error is fixed by using the
TranslateDXLToScalar function, which allows processing the tree in the child
nodes of TestExpr (mostly the left node). But in this case, it is impossible
to get the TestExpr param (currently it is read directly from node). It is
impossible to determine whether this is a param or a Var (there are no
markers indicating this), if there is more than one attribute in the
tree - this will cause the error "Attribute number ... not found in project
list". Therefore, the TestExpr params must be obtained in a separate structure
and added in advance to the list of references to attributes
(CMappingColIdVar). Determinating the TestExpr params and adding them to the
CMappingColIdVar before handling DXL fixes the "Attribute number ... not
found in project list" error, but since the left node may contain a tree,
this will cause the "Unsupported subplan test expression" error. Therefore,
these errors must be fixed simultaneously.

Solution:
1. Determine the necessary columns as TestExpr params at the DXL generating
stage;
2. Add references to attributes processed as TestExpr params at the DXL to
Plan Statement stage (prefilling CMappingColIdVar);
3. Add support for processing a tree with params in the left node of TestExpr.

Changes:
At the DXL generation stage (in the PdxlnQuantifiedSubplan function),
the determination of the TestExpr params for PhysicalCorrelated***NLJoin
nodes has been unified. Instead of the "has_outer_refs" flag, the presence
of TestExpr params is now determined by the array of columns -
m_test_expr_params (passed via the CDXLScalarSubPlan class, not serialized).
At the DXL to Plan Statement stage in the subplan handler, a copy of the
mapping (list of references to columns) of the subplan is created to
handle <dxl:TestExpr>, including the TestExpr params (obtained from
m_test_expr_params). We use the copy because we do not want the TestExpr
params to be mixed with the subplan params.
In the <dxl:TestExpr> handler, the TranslateDXLToScalar function is
used instead of TranslateDXLTestExprScalarIdentToExpr for the left node,
which allows processing trees.
For the right node <dxl:TestExpr>, TranslateDXLToScalar is also used for
unification purposes. The TranslateDXLTestExprScalarIdentToExpr function
has been removed as unnecessary.

(cherry picked from commit 5173e2fcfeeea60f02b7fe8aca5ac0f9996824fb)

Changes compared to the original commit:

1) NULL replaced with nullptr

2) A new local variable plstmt has been added to the
CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar function, reducing
duplicate code.

3) The dxl_to_plstmt_ctxt->GetNextParamId function call in the
CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar function has been
adapted for 7X by adding a new local variable type_oid.

4) Test output has been adapted for 7X.

5) The tables in the test have been renamed and made temporary so that they do
not interfere with tables in parallel tests, such as join.

Ticket: ADBDEV-7148

---
Note: do not squash to preserve authorship