### PR TITLE
Fix functions for working with orphaned files to handle custom tablespaces correctly

### DIFF
--- a/gpcontrib/gp_toolkit/Makefile
+++ b/gpcontrib/gp_toolkit/Makefile
@@ -2,7 +2,7 @@ EXTENSION = gp_toolkit
 DATA = gp_toolkit--1.1--1.2.sql gp_toolkit--1.0--1.1.sql gp_toolkit--1.0.sql \
 		gp_toolkit--1.2--1.3.sql gp_toolkit--1.3.sql gp_toolkit--1.3--1.4.sql \
 		gp_toolkit--1.4--1.5.sql gp_toolkit--1.5--1.6.sql \
-		gp_toolkit--1.6--1.7.sql
+		gp_toolkit--1.6--1.7.sql gp_toolkit--1.7--1.8.sql
 MODULE_big = gp_toolkit
 ifeq ($(shell uname -s), Linux)
 OBJS = resgroup.o gp_partition_maint.o gp_segment_files_maint.o

--- a/gpcontrib/gp_toolkit/gp_toolkit--1.7--1.8.sql
+++ b/gpcontrib/gp_toolkit/gp_toolkit--1.7--1.8.sql
@@ -1,0 +1,466 @@
+/* gpcontrib/gp_toolkit/gp_toolkit--1.7--1.8.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION gp_toolkit UPDATE TO '1.8" to load this file. \quit
+
+--------------------------------------------------------------------------------
+-- @view:
+--        gp_toolkit.__get_exist_files
+--
+-- @doc:
+--        Retrieve a list of all existing data files in the default
+--        and user tablespaces.
+--
+--------------------------------------------------------------------------------
+CREATE OR REPLACE VIEW gp_toolkit.__get_exist_files AS
+WITH Tablespaces AS (
+-- 1. The default tablespace
+    SELECT t.oid AS tablespace, 'base/' || d.oid::text AS dirname
+    FROM pg_tablespace t, pg_database d 
+    WHERE t.spcname = 'pg_default' AND d.datname = current_database()
+    UNION
+-- 2. The global tablespace
+    SELECT oid AS tablespace, 'global' AS dirname
+    FROM pg_tablespace
+    WHERE spcname = 'pg_global'
+    UNION
+-- 3. The user-defined tablespaces
+    SELECT ts.oid AS tablespace,
+       'pg_tblspc/' || ts.oid::text || '/' || get_tablespace_version_directory_name() || '/' ||
+         (SELECT d.oid::text FROM pg_database d WHERE d.datname = current_database()) AS dirname
+    FROM pg_tablespace ts
+    WHERE ts.spcname NOT IN ('pg_default', 'pg_global')
+)
+SELECT tablespace, files.filename, dirname || '/' || files.filename AS filepath
+FROM Tablespaces, pg_ls_dir(dirname, true, false) AS files(filename);
+
+--------------------------------------------------------------------------------
+-- @view:
+--        __gp_toolkit.__get_expect_files
+--
+-- @doc:
+--        Retrieve a list of expected data files in the database,
+--        using the knowledge from catalogs. This does not include
+--        any extended data files.
+--
+--------------------------------------------------------------------------------
+CREATE OR REPLACE VIEW gp_toolkit.__get_expect_files AS
+SELECT CASE WHEN s.reltablespace = 0 THEN
+            (SELECT dattablespace FROM pg_database WHERE datname = current_database())
+            ELSE s.reltablespace END AS tablespace,
+        s.relname, a.amname AS AM,
+        (CASE WHEN s.relfilenode != 0 THEN s.relfilenode ELSE pg_relation_filenode(s.oid) END)::text AS filename
+FROM pg_class s
+LEFT JOIN pg_am a ON s.relam = a.oid
+WHERE s.relkind != 'v'; -- view could have valid relfilenode if created from a table, but its relfile is gone
+
+--------------------------------------------------------------------------------
+-- @view:
+--        gp_toolkit.__get_expect_files_ext
+--
+-- @doc:
+--        Retrieve a list of expected data files in the database,
+--        using the knowledge from catalogs. This includes all
+--        the extended data files for AO/CO tables.
+--        But ignore those w/ eof=0. They might be created just for
+--        modcount whereas no data has ever been inserted to the seg.
+--        Or, they could be created when a seg has only aborted rows.
+--        In both cases, we can ignore these segs, because no matter
+--        whether the data files exist or not, the rest of the system
+--        can handle them gracefully.
+--        Also exclude views which could have valid relfilenode if 
+--        created from a table, but their relfiles are gone.
+--
+--------------------------------------------------------------------------------
+CREATE OR REPLACE VIEW gp_toolkit.__get_expect_files_ext AS
+WITH class_info AS (
+  SELECT c.oid, c.relname, c.relkind, a.amname AS AM, c.relfilenode,
+    CASE WHEN reltablespace = 0 THEN 
+      (SELECT dattablespace FROM pg_database WHERE datname = current_database())
+      ELSE reltablespace END AS tablespace
+  FROM pg_class c LEFT JOIN pg_am a ON c.relam = a.oid
+)
+SELECT tablespace, relname, AM,
+       (CASE WHEN relfilenode != 0 THEN relfilenode ELSE pg_relation_filenode(oid) END)::text AS filename
+FROM class_info
+WHERE relkind != 'v'
+UNION
+-- AO extended files
+SELECT c.tablespace, c.relname, c.AM,
+       format(c.relfilenode::text || '.' || s.segno::text) AS filename
+FROM gp_toolkit.__get_ao_segno_list() s
+JOIN class_info c ON s.relid = c.oid
+WHERE s.eof > 0 AND c.relkind != 'v'
+UNION
+-- CO extended files
+SELECT c.tablespace, c.relname, c.AM,
+       format(c.relfilenode::text || '.' || s.segno::text) AS filename
+FROM gp_toolkit.__get_aoco_segno_list() s
+JOIN class_info c ON s.relid = c.oid
+WHERE s.eof > 0 AND c.relkind != 'v';
+
+-------------------------------------------------------------------------------
+-- @function:
+--        gp_toolkit.__gp_check_orphaned_files_func
+--
+-- @in:
+--
+-- @out:
+--        gp_segment_id int - segment content ID
+--        tablespace oid - tablespace OID
+--        filename text - name of the orphaned file
+--        filepath text - relative path of the orphaned file in data directory
+--
+-- @doc:
+--        (Internal UDF, shouldn't be exposed)
+--        UDF to retrieve orphaned files and their paths.
+--
+--        Locks pg_class in shared mode and ensures no transactions are running.
+--        May pause and wait if pg_class is already locked by another process.
+--
+--------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION gp_toolkit.__gp_check_orphaned_files_func()
+RETURNS TABLE (
+    gp_segment_id int,
+    tablespace oid,
+    filename text,
+    filepath text
+)
+SET search_path = pg_catalog, pg_temp
+LANGUAGE plpgsql AS $$
+BEGIN
+    -- lock pg_class so that no one will be adding/altering relfilenodes
+    -- NOTE: This operation may pause and wait if pg_class is already locked
+    -- by another transaction! We intentionally do not use NOWAIT here.
+    -- NOWAIT inside PL/pgSQL does not behave as expected: instead of throwing
+    -- exception when the lock is unavailable, it silently waits.
+    LOCK TABLE pg_class IN SHARE MODE;
+
+    -- make sure no other active/idle transaction is running
+    IF EXISTS (
+        SELECT 1
+        FROM gp_stat_activity
+        WHERE
+        sess_id <> -1 AND backend_type IN ('client backend', 'unknown process type') -- exclude background worker types
+        AND sess_id <> current_setting('gp_session_id')::int -- Exclude the current session
+        AND state <> 'idle' -- Exclude idle session like GDD
+    ) THEN
+        RAISE EXCEPTION 'There is a client session running on one or more segment. Aborting...';
+    END IF;
+
+    -- force checkpoint to make sure we do not include files that are normally pending delete
+    CHECKPOINT;
+
+    RETURN QUERY
+    SELECT v.gp_segment_id, v.tablespace, v.filename, v.filepath
+    FROM gp_dist_random('gp_toolkit.__check_orphaned_files') v
+    UNION ALL
+    SELECT -1 AS gp_segment_id, v.tablespace, v.filename, v.filepath
+    FROM gp_toolkit.__check_orphaned_files v;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION __gp_check_orphaned_files_func() TO public;
+
+CREATE TYPE gp_toolkit.__gp_move_orphaned_files_pairs AS (
+    spc_oid        oid,        -- tablespace oid
+    target_path    text        -- directory to move orphaned files to
+);
+
+--------------------------------------------------------------------------------
+-- @function:
+--        gp_toolkit.__gp_move_orphaned_files
+--
+-- @in:
+--        tablespace_location_pairs __gp_move_orphaned_files_pairs
+--                array of pairs {tablespace_oid, target_path}. When
+--                process_all_tablespaces = TRUE the array must contain
+--                exactly one element; its tablespace_oid component is
+--                ignored and its target_path component designates the
+--                directory into which all orphaned files are moved.
+--
+--        process_all_tablespaces boolean default false
+--                if TRUE, operate on orphaned files belonging to every
+--                tablespace found on the segment; otherwise move files only
+--                for the OIDs explicitly listed in tablespace_location_pairs.
+--
+-- @out:
+--        gp_segment_id int - segment content ID
+--        move_success bool - TRUE if the move succeeded
+--        oldpath text - absolute pathname before the move
+--        newpath text - absolute pathname after the move
+--
+-- @doc:
+--        Internal helper invoked by the user‑facing wrappers.
+--
+--        Because the move relies on the rename syscall, the target
+--        directory must reside on the same filesystem as the source file or
+--        the operation will fail with "Invalid cross‑device link".
+--
+--        Locks pg_class in shared mode and ensures no transactions are running.
+--        May pause and wait if pg_class is already locked by another process.
+--
+--------------------------------------------------------------------------------
+CREATE FUNCTION gp_toolkit.__gp_move_orphaned_files(
+        tablespace_location_pairs gp_toolkit.__gp_move_orphaned_files_pairs[],
+        process_all_tablespaces bool DEFAULT false)
+RETURNS TABLE (
+    gp_segment_id int,
+    move_success bool,
+    oldpath text,
+    newpath text
+)
+SET search_path = pg_catalog, pg_temp
+LANGUAGE plpgsql AS $$
+DECLARE
+    pair gp_toolkit.__gp_move_orphaned_files_pairs;
+BEGIN
+    -- if process_all_tablespaces is true, tablespace_location_pairs should contain only one element
+    -- with directory where we move the orphaned files from all tablespaces.
+    IF process_all_tablespaces THEN
+        IF array_length(tablespace_location_pairs, 1) <> 1 THEN
+            RAISE EXCEPTION 'When process_all_tablespaces is true, tablespace_location_pairs must contain exactly one element.';
+        END IF;
+    END IF;
+
+    -- lock pg_class so that no one will be adding/altering relfilenodes
+    -- NOTE: This operation may pause and wait if pg_class is already locked
+    -- by another transaction! We intentionally do not use NOWAIT here.
+    -- NOWAIT inside PL/pgSQL does not behave as expected: instead of throwing
+    -- exception when the lock is unavailable, it silently waits.
+    LOCK TABLE pg_class IN SHARE MODE;
+
+    -- make sure no other active/idle transaction is running
+    IF EXISTS (
+        SELECT 1
+        FROM gp_stat_activity
+        WHERE
+        sess_id <> -1 AND backend_type IN ('client backend', 'unknown process type') -- exclude background worker types
+        AND sess_id <> current_setting('gp_session_id')::int -- Exclude the current session
+        AND state <> 'idle' -- Exclude idle session like GDD
+    ) THEN
+        RAISE EXCEPTION 'There is a client session running on one or more segment. Aborting...';
+    END IF;
+
+    -- force checkpoint to make sure we do not include files that are normally pending delete
+    CHECKPOINT;
+
+    -- process each (tablespace oid -> target_path) pair
+    FOREACH pair IN ARRAY tablespace_location_pairs LOOP
+        RETURN QUERY
+        SELECT
+            q.gp_segment_id,
+            q.move_success,
+            q.oldpath,
+            q.newpath
+        FROM 
+        (
+            SELECT s1.gp_segment_id, s1.oldpath, s1.newpath, pg_file_rename(s1.oldpath, s1.newpath, NULL) AS move_success
+            FROM
+            (
+                SELECT
+                    o.gp_segment_id,
+                    s.setting || '/' || o.filepath AS oldpath,
+                    pair.target_path || '/seg' || o.gp_segment_id::text || '_' || REPLACE(o.filepath, '/', '_') AS newpath
+                FROM gp_toolkit.__check_orphaned_files o
+                JOIN gp_settings s on o.gp_segment_id = s.gp_segment_id
+                WHERE s.name = 'data_directory' AND (o.tablespace = pair.spc_oid OR process_all_tablespaces)
+            ) s1
+            UNION ALL
+            -- segments
+            SELECT s2.gp_segment_id, s2.oldpath, s2.newpath, pg_file_rename(s2.oldpath, s2.newpath, NULL) AS move_success
+            FROM
+            (
+                SELECT
+                    o.gp_segment_id,
+                    s.setting || '/' || o.filepath AS oldpath,
+                    pair.target_path || '/seg' || o.gp_segment_id::text || '_' || REPLACE(o.filepath, '/', '_') AS newpath
+                FROM gp_dist_random('gp_toolkit.__check_orphaned_files') o
+                JOIN gp_settings s on o.gp_segment_id = s.gp_segment_id
+                WHERE s.name = 'data_directory' AND (o.tablespace = pair.spc_oid OR process_all_tablespaces)
+            ) s2
+        ) AS q
+        ORDER BY q.gp_segment_id, q.oldpath;
+    END LOOP;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        DECLARE
+            original_msg text;
+            original_hint text;
+            original_detail text;
+            original_code text;
+        BEGIN
+            GET STACKED DIAGNOSTICS
+                original_msg    = MESSAGE_TEXT,
+                original_hint   = PG_EXCEPTION_HINT,
+                original_detail = PG_EXCEPTION_DETAIL,
+                original_code   = RETURNED_SQLSTATE;
+
+            RAISE EXCEPTION '%', original_msg
+            USING
+                ERRCODE = original_code,
+                DETAIL  = original_detail,
+                HINT    = CASE WHEN original_hint IS NOT NULL AND original_hint <> ''
+                              THEN original_hint || E'\n'
+                              ELSE ''
+                          END ||
+                            'Operation was interrupted with an error. Only some or no files were renamed. ' ||
+                            'Use gp_check_orphaned_files to see remaining files. Then call ' ||
+                            'gp_move_orphaned_files_by_tablespace_location(tablespace_oid, /path) or ' ||
+                            'gp_move_orphaned_files_by_tablespace_location(ARRAY[''{tablespace_oid, /path}'', ...]) ' ||
+                            'to move files for specific tablespaces.';
+        END;
+END;
+$$;
+
+--------------------------------------------------------------------------------
+-- @function:
+--        gp_toolkit.gp_move_orphaned_files
+--
+-- @in:
+--        target_location text
+--                Absolute path of the directory to which all orphaned files
+--                should be moved. The directory must be located on the same
+--                filesystem as each orphaned file on the segment; otherwise
+--                rename will fail.
+--
+-- @out:
+--        gp_segment_id int - segment content ID
+--        move_success bool - TRUE if the move succeeded
+--        oldpath text - absolute pathname before the move
+--        newpath text - absolute pathname after the move
+--
+-- @doc:
+--        Moves all orphaned files detected on a segment
+--        to a single target directory. If tablespaces reside on
+--        multiple filesystems, use
+--        gp_move_orphaned_files_by_tablespace_location instead.
+--
+--        Locks pg_class in shared mode and ensures no transactions are running.
+--        May pause and wait if pg_class is already locked by another process.
+--
+--------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION gp_toolkit.gp_move_orphaned_files(target_location text) RETURNS TABLE (
+    gp_segment_id int,
+    move_success bool,
+    oldpath text,
+    newpath text
+)
+SET search_path = pg_catalog, pg_temp
+LANGUAGE SQL AS $$
+SELECT * FROM gp_toolkit.__gp_move_orphaned_files(
+    ARRAY[ROW(0, target_location)::gp_toolkit.__gp_move_orphaned_files_pairs],
+    process_all_tablespaces := TRUE::bool
+);
+$$;
+
+--------------------------------------------------------------------------------
+-- @function:
+--        gp_toolkit.gp_move_orphaned_files_by_tablespace_location
+--
+-- @in:
+--        tablespace_oid oid
+--                OID of the tablespace whose orphaned files should be moved.
+--        target_location text
+--                Absolute path of the directory that will receive the files.
+--                Must be on the same filesystem as the tablespace location.
+--
+-- @out:
+--        gp_segment_id int - segment content ID
+--        move_success bool - TRUE if the move succeeded
+--        oldpath text - absolute pathname before the move
+--        newpath text - absolute pathname after the move
+--
+-- @doc:
+--        Moves orphaned files belonging to a specific tablespace
+--        to the supplied target directory.
+--
+--        Locks pg_class in shared mode and ensures no transactions are running.
+--        May pause and wait if pg_class is already locked by another process.
+--
+--------------------------------------------------------------------------------
+CREATE FUNCTION gp_toolkit.gp_move_orphaned_files_by_tablespace_location(
+        tablespace_oid  oid,
+        target_location text
+)
+RETURNS TABLE (
+        gp_segment_id  int,
+        move_success   bool,
+        oldpath        text,
+        newpath        text
+)
+SET search_path = pg_catalog, pg_temp
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF target_location IS NULL OR target_location = '' THEN
+        RAISE EXCEPTION 'target_location cannot be NULL or empty';
+    ELSIF NOT target_location LIKE '/%' THEN
+        RAISE EXCEPTION 'target_location must be an absolute path, got: "%"', target_location;
+    END IF;
+
+    RETURN QUERY
+    SELECT * FROM gp_toolkit.__gp_move_orphaned_files(
+        ARRAY[ROW(tablespace_oid, target_location)::gp_toolkit.__gp_move_orphaned_files_pairs],
+        process_all_tablespaces := FALSE::bool
+    );
+END;
+$$;
+
+--------------------------------------------------------------------------------
+-- @function:
+--        gp_toolkit.gp_move_orphaned_files_by_tablespace_location
+--        (overloaded variant)
+--
+-- @in:
+--        tablespace_location_pairs text[]
+--                Array of text pairs formatted as
+--                ARRAY['{tablespace_oid, /absolute/target/path}', ...]. Each
+--                pair identifies a tablespace and the directory on the same
+--                filesystem where its orphaned files will be moved.
+--
+-- @out:
+--        gp_segment_id int - segment content ID
+--        move_success bool - TRUE if the move succeeded
+--        oldpath text - absolute pathname before the move
+--        newpath text - absolute pathname after the move
+--
+-- @doc:
+--        Moves orphaned files from multiple tablespaces to their
+--        specified target directories.
+--
+--        Locks pg_class in shared mode and ensures no transactions are running.
+--        May pause and wait if pg_class is already locked by another process.
+--
+--------------------------------------------------------------------------------
+CREATE FUNCTION gp_toolkit.gp_move_orphaned_files_by_tablespace_location(
+        tablespace_location_pairs text[]
+)
+RETURNS TABLE (
+        gp_segment_id  int,
+        move_success   bool,
+        oldpath        text,
+        newpath        text
+)
+SET search_path = pg_catalog, pg_temp
+LANGUAGE plpgsql AS $$
+DECLARE
+    raw_entry text;
+    m text[];
+    parsed gp_toolkit.__gp_move_orphaned_files_pairs[] :=
+        ARRAY[]::gp_toolkit.__gp_move_orphaned_files_pairs[];
+BEGIN
+    FOREACH raw_entry IN ARRAY tablespace_location_pairs LOOP
+        -- Use SELECT INTO since regexp_matches() returns SETOF text[]
+        SELECT regexp_matches(raw_entry, '^\{\s*(\d+)\s*,\s*(/.+?)\s*\}$') INTO m;
+
+        IF m IS NULL THEN
+            RAISE EXCEPTION 'invalid format: "%". Expected format: {oid, /path}', raw_entry;
+        END IF;
+
+        parsed := parsed || ROW(m[1]::oid, m[2])::gp_toolkit.__gp_move_orphaned_files_pairs;
+    END LOOP;
+    RETURN QUERY
+    SELECT * FROM gp_toolkit.__gp_move_orphaned_files(parsed, process_all_tablespaces := FALSE::bool);
+END;
+$$;

--- a/gpcontrib/gp_toolkit/gp_toolkit.control
+++ b/gpcontrib/gp_toolkit/gp_toolkit.control
@@ -1,5 +1,5 @@
 # gp_toolkit extension
 
 comment = 'various GPDB administrative views/functions'
-default_version = '1.7'
+default_version = '1.8'
 schema = gp_toolkit

--- a/src/test/regress/input/gp_check_files.source
+++ b/src/test/regress/input/gp_check_files.source
@@ -7,170 +7,571 @@
 -- s/aocsseg_\d+/aocsseg_xxx/g
 -- m/aovisimap_\d+/
 -- s/aovisimap_\d+/aovisimap_xxx/g
+-- m/seg-1_pg_tblspc_.*/
+-- s/seg-1_pg_tblspc_.*/seg-1_pg_tblspc_XXX/g
+-- m/seg-1_base_.*/
+-- s/seg-1_base_.*/seg-1_base_XXX/g
 -- m/seg1_pg_tblspc_.*/
 -- s/seg1_pg_tblspc_.*/seg1_pg_tblspc_XXX/g
+-- m/seg1_base_.*/
+-- s/seg1_base_.*/seg1_base_XXX/g
 -- m/ERROR\:  could not rename .*/
 -- s/ERROR\:  could not rename .*/ERROR\:  could not rename XXX/g
 -- m/ERROR\:  cannot rename .*/
 -- s/ERROR\:  cannot rename .*/ERROR\:  cannot rename XXX/g
+-- m/HINT:  Operation was interrupted .*/
+-- s/HINT:  Operation was interrupted .*/HINT:  Operation was interrupted XXX/g
+-- m/CONTEXT: .*/
+-- s/CONTEXT:  .*/CONTEXT: XXX/g
+-- m/PL\/pgSQL function .*/
+-- s/PL\/pgSQL function .*/PL\/pgSQL function XXX/g
 -- end_matchsubs
 
--- helper function to repeatedly run gp_toolkit.gp_check_orphaned_files for up to 10 minutes,
--- in case any flakiness happens (like background worker makes LOCK pg_class unsuccessful etc.)
-CREATE OR REPLACE FUNCTION run_orphaned_files_view()
-RETURNS TABLE(gp_segment_id INT, filename TEXT) AS $$
+-- we'll use a specific tablespace and database to test
+CREATE TABLESPACE checkfile_ts LOCATION '@testtablespace@';
+CREATE DATABASE checkfile_db TABLESPACE checkfile_ts;
+\c checkfile_db
+
+-- helper function to repeatedly run input_query for up to 10 minutes,
+-- in case any flakiness happens (if another active backend is detected through pg_stat_activity)
+CREATE OR REPLACE FUNCTION run_with_retry(input_query TEXT)
+RETURNS SETOF record AS $$
 DECLARE
     retry_counter INT := 0;
 BEGIN
     WHILE retry_counter < 120 LOOP
         BEGIN
-            RETURN QUERY SELECT q.gp_segment_id, q.filename FROM gp_toolkit.gp_check_orphaned_files q;
+            RETURN QUERY EXECUTE input_query;
             RETURN; -- If successful
         EXCEPTION
             WHEN OTHERS THEN
-                RAISE LOG 'attempt failed % with error: %', retry_counter + 1, SQLERRM;
-                -- When an exception occurs, wait for 5 seconds and then retry
-                PERFORM pg_sleep(5);
-                -- Refresh to get the latest pg_stat_activity
-                PERFORM pg_stat_clear_snapshot();
-                retry_counter := retry_counter + 1;
+                IF SQLERRM LIKE '%There is a client session running on one or more segment%' THEN
+                    -- Log information about the retry attempt and the blocking session
+                    RAISE LOG 'attempt % failed %. Blocker: %',
+                        retry_counter + 1,
+                        SQLERRM,
+                        COALESCE(
+                        (
+                            SELECT format(
+                                    'seg=%s sess_id=%s db=%s user=%s app=%s state=%s query=%s',
+                                    gp_segment_id,
+                                    sess_id,
+                                    datname,
+                                    usename,
+                                    COALESCE(application_name, '-'),
+                                    state,
+                                    left(query, 100)
+                                )
+                            FROM (
+                            SELECT -1 AS gp_segment_id, * FROM pg_stat_activity
+                            UNION ALL
+                            SELECT gp_execution_segment() AS gp_segment_id, *
+                            FROM gp_dist_random('pg_stat_activity')
+                            ) AS all_sessions
+                            WHERE sess_id <> -1                                   -- exclude the system session
+                            AND sess_id <> current_setting('gp_session_id')::int  -- exclude the current one
+                            AND state <> 'idle'                                   -- exclude idle sessions
+                            LIMIT 1                                                  
+                        ),
+                        '<none>'  
+                        );
+                    -- When an exception occurs, wait for 5 seconds and then retry
+                    PERFORM pg_sleep(5);
+                    -- Refresh to get the latest pg_stat_activity
+                    PERFORM pg_stat_clear_snapshot();
+                    retry_counter := retry_counter + 1;
+                ELSE
+                    RAISE;
+                END IF;
         END;
     END LOOP;
 
     -- all retries failed
-    RAISE EXCEPTION 'failed to retrieve orphaned files after 10 minutes of retries.';
+    RAISE EXCEPTION 'failed to execute statement after 10 minutes of retries.';
 END;
 $$ LANGUAGE plpgsql;
 
--- we'll use a specific tablespace to test
-CREATE TABLESPACE checkfile_ts LOCATION '@testtablespace@';
-set default_tablespace = checkfile_ts;
+CREATE OR REPLACE FUNCTION run_orphaned_files_view()
+RETURNS TABLE(gp_segment_id int, filename text, filepath text) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT t.gp_segment_id,
+           t.filename,
+           regexp_replace(t.filepath, '^([^/]+)/.*/([^/]+)$', '\1/XXX/\2') AS filepath
+    FROM   run_with_retry(
+               'SELECT gp_segment_id, filename, filepath FROM gp_toolkit.gp_check_orphaned_files')
+           AS t(gp_segment_id int, filename text, filepath text);
+END;
+$$ LANGUAGE plpgsql;
 
--- create a table that we'll delete the files to test missing files.
--- this have to be created beforehand in order for the tablespace directories to be created.
-CREATE TABLE checkmissing_heap(a int, b int, c int);
-insert into checkmissing_heap select i,i,i from generate_series(1,100)i;
+CREATE OR REPLACE FUNCTION mv_files_wrp(target_location text)
+RETURNS TABLE(gp_segment_id int,
+              move_success  bool,
+              oldpath       text,
+              newpath       text) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT t.gp_segment_id,
+           t.move_success,
+           regexp_replace(t.oldpath, '^.*/(.+)$', '\1') as oldpath,
+           regexp_replace(
+               regexp_replace(t.newpath, '^.*/(.+)$', '\1'),
+               '^(([^_]+_){2}).*_([^_/]+)$',
+               '\1XXX_\3') AS newpath
+    FROM   run_with_retry(
+               'SELECT * FROM gp_toolkit.gp_move_orphaned_files(''' || target_location || ''')')
+           AS t(gp_segment_id int, move_success bool,
+                oldpath text, newpath text);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION mv_files_by_ts_wrp(
+        tablespace_oid  oid,
+        target_location text)
+RETURNS TABLE(gp_segment_id int,
+              move_success  bool,
+              oldpath       text,
+              newpath       text) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT t.gp_segment_id,
+           t.move_success,
+           regexp_replace(t.oldpath, '^.*/(.+)$', '\1') as oldpath,
+           regexp_replace(
+               regexp_replace(t.newpath, '^.*/(.+)$', '\1'),
+               '^(([^_]+_){2}).*_([^_/]+)$',
+               '\1XXX_\3') AS newpath
+    FROM   run_with_retry(
+               'SELECT * FROM gp_toolkit.gp_move_orphaned_files_by_tablespace_location('
+               || tablespace_oid || ', ''' || target_location || ''')')
+           AS t(gp_segment_id int, move_success bool,
+                oldpath text, newpath text);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION mv_files_by_ts_wrp(
+        tablespace_location_pairs text[])
+RETURNS TABLE(gp_segment_id int,
+              move_success  bool,
+              oldpath       text,
+              newpath       text) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT t.gp_segment_id,
+           t.move_success,
+           regexp_replace(t.oldpath, '^.*/(.+)$', '\1') as oldpath,
+           regexp_replace(
+               regexp_replace(t.newpath, '^.*/(.+)$', '\1'),
+               '^(([^_]+_){2}).*_([^_/]+)$',
+               '\1XXX_\3') AS newpath
+    FROM   run_with_retry(
+               'SELECT * FROM gp_toolkit.gp_move_orphaned_files_by_tablespace_location(ARRAY['''
+               || array_to_string(tablespace_location_pairs, ''',''') || ''']::text[])')
+           AS t(gp_segment_id int, move_success bool,
+                oldpath text, newpath text);
+END;
+$$ LANGUAGE plpgsql;
 
 --
--- Tests for orphaned files
+-- Test behaviour of gp_check_orphaned_files if database directory isn't yet created
 --
 
--- go to seg1's data directory for the tablespace we just created
+set client_min_messages = ERROR;
+select * from run_orphaned_files_view();
+reset client_min_messages;
+
+--
+-- Test for checking orphaned files
+--
+
+-- create tables that we'll delete the files to test missing files
+
+-- heap table inside checkfile_ts, this creates database directory 
+create table checkmissing_heap_usr_ts(a int, b int, c int);
+insert into checkmissing_heap_usr_ts select i,i,i from generate_series(1,100)i;
+-- heap table inside pg_default this creates database directory
+create table checkmissing_heap_def_ts(a int, b int, c int) tablespace pg_default;
+insert into checkmissing_heap_def_ts select i,i,i from generate_series(1,100)i;
+-- AO/CO tables inside checkfile_ts
+create table checkmissing_ao_usr_ts(a int, b int, c int) using ao_row;
+create table checkmissing_co_usr_ts(a int, b int, c int) using ao_column;
+insert into checkmissing_ao_usr_ts select i,i,i from generate_series(1,100)i;
+insert into checkmissing_co_usr_ts select i,i,i from generate_series(1,100)i;
+-- AO/CO tables inside pg_default
+create table checkmissing_ao_def_ts(a int, b int, c int) using ao_row tablespace pg_default;
+create table checkmissing_co_def_ts(a int, b int, c int) using ao_column tablespace pg_default;
+insert into checkmissing_ao_def_ts select i,i,i from generate_series(1,100)i;
+insert into checkmissing_co_def_ts select i,i,i from generate_series(1,100)i;
+
+-- We will use 4000000000X as a base for name of orphaned files.
+-- 4*10e9 is a real oid value, but theoretically not achievable inside tests.
+
+-- create orphan files in master's and seg1's within pg_global tablespace
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir/global
+\! touch 4000000000 4000000000.3
+select datadir from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :datadir/global
+\! touch 4000000000 4000000000.42
+-- create orphan files in master's and seg1's within pg_default tablespace
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir/base
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! touch 4000000001 4000000001.3
+select datadir from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :datadir/base
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! touch 4000000001 4000000001.42
+-- create orphan files in master's and seg1's within checkfile_ts tablespace
 \cd @testtablespace@
-select dbid from gp_segment_configuration where content = 1 and role = 'p' \gset
+select dbid from gp_segment_configuration where content = -1 and role = 'p' \gset
 \cd :dbid
 select get_tablespace_version_directory_name() as version_dir \gset
 \cd :version_dir
 select oid from pg_database where datname = current_database() \gset
 \cd :oid
-
--- create some orphaned files
-\! touch 987654
-\! touch 987654.3
+\! touch 4000000002 4000000002.3
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :dbid
+select get_tablespace_version_directory_name() as version_dir \gset
+\cd :version_dir
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! touch 4000000002 4000000002.42
 
 -- check orphaned files, note that this forces a checkpoint internally.
 set client_min_messages = ERROR;
-select gp_segment_id, filename from run_orphaned_files_view();
+select * from run_orphaned_files_view();
+reset client_min_messages;
 
--- test moving the orphaned files
+--
+-- Test error cases for moving orphaned files
+--
 
 -- firstly, should not move anything if the target directory doesn't exist
-select * from gp_toolkit.gp_move_orphaned_files('@testtablespace@/non_exist_dir');
-select gp_segment_id, filename from run_orphaned_files_view();
+select * from mv_files_wrp('@testtablespace@/non_exist_dir');
+select * from mv_files_by_ts_wrp((select oid from pg_tablespace where spcname = 'checkfile_ts'), '@testtablespace@/non_exist_dir');
+select * from mv_files_by_ts_wrp(array[format('{%s,%s}', (select oid from pg_tablespace where spcname = 'checkfile_ts'), '@testtablespace@/non_exist_dir')]);
 
 -- should also fail to move if no proper permission to the target directory
 \! mkdir @testtablespace@/moving_orphaned_file_test
 \! chmod 000 @testtablespace@/moving_orphaned_file_test
-select * from gp_toolkit.gp_move_orphaned_files('@testtablespace@/moving_orphaned_file_test');
-select gp_segment_id, filename from run_orphaned_files_view();
+select * from mv_files_wrp('@testtablespace@/moving_orphaned_file_test');
+select * from mv_files_by_ts_wrp((select oid from pg_tablespace where spcname = 'checkfile_ts'), '@testtablespace@/moving_orphaned_file_test');
+select * from mv_files_by_ts_wrp(array[format('{%s,%s}', (select oid from pg_tablespace where spcname = 'checkfile_ts'), '@testtablespace@/moving_orphaned_file_test')]);
+\! chmod 700 @testtablespace@/moving_orphaned_file_test
 
 -- should not allow non-superuser to run,
--- though it would complain as soon as non-superuser tries to lock pg_class in gp_toolkit.gp_move_orphaned_files
+-- though it would complain as soon as non-superuser tries to lock pg_class in gp_move_orphaned_files
 create role check_file_test_role nosuperuser;
 set role = check_file_test_role;
-select * from gp_toolkit.gp_move_orphaned_files('@testtablespace@/moving_orphaned_file_test');
+select * from mv_files_wrp('@testtablespace@/moving_orphaned_file_test');
 reset role;
 drop role check_file_test_role;
 
-\! chmod 700 @testtablespace@/moving_orphaned_file_test
--- should correctly move the orphaned files,
--- filter out exact paths as that could vary
-\a
-select gp_segment_id, move_success, regexp_replace(oldpath, '^.*/(.+)$', '\1') as oldpath, regexp_replace(newpath, '^.*/(.+)$', '\1') as newpath
-from gp_toolkit.gp_move_orphaned_files('@testtablespace@/moving_orphaned_file_test');
-\a
+-- check that orphaned files are still there
+select * from run_orphaned_files_view();
 
--- The moved orphaned files are in the target directory tree with a name that indicates its original location in data directory
-\cd @testtablespace@/moving_orphaned_file_test/
+--
+-- Test for moving all orphaned files at a time
+--
 
--- should see the orphaned files being moved
-\! ls
+-- we have to create dir in master datadir to move orphaned files from
+-- pg_default and pg_global there because @testtablespace@ can be on different
+-- devices, so we cannot move (rename) files across devices
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir
+\! mkdir moving_orphaned_file_test
+
+create temp table masterdir(dir text);
+insert into masterdir select datadir || '/moving_orphaned_file_test' from gp_segment_configuration where content = -1 and role = 'p';
+
+-- should correctly move the orphaned files, filter out exact paths as that could vary
+select * from mv_files_by_ts_wrp(array[
+   format('{%s,%s}', (select oid from pg_tablespace where spcname = 'pg_global'), (select dir from masterdir)),
+   format('{%s,%s}', (select oid from pg_tablespace where spcname = 'pg_default'), (select dir from masterdir)),
+   format('{%s,%s}', (select oid from pg_tablespace where spcname = 'checkfile_ts'), '@testtablespace@/moving_orphaned_file_test')
+]);
+
 -- no orphaned files can be found now
-select gp_segment_id, filename from run_orphaned_files_view();
+select * from run_orphaned_files_view();
 
--- should not affect existing tables
-select count(*) from checkmissing_heap;
-
-reset client_min_messages;
-
--- go back to the valid data directory
+-- check that files have been moved to the target directory tree
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir
+\! ls -1 moving_orphaned_file_test | LC_ALL=C sort
+\! rm -rf moving_orphaned_file_test/*
 \cd @testtablespace@
-select dbid from gp_segment_configuration where content = 1 and role = 'p' \gset
+\! ls -1 moving_orphaned_file_test | LC_ALL=C sort
+\! rm -rf moving_orphaned_file_test/*
+
+--
+-- Test for moving orphaned files step by step
+--
+
+-- we have to create orphaned files again
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir/global
+\! touch 4000000000 4000000000.3
+select datadir from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :datadir/global
+\! touch 4000000000 4000000000.42
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir/base
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! touch 4000000001 4000000001.3
+select datadir from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :datadir/base
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! touch 4000000001 4000000001.42
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content = -1 and role = 'p' \gset
 \cd :dbid
 select get_tablespace_version_directory_name() as version_dir \gset
 \cd :version_dir
 select oid from pg_database where datname = current_database() \gset
 \cd :oid
+\! touch 4000000002 4000000002.3
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :dbid
+select get_tablespace_version_directory_name() as version_dir \gset
+\cd :version_dir
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! touch 4000000002 4000000002.42
+
+select * from run_orphaned_files_view();
+
+-- move orphaned files from checkfile_ts at first
+select * from mv_files_by_ts_wrp((select oid from pg_tablespace where spcname = 'checkfile_ts'),
+                                 '@testtablespace@/moving_orphaned_file_test');
+
+-- move remaining orphaned files from pg_global and pg_default
+select * from mv_files_wrp((select dir from masterdir));
+
+-- no orphaned files can be found now
+select * from run_orphaned_files_view();
+
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir
+\! ls -1 moving_orphaned_file_test | LC_ALL=C sort
+\! rm -rf moving_orphaned_file_test/*
+\cd @testtablespace@
+\! ls -1 moving_orphaned_file_test | LC_ALL=C sort
+
+-- should not affect existing tables
+select count(*) from checkmissing_heap_usr_ts;
+select count(*) from checkmissing_heap_def_ts;
+select count(*) from checkmissing_ao_usr_ts;
+select count(*) from checkmissing_co_usr_ts;
+select count(*) from checkmissing_ao_def_ts;
+select count(*) from checkmissing_co_def_ts;
+
+-- remove temp table; otherwise, gp_check_missing_files will show false results =)
+drop table masterdir;
 
 --
 -- Tests for missing files
 --
 
--- Now remove the data file for the table we just created.
--- But check to see if the working directory is what we expect (under
--- the test tablespace). Also just delete one and only one file that
--- is number-named.
-\! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+' -exec rm {} \; -quit; fi
-
--- now create AO/CO tables and delete only their extended files
-CREATE TABLE checkmissing_ao(a int, b int, c int) using ao_row;
-CREATE TABLE checkmissing_co(a int, b int, c int) using ao_column;
-insert into checkmissing_ao select i,i,i from generate_series(1,100)i;
-insert into checkmissing_co select i,i,i from generate_series(1,100)i;
-
--- Now remove the extended data file '.1' for the AO/CO tables we just created.
--- Still, check to see if the working directory is what we expect, and only
--- delete exact two '.1' files.
-\! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+\.1' -exec rm {} \; -quit; fi
-\! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+\.1' -exec rm {} \; -quit; fi
-
 -- create some normal tables
-CREATE TABLE checknormal_heap(a int, b int, c int);
-CREATE TABLE checknormal_ao(a int, b int, c int) using ao_row;
-CREATE TABLE checknormal_co(a int, b int, c int) using ao_column;
-insert into checknormal_heap select i,i,i from generate_series(1,100)i;
-insert into checknormal_ao select i,i,i from generate_series(1,100)i;
-insert into checknormal_co select i,i,i from generate_series(1,100)i;
+create table checknormal_heap_usr_ts(a int, b int, c int);
+create table checknormal_ao_usr_ts(a int, b int, c int) using ao_row;
+create table checknormal_co_usr_ts(a int, b int, c int) using ao_column;
+create table checknormal_heap_def_ts(a int, b int, c int) tablespace pg_default;
+create table checknormal_ao_def_ts(a int, b int, c int) using ao_row tablespace pg_default;
+create table checknormal_co_def_ts(a int, b int, c int) using ao_column tablespace pg_default;
+insert into checknormal_heap_usr_ts select i,i,i from generate_series(1,100)i;
+insert into checknormal_ao_usr_ts select i,i,i from generate_series(1,100)i;
+insert into checknormal_co_usr_ts select i,i,i from generate_series(1,100)i;
+insert into checknormal_heap_def_ts select i,i,i from generate_series(1,100)i;
+insert into checknormal_ao_def_ts select i,i,i from generate_series(1,100)i;
+insert into checknormal_co_def_ts select i,i,i from generate_series(1,100)i;
 
--- check non-extended missing files
+
+-- disable formatting for clean shell script output
+\pset format unaligned
+\pset tuples_only on
+
+-- remove data inside checkfile_ts
+-- go to the master's directory
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :dbid
+select get_tablespace_version_directory_name() as version_dir \gset
+\cd :version_dir
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+-- lock all tables in one transaction and remove files
+begin;
+lock table checkmissing_heap_usr_ts, checkmissing_ao_usr_ts, checkmissing_co_usr_ts in access exclusive mode;
+-- write rm commands into script (no extended files for AO/CO in master)
+\o @testtablespace@/rm_files.sh
+select 'if pwd | grep -q "^@testtablespace@/.*$"; then rm -f ' || pg_relation_filenode('checkmissing_heap_usr_ts') || '; fi';
+select 'if pwd | grep -q "^@testtablespace@/.*$"; then rm -f ' || pg_relation_filenode('checkmissing_ao_usr_ts') || '; fi';
+select 'if pwd | grep -q "^@testtablespace@/.*$"; then rm -f ' || pg_relation_filenode('checkmissing_co_usr_ts') || '; fi';
+\o
+\! bash @testtablespace@/rm_files.sh
+commit;
+
+-- go to the seg1's directory
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content = 1 and role = 'p' \gset
+\cd :dbid
+select get_tablespace_version_directory_name() as version_dir \gset
+\cd :version_dir
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+-- lock all tables in one transaction and remove files
+begin;
+lock table checkmissing_heap_usr_ts, checkmissing_ao_usr_ts, checkmissing_co_usr_ts in access exclusive mode;
+-- write rm commands into script (remove extended files for AO/CO)
+\o @testtablespace@/rm_files.sh
+select 'if pwd | grep -q "^@testtablespace@/.*$"; then rm -f ' || relfilenode || '; fi'
+from gp_dist_random('pg_class') 
+where relname = 'checkmissing_heap_usr_ts' AND gp_segment_id = 1;
+
+select 'if pwd | grep -q "^@testtablespace@/.*$"; then rm -f ' || relfilenode || '.1; fi'
+from gp_dist_random('pg_class') 
+where relname = 'checkmissing_ao_usr_ts' AND gp_segment_id = 1;
+
+select 'if pwd | grep -q "^@testtablespace@/.*$"; then rm -f ' || relfilenode || '.1; fi'
+from gp_dist_random('pg_class') 
+where relname = 'checkmissing_co_usr_ts' AND gp_segment_id = 1;
+\o
+\! bash @testtablespace@/rm_files.sh
+commit;
+
+-- remove data inside pg_default
+-- go to the master's directory
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir/base
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+-- lock all tables in one transaction and remove files with script
+begin;
+lock table checkmissing_heap_def_ts, checkmissing_ao_def_ts, checkmissing_co_def_ts in access exclusive mode;
+-- write rm commands into script (no extended files for AO/CO in master)
+\o @testtablespace@/rm_files.sh
+select 'if pwd | grep -q "^' || :'datadir' || '/base/' || :'oid' || '$"; then rm -f ' || pg_relation_filenode('checkmissing_heap_def_ts') || '; fi';
+select 'if pwd | grep -q "^' || :'datadir' || '/base/' || :'oid' || '$"; then rm -f ' || pg_relation_filenode('checkmissing_ao_def_ts') || '; fi';
+select 'if pwd | grep -q "^' || :'datadir' || '/base/' || :'oid' || '$"; then rm -f ' || pg_relation_filenode('checkmissing_co_def_ts') || '; fi';
+\o
+\! bash @testtablespace@/rm_files.sh
+commit;
+
+-- go to the seg1's directory
+select datadir from gp_segment_configuration where content = 1 and role = 'p' \gset
+\cd :datadir/base
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+-- lock all tables in one transaction and remove files with script
+begin;
+lock table checkmissing_heap_def_ts, checkmissing_ao_def_ts, checkmissing_co_def_ts in access exclusive mode;
+-- write rm commands into script (remove extended files for AO/CO)
+\o @testtablespace@/rm_files.sh
+select 'if pwd | grep -q "^' || :'datadir' || '/base/' || :'oid' || '$"; then rm -f ' || relfilenode || '; fi'
+from gp_dist_random('pg_class')
+where relname = 'checkmissing_heap_def_ts' and gp_segment_id = 1;
+
+select 'if pwd | grep -q "^' || :'datadir' || '/base/' || :'oid' || '$"; then rm -f ' || relfilenode || '.1; fi'
+from gp_dist_random('pg_class')
+where relname = 'checkmissing_ao_def_ts' and gp_segment_id = 1;
+
+select 'if pwd | grep -q "^' || :'datadir' || '/base/' || :'oid' || '$"; then rm -f ' || relfilenode || '.1; fi'
+from gp_dist_random('pg_class')
+where relname = 'checkmissing_co_def_ts' and gp_segment_id = 1;
+\o
+\! bash @testtablespace@/rm_files.sh
+commit;
+
+-- restore formatting
+\pset format aligned
+\pset tuples_only off
+
+-- check non-extended files
 select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_toolkit.gp_check_missing_files;
-
-SET client_min_messages = ERROR;
+set client_min_messages = ERROR;
 
 -- check extended files
 select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_toolkit.gp_check_missing_files_ext;
+reset client_min_messages;
 
-RESET client_min_messages;
+--
+-- Cleanup
+--
 
--- cleanup
-drop table checkmissing_heap;
-drop table checkmissing_ao;
-drop table checkmissing_co;
-drop table checknormal_heap;
-drop table checknormal_ao;
-drop table checknormal_co;
+--drop helper functions
+drop function run_with_retry(text);
+drop function run_orphaned_files_view();
+drop function mv_files_wrp(text);
+drop function mv_files_by_ts_wrp(oid, text);
+drop function mv_files_by_ts_wrp(text[]);
 
-\! rm -rf @testtablespace@/*;
+-- drop tables
+drop table checkmissing_heap_usr_ts;
+drop table checkmissing_heap_def_ts;
+drop table checkmissing_ao_usr_ts;
+drop table checkmissing_ao_def_ts;
+drop table checkmissing_co_usr_ts;
+drop table checkmissing_co_def_ts;
+drop table checknormal_heap_usr_ts;
+drop table checknormal_heap_def_ts;
+drop table checknormal_ao_usr_ts;
+drop table checknormal_ao_def_ts;
+drop table checknormal_co_usr_ts;
+drop table checknormal_co_def_ts;
 
+-- remove masterdir used to store moved orphaned files
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir
+\! rm -r moving_orphaned_file_test
+
+-- cleanup testtablespace dirrectory
+\! rm @testtablespace@/rm_files.sh
+\! rm -r @testtablespace@/moving_orphaned_file_test
+
+-- cleanup orphaned files if they still exist
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir/global
+\! rm -f 4000000000 4000000000.3
+select datadir from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :datadir/global
+\! rm -f 4000000000 4000000000.42
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir/base
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! rm -f 4000000001 4000000001.3
+select datadir from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :datadir/base
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! rm -f 4000000001 4000000001.42
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :dbid
+select get_tablespace_version_directory_name() as version_dir \gset
+\cd :version_dir
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! rm -f 4000000002 4000000002.3
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :dbid
+select get_tablespace_version_directory_name() as version_dir \gset
+\cd :version_dir
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! rm -f 4000000002 4000000002.42
+
+-- drop database and tablespace
+\c regression
+DROP DATABASE checkfile_db;
 DROP TABLESPACE checkfile_ts;
-

--- a/src/test/regress/output/gp_check_files.source
+++ b/src/test/regress/output/gp_check_files.source
@@ -6,135 +6,576 @@
 -- s/aocsseg_\d+/aocsseg_xxx/g
 -- m/aovisimap_\d+/
 -- s/aovisimap_\d+/aovisimap_xxx/g
+-- m/seg-1_pg_tblspc_.*/
+-- s/seg-1_pg_tblspc_.*/seg-1_pg_tblspc_XXX/g
+-- m/seg-1_base_.*/
+-- s/seg-1_base_.*/seg-1_base_XXX/g
 -- m/seg1_pg_tblspc_.*/
 -- s/seg1_pg_tblspc_.*/seg1_pg_tblspc_XXX/g
+-- m/seg1_base_.*/
+-- s/seg1_base_.*/seg1_base_XXX/g
 -- m/ERROR\:  could not rename .*/
 -- s/ERROR\:  could not rename .*/ERROR\:  could not rename XXX/g
 -- m/ERROR\:  cannot rename .*/
 -- s/ERROR\:  cannot rename .*/ERROR\:  cannot rename XXX/g
+-- m/^HINT:  Operation was interrupted .*/
+-- m/CONTEXT: .*/
+-- s/CONTEXT:  .*/CONTEXT: XXX/g
+-- m/PL\/pgSQL function .*/
+-- s/PL\/pgSQL function .*/PL\/pgSQL function XXX/g
 -- end_matchsubs
--- helper function to repeatedly run gp_toolkit.gp_check_orphaned_files for up to 10 minutes,
--- in case any flakiness happens (like background worker makes LOCK pg_class unsuccessful etc.)
-CREATE OR REPLACE FUNCTION run_orphaned_files_view()
-RETURNS TABLE(gp_segment_id INT, filename TEXT) AS $$
+--start_ignore
+-- Workaround: send SIGHUP to avoid rare dtx recovery blocking issue in run_with_retry.
+-- Blocker is always a long-running pg_prepared_xacts scan; see log for details.
+\! gpstop -u
+--end_ignore
+-- we'll use a specific tablespace and database to test
+CREATE TABLESPACE checkfile_ts LOCATION '@testtablespace@';
+CREATE DATABASE checkfile_db TABLESPACE checkfile_ts;
+\c checkfile_db
+-- helper function to repeatedly run input_query for up to 10 minutes,
+-- in case any flakiness happens (if another active backend is detected through pg_stat_activity)
+CREATE OR REPLACE FUNCTION run_with_retry(input_query TEXT)
+RETURNS SETOF record AS $$
 DECLARE
     retry_counter INT := 0;
 BEGIN
     WHILE retry_counter < 120 LOOP
         BEGIN
-            RETURN QUERY SELECT q.gp_segment_id, q.filename FROM gp_toolkit.gp_check_orphaned_files q;
+            RETURN QUERY EXECUTE input_query;
             RETURN; -- If successful
         EXCEPTION
             WHEN OTHERS THEN
-                RAISE LOG 'attempt failed % with error: %', retry_counter + 1, SQLERRM;
-                -- When an exception occurs, wait for 5 seconds and then retry
-                PERFORM pg_sleep(5);
-                -- Refresh to get the latest pg_stat_activity
-                PERFORM pg_stat_clear_snapshot();
-                retry_counter := retry_counter + 1;
+                IF SQLERRM LIKE '%There is a client session running on one or more segment%' THEN
+                    -- Log information about the retry attempt and the blocking session
+                    RAISE LOG 'attempt % failed %. Blocker: %',
+                        retry_counter + 1,
+                        SQLERRM,
+                        COALESCE(
+                        (
+                            SELECT format(
+                                    'seg=%s sess_id=%s db=%s user=%s app=%s state=%s query=%s',
+                                    gp_segment_id,
+                                    sess_id,
+                                    datname,
+                                    usename,
+                                    COALESCE(application_name, '-'),
+                                    state,
+                                    left(query, 100)
+                                )
+                            FROM (
+                            SELECT -1 AS gp_segment_id, * FROM pg_stat_activity
+                            UNION ALL
+                            SELECT gp_execution_segment() AS gp_segment_id, *
+                            FROM gp_dist_random('pg_stat_activity')
+                            ) AS all_sessions
+                            WHERE sess_id <> -1                                   -- exclude the system session
+                            AND sess_id <> current_setting('gp_session_id')::int  -- exclude the current one
+                            AND state <> 'idle'                                   -- exclude idle sessions
+                            LIMIT 1                                                  
+                        ),
+                        '<none>'  
+                        );
+                    -- When an exception occurs, wait for 5 seconds and then retry
+                    PERFORM pg_sleep(5);
+                    -- Refresh to get the latest pg_stat_activity
+                    PERFORM pg_stat_clear_snapshot();
+                    retry_counter := retry_counter + 1;
+                ELSE
+                    RAISE;
+                END IF;
         END;
     END LOOP;
 
     -- all retries failed
-    RAISE EXCEPTION 'failed to retrieve orphaned files after 10 minutes of retries.';
+    RAISE EXCEPTION 'failed to execute statement after 10 minutes of retries.';
 END;
 $$ LANGUAGE plpgsql;
--- we'll use a specific tablespace to test
-CREATE TABLESPACE checkfile_ts LOCATION '@testtablespace@';
-set default_tablespace = checkfile_ts;
--- create a table that we'll delete the files to test missing files.
--- this have to be created beforehand in order for the tablespace directories to be created.
-CREATE TABLE checkmissing_heap(a int, b int, c int);
-insert into checkmissing_heap select i,i,i from generate_series(1,100)i;
+CREATE OR REPLACE FUNCTION run_orphaned_files_view()
+RETURNS TABLE(gp_segment_id int, filename text, filepath text) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT t.gp_segment_id,
+           t.filename,
+           regexp_replace(t.filepath, '^([^/]+)/.*/([^/]+)$', '\1/XXX/\2') AS filepath
+    FROM   run_with_retry(
+               'SELECT gp_segment_id, filename, filepath FROM gp_toolkit.gp_check_orphaned_files')
+           AS t(gp_segment_id int, filename text, filepath text);
+END;
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION mv_files_wrp(target_location text)
+RETURNS TABLE(gp_segment_id int,
+              move_success  bool,
+              oldpath       text,
+              newpath       text) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT t.gp_segment_id,
+           t.move_success,
+           regexp_replace(t.oldpath, '^.*/(.+)$', '\1') as oldpath,
+           regexp_replace(
+               regexp_replace(t.newpath, '^.*/(.+)$', '\1'),
+               '^(([^_]+_){2}).*_([^_/]+)$',
+               '\1XXX_\3') AS newpath
+    FROM   run_with_retry(
+               'SELECT * FROM gp_toolkit.gp_move_orphaned_files(''' || target_location || ''')')
+           AS t(gp_segment_id int, move_success bool,
+                oldpath text, newpath text);
+END;
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION mv_files_by_ts_wrp(
+        tablespace_oid  oid,
+        target_location text)
+RETURNS TABLE(gp_segment_id int,
+              move_success  bool,
+              oldpath       text,
+              newpath       text) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT t.gp_segment_id,
+           t.move_success,
+           regexp_replace(t.oldpath, '^.*/(.+)$', '\1') as oldpath,
+           regexp_replace(
+               regexp_replace(t.newpath, '^.*/(.+)$', '\1'),
+               '^(([^_]+_){2}).*_([^_/]+)$',
+               '\1XXX_\3') AS newpath
+    FROM   run_with_retry(
+               'SELECT * FROM gp_toolkit.gp_move_orphaned_files_by_tablespace_location('
+               || tablespace_oid || ', ''' || target_location || ''')')
+           AS t(gp_segment_id int, move_success bool,
+                oldpath text, newpath text);
+END;
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION mv_files_by_ts_wrp(
+        tablespace_location_pairs text[])
+RETURNS TABLE(gp_segment_id int,
+              move_success  bool,
+              oldpath       text,
+              newpath       text) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT t.gp_segment_id,
+           t.move_success,
+           regexp_replace(t.oldpath, '^.*/(.+)$', '\1') as oldpath,
+           regexp_replace(
+               regexp_replace(t.newpath, '^.*/(.+)$', '\1'),
+               '^(([^_]+_){2}).*_([^_/]+)$',
+               '\1XXX_\3') AS newpath
+    FROM   run_with_retry(
+               'SELECT * FROM gp_toolkit.gp_move_orphaned_files_by_tablespace_location(ARRAY['''
+               || array_to_string(tablespace_location_pairs, ''',''') || ''']::text[])')
+           AS t(gp_segment_id int, move_success bool,
+                oldpath text, newpath text);
+END;
+$$ LANGUAGE plpgsql;
 --
--- Tests for orphaned files
+-- Test behaviour of gp_check_orphaned_files if database directory isn't yet created
 --
--- go to seg1's data directory for the tablespace we just created
+set client_min_messages = ERROR;
+select * from run_orphaned_files_view();
+ gp_segment_id | filename | filepath 
+---------------+----------+----------
+(0 rows)
+
+reset client_min_messages;
+--
+-- Test for checking orphaned files
+--
+-- create tables that we'll delete the files to test missing files
+-- heap table inside checkfile_ts, this creates database directory 
+create table checkmissing_heap_usr_ts(a int, b int, c int);
+insert into checkmissing_heap_usr_ts select i,i,i from generate_series(1,100)i;
+-- heap table inside pg_default this creates database directory
+create table checkmissing_heap_def_ts(a int, b int, c int) tablespace pg_default;
+insert into checkmissing_heap_def_ts select i,i,i from generate_series(1,100)i;
+-- AO/CO tables inside checkfile_ts
+create table checkmissing_ao_usr_ts(a int, b int, c int) using ao_row;
+create table checkmissing_co_usr_ts(a int, b int, c int) using ao_column;
+insert into checkmissing_ao_usr_ts select i,i,i from generate_series(1,100)i;
+insert into checkmissing_co_usr_ts select i,i,i from generate_series(1,100)i;
+-- AO/CO tables inside pg_default
+create table checkmissing_ao_def_ts(a int, b int, c int) using ao_row tablespace pg_default;
+create table checkmissing_co_def_ts(a int, b int, c int) using ao_column tablespace pg_default;
+insert into checkmissing_ao_def_ts select i,i,i from generate_series(1,100)i;
+insert into checkmissing_co_def_ts select i,i,i from generate_series(1,100)i;
+-- We will use 4000000000X as a base for name of orphaned files.
+-- 4*10e9 is a real oid value, but theoretically not achievable inside tests.
+-- create orphan files in master's and seg1's within pg_global tablespace
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir/global
+\! touch 4000000000 4000000000.3
+select datadir from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :datadir/global
+\! touch 4000000000 4000000000.42
+-- create orphan files in master's and seg1's within pg_default tablespace
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir/base
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! touch 4000000001 4000000001.3
+select datadir from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :datadir/base
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! touch 4000000001 4000000001.42
+-- create orphan files in master's and seg1's within checkfile_ts tablespace
 \cd @testtablespace@
-select dbid from gp_segment_configuration where content = 1 and role = 'p' \gset
+select dbid from gp_segment_configuration where content = -1 and role = 'p' \gset
 \cd :dbid
 select get_tablespace_version_directory_name() as version_dir \gset
 \cd :version_dir
 select oid from pg_database where datname = current_database() \gset
 \cd :oid
--- create some orphaned files
-\! touch 987654
-\! touch 987654.3
+\! touch 4000000002 4000000002.3
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :dbid
+select get_tablespace_version_directory_name() as version_dir \gset
+\cd :version_dir
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! touch 4000000002 4000000002.42
 -- check orphaned files, note that this forces a checkpoint internally.
 set client_min_messages = ERROR;
-select gp_segment_id, filename from run_orphaned_files_view();
- gp_segment_id | filename 
----------------+----------
-             1 | 987654
-             1 | 987654.3
-(2 rows)
+select * from run_orphaned_files_view();
+ gp_segment_id |   filename    |          filepath           
+---------------+---------------+-----------------------------
+             1 | 4000000002.42 | pg_tblspc/XXX/4000000002.42
+             1 | 4000000002    | pg_tblspc/XXX/4000000002
+             1 | 4000000001    | base/XXX/4000000001
+             1 | 4000000001.42 | base/XXX/4000000001.42
+             1 | 4000000000    | global/4000000000
+             1 | 4000000000.42 | global/4000000000.42
+            -1 | 4000000002    | pg_tblspc/XXX/4000000002
+            -1 | 4000000002.3  | pg_tblspc/XXX/4000000002.3
+            -1 | 4000000001    | base/XXX/4000000001
+            -1 | 4000000001.3  | base/XXX/4000000001.3
+            -1 | 4000000000    | global/4000000000
+            -1 | 4000000000.3  | global/4000000000.3
+(12 rows)
 
--- test moving the orphaned files
+reset client_min_messages;
+--
+-- Test error cases for moving orphaned files
+--
 -- firstly, should not move anything if the target directory doesn't exist
-select * from gp_toolkit.gp_move_orphaned_files('@testtablespace@/non_exist_dir');
+select * from mv_files_wrp('@testtablespace@/non_exist_dir');
 ERROR:  could not rename XXX
-select gp_segment_id, filename from run_orphaned_files_view();
- gp_segment_id | filename 
----------------+----------
-             1 | 987654.3
-             1 | 987654
-(2 rows)
-
+HINT:  Operation was interrupted XXX
+CONTEXT: XXX
+SQL function "gp_move_orphaned_files" statement 1
+PL/pgSQL function XXX
+PL/pgSQL function XXX
+select * from mv_files_by_ts_wrp((select oid from pg_tablespace where spcname = 'checkfile_ts'), '@testtablespace@/non_exist_dir');
+ERROR:  could not rename XXX
+HINT:  Operation was interrupted XXX
+CONTEXT: XXX
+PL/pgSQL function XXX
+PL/pgSQL function XXX
+PL/pgSQL function XXX
+select * from mv_files_by_ts_wrp(array[format('{%s,%s}', (select oid from pg_tablespace where spcname = 'checkfile_ts'), '@testtablespace@/non_exist_dir')]);
+ERROR:  could not rename XXX
+HINT:  Operation was interrupted XXX
+CONTEXT: XXX
+PL/pgSQL function XXX
+PL/pgSQL function XXX
+PL/pgSQL function XXX
 -- should also fail to move if no proper permission to the target directory
 \! mkdir @testtablespace@/moving_orphaned_file_test
 \! chmod 000 @testtablespace@/moving_orphaned_file_test
-select * from gp_toolkit.gp_move_orphaned_files('@testtablespace@/moving_orphaned_file_test');
+select * from mv_files_wrp('@testtablespace@/moving_orphaned_file_test');
 ERROR:  cannot rename XXX
-CONTEXT:  PL/pgSQL function gp_toolkit.gp_move_orphaned_files(text) line 20 at RETURN QUERY
-select gp_segment_id, filename from run_orphaned_files_view();
- gp_segment_id | filename 
----------------+----------
-             1 | 987654.3
-             1 | 987654
-(2 rows)
-
+HINT:  Operation was interrupted XXX
+CONTEXT: XXX
+SQL function "gp_move_orphaned_files" statement 1
+PL/pgSQL function XXX
+PL/pgSQL function XXX
+select * from mv_files_by_ts_wrp((select oid from pg_tablespace where spcname = 'checkfile_ts'), '@testtablespace@/moving_orphaned_file_test');
+ERROR:  cannot rename XXX
+HINT:  Operation was interrupted XXX
+CONTEXT: XXX
+PL/pgSQL function XXX
+PL/pgSQL function XXX
+PL/pgSQL function XXX
+select * from mv_files_by_ts_wrp(array[format('{%s,%s}', (select oid from pg_tablespace where spcname = 'checkfile_ts'), '@testtablespace@/moving_orphaned_file_test')]);
+ERROR:  cannot rename XXX
+HINT:  Operation was interrupted XXX
+CONTEXT: XXX
+PL/pgSQL function XXX
+PL/pgSQL function XXX
+PL/pgSQL function XXX
+\! chmod 700 @testtablespace@/moving_orphaned_file_test
 -- should not allow non-superuser to run,
--- though it would complain as soon as non-superuser tries to lock pg_class in gp_toolkit.gp_move_orphaned_files
+-- though it would complain as soon as non-superuser tries to lock pg_class in gp_move_orphaned_files
 create role check_file_test_role nosuperuser;
 set role = check_file_test_role;
-select * from gp_toolkit.gp_move_orphaned_files('@testtablespace@/moving_orphaned_file_test');
+select * from mv_files_wrp('@testtablespace@/moving_orphaned_file_test');
 ERROR:  permission denied for table pg_class
-CONTEXT:  SQL statement "LOCK TABLE pg_class IN SHARE MODE NOWAIT"
-PL/pgSQL function gp_toolkit.gp_move_orphaned_files(text) line 4 at SQL statement
+HINT:  Operation was interrupted XXX
+CONTEXT: XXX
+SQL function "gp_move_orphaned_files" statement 1
+PL/pgSQL function XXX
+PL/pgSQL function XXX
 reset role;
 drop role check_file_test_role;
-\! chmod 700 @testtablespace@/moving_orphaned_file_test
--- should correctly move the orphaned files,
--- filter out exact paths as that could vary
-\a
-select gp_segment_id, move_success, regexp_replace(oldpath, '^.*/(.+)$', '\1') as oldpath, regexp_replace(newpath, '^.*/(.+)$', '\1') as newpath
-from gp_toolkit.gp_move_orphaned_files('@testtablespace@/moving_orphaned_file_test');
-gp_segment_id|move_success|oldpath|newpath
-1|t|987654|seg1_pg_tblspc_17816_GPDB_7_302307241_17470_987654
-1|t|987654.3|seg1_pg_tblspc_17816_GPDB_7_302307241_17470_987654.3
-(2 rows)
-\a
--- The moved orphaned files are in the target directory tree with a name that indicates its original location in data directory
-\cd @testtablespace@/moving_orphaned_file_test/
--- should see the orphaned files being moved
-\! ls
-seg1_pg_tblspc_37385_GPDB_7_302307241_37039_987654
-seg1_pg_tblspc_37385_GPDB_7_302307241_37039_987654.3
+-- check that orphaned files are still there
+select * from run_orphaned_files_view();
+ gp_segment_id |   filename    |          filepath           
+---------------+---------------+-----------------------------
+             1 | 4000000002.42 | pg_tblspc/XXX/4000000002.42
+             1 | 4000000002    | pg_tblspc/XXX/4000000002
+             1 | 4000000001    | base/XXX/4000000001
+             1 | 4000000001.42 | base/XXX/4000000001.42
+             1 | 4000000000    | global/4000000000
+             1 | 4000000000.42 | global/4000000000.42
+            -1 | 4000000002    | pg_tblspc/XXX/4000000002
+            -1 | 4000000002.3  | pg_tblspc/XXX/4000000002.3
+            -1 | 4000000001    | base/XXX/4000000001
+            -1 | 4000000001.3  | base/XXX/4000000001.3
+            -1 | 4000000000    | global/4000000000
+            -1 | 4000000000.3  | global/4000000000.3
+(12 rows)
+
+--
+-- Test for moving all orphaned files at a time
+--
+-- we have to create dir in master datadir to move orphaned files from
+-- pg_default and pg_global there because @testtablespace@ can be on different
+-- devices, so we cannot move (rename) files across devices
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir
+\! mkdir moving_orphaned_file_test
+create temp table masterdir(dir text);
+insert into masterdir select datadir || '/moving_orphaned_file_test' from gp_segment_configuration where content = -1 and role = 'p';
+-- should correctly move the orphaned files, filter out exact paths as that could vary
+select * from mv_files_by_ts_wrp(array[
+   format('{%s,%s}', (select oid from pg_tablespace where spcname = 'pg_global'), (select dir from masterdir)),
+   format('{%s,%s}', (select oid from pg_tablespace where spcname = 'pg_default'), (select dir from masterdir)),
+   format('{%s,%s}', (select oid from pg_tablespace where spcname = 'checkfile_ts'), '@testtablespace@/moving_orphaned_file_test')
+]);
+ gp_segment_id | move_success |    oldpath    |           newpath           
+---------------+--------------+---------------+-----------------------------
+            -1 | t            | 4000000000    | seg-1_global_4000000000
+            -1 | t            | 4000000000.3  | seg-1_global_4000000000.3
+             1 | t            | 4000000000    | seg1_global_4000000000
+             1 | t            | 4000000000.42 | seg1_global_4000000000.42
+            -1 | t            | 4000000001    | seg-1_base_XXX_4000000001
+            -1 | t            | 4000000001.3  | seg-1_base_XXX_4000000001.3
+             1 | t            | 4000000001    | seg1_base_XXX_4000000001
+             1 | t            | 4000000001.42 | seg1_base_XXX_4000000001.42
+            -1 | t            | 4000000002    | seg-1_pg_XXX_4000000002
+            -1 | t            | 4000000002.3  | seg-1_pg_XXX_4000000002.3
+             1 | t            | 4000000002    | seg1_pg_XXX_4000000002
+             1 | t            | 4000000002.42 | seg1_pg_XXX_4000000002.42
+(12 rows)
+
 -- no orphaned files can be found now
-select gp_segment_id, filename from run_orphaned_files_view();
- gp_segment_id | filename 
----------------+----------
+select * from run_orphaned_files_view();
+ gp_segment_id | filename | filepath 
+---------------+----------+----------
 (0 rows)
 
+-- check that files have been moved to the target directory tree
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir
+\! ls -1 moving_orphaned_file_test | LC_ALL=C sort
+seg-1_base_XXX
+seg-1_base_XXX
+seg-1_global_4000000000
+seg-1_global_4000000000.3
+seg1_base_XXX
+seg1_base_XXX
+seg1_global_4000000000
+seg1_global_4000000000.42
+\! rm -rf moving_orphaned_file_test/*
+\cd @testtablespace@
+\! ls -1 moving_orphaned_file_test | LC_ALL=C sort
+seg-1_pg_tblspc_XXX
+seg-1_pg_tblspc_XXX
+seg1_pg_tblspc_XXX
+seg1_pg_tblspc_XXX
+\! rm -rf moving_orphaned_file_test/*
+--
+-- Test for moving orphaned files step by step
+--
+-- we have to create orphaned files again
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir/global
+\! touch 4000000000 4000000000.3
+select datadir from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :datadir/global
+\! touch 4000000000 4000000000.42
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir/base
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! touch 4000000001 4000000001.3
+select datadir from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :datadir/base
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! touch 4000000001 4000000001.42
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :dbid
+select get_tablespace_version_directory_name() as version_dir \gset
+\cd :version_dir
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! touch 4000000002 4000000002.3
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :dbid
+select get_tablespace_version_directory_name() as version_dir \gset
+\cd :version_dir
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! touch 4000000002 4000000002.42
+select * from run_orphaned_files_view();
+ gp_segment_id |   filename    |          filepath           
+---------------+---------------+-----------------------------
+             1 | 4000000002.42 | pg_tblspc/XXX/4000000002.42
+             1 | 4000000002    | pg_tblspc/XXX/4000000002
+             1 | 4000000001    | base/XXX/4000000001
+             1 | 4000000001.42 | base/XXX/4000000001.42
+             1 | 4000000000    | global/4000000000
+             1 | 4000000000.42 | global/4000000000.42
+            -1 | 4000000002    | pg_tblspc/XXX/4000000002
+            -1 | 4000000002.3  | pg_tblspc/XXX/4000000002.3
+            -1 | 4000000001    | base/XXX/4000000001
+            -1 | 4000000001.3  | base/XXX/4000000001.3
+            -1 | 4000000000    | global/4000000000
+            -1 | 4000000000.3  | global/4000000000.3
+(12 rows)
+
+-- move orphaned files from checkfile_ts at first
+select * from mv_files_by_ts_wrp((select oid from pg_tablespace where spcname = 'checkfile_ts'),
+                                 '@testtablespace@/moving_orphaned_file_test');
+ gp_segment_id | move_success |    oldpath    |          newpath          
+---------------+--------------+---------------+---------------------------
+            -1 | t            | 4000000002    | seg-1_pg_XXX_4000000002
+            -1 | t            | 4000000002.3  | seg-1_pg_XXX_4000000002.3
+             1 | t            | 4000000002    | seg1_pg_XXX_4000000002
+             1 | t            | 4000000002.42 | seg1_pg_XXX_4000000002.42
+(4 rows)
+
+-- move remaining orphaned files from pg_global and pg_default
+select * from mv_files_wrp((select dir from masterdir));
+ gp_segment_id | move_success |    oldpath    |           newpath           
+---------------+--------------+---------------+-----------------------------
+            -1 | t            | 4000000001    | seg-1_base_XXX_4000000001
+            -1 | t            | 4000000001.3  | seg-1_base_XXX_4000000001.3
+            -1 | t            | 4000000000    | seg-1_global_4000000000
+            -1 | t            | 4000000000.3  | seg-1_global_4000000000.3
+             1 | t            | 4000000001    | seg1_base_XXX_4000000001
+             1 | t            | 4000000001.42 | seg1_base_XXX_4000000001.42
+             1 | t            | 4000000000    | seg1_global_4000000000
+             1 | t            | 4000000000.42 | seg1_global_4000000000.42
+(8 rows)
+
+-- no orphaned files can be found now
+select * from run_orphaned_files_view();
+ gp_segment_id | filename | filepath 
+---------------+----------+----------
+(0 rows)
+
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir
+\! ls -1 moving_orphaned_file_test | LC_ALL=C sort
+seg-1_base_XXX
+seg-1_base_XXX
+seg-1_global_4000000000
+seg-1_global_4000000000.3
+seg1_base_XXX
+seg1_base_XXX
+seg1_global_4000000000
+seg1_global_4000000000.42
+\! rm -rf moving_orphaned_file_test/*
+\cd @testtablespace@
+\! ls -1 moving_orphaned_file_test | LC_ALL=C sort
+seg-1_pg_tblspc_XXX
+seg-1_pg_tblspc_XXX
+seg1_pg_tblspc_XXX
+seg1_pg_tblspc_XXX
 -- should not affect existing tables
-select count(*) from checkmissing_heap;
+select count(*) from checkmissing_heap_usr_ts;
  count 
 -------
    100
 (1 row)
 
-reset client_min_messages;
--- go back to the valid data directory
+select count(*) from checkmissing_heap_def_ts;
+ count 
+-------
+   100
+(1 row)
+
+select count(*) from checkmissing_ao_usr_ts;
+ count 
+-------
+   100
+(1 row)
+
+select count(*) from checkmissing_co_usr_ts;
+ count 
+-------
+   100
+(1 row)
+
+select count(*) from checkmissing_ao_def_ts;
+ count 
+-------
+   100
+(1 row)
+
+select count(*) from checkmissing_co_def_ts;
+ count 
+-------
+   100
+(1 row)
+
+-- remove temp table; otherwise, gp_check_missing_files will show false results =)
+drop table masterdir;
+--
+-- Tests for missing files
+--
+-- create some normal tables
+create table checknormal_heap_usr_ts(a int, b int, c int);
+create table checknormal_ao_usr_ts(a int, b int, c int) using ao_row;
+create table checknormal_co_usr_ts(a int, b int, c int) using ao_column;
+create table checknormal_heap_def_ts(a int, b int, c int) tablespace pg_default;
+create table checknormal_ao_def_ts(a int, b int, c int) using ao_row tablespace pg_default;
+create table checknormal_co_def_ts(a int, b int, c int) using ao_column tablespace pg_default;
+insert into checknormal_heap_usr_ts select i,i,i from generate_series(1,100)i;
+insert into checknormal_ao_usr_ts select i,i,i from generate_series(1,100)i;
+insert into checknormal_co_usr_ts select i,i,i from generate_series(1,100)i;
+insert into checknormal_heap_def_ts select i,i,i from generate_series(1,100)i;
+insert into checknormal_ao_def_ts select i,i,i from generate_series(1,100)i;
+insert into checknormal_co_def_ts select i,i,i from generate_series(1,100)i;
+-- disable formatting for clean shell script output
+\pset format unaligned
+\pset tuples_only on
+-- remove data inside checkfile_ts
+-- go to the master's directory
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :dbid
+select get_tablespace_version_directory_name() as version_dir \gset
+\cd :version_dir
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+-- lock all tables in one transaction and remove files
+begin;
+lock table checkmissing_heap_usr_ts, checkmissing_ao_usr_ts, checkmissing_co_usr_ts in access exclusive mode;
+-- write rm commands into script (no extended files for AO/CO in master)
+\o @testtablespace@/rm_files.sh
+select 'if pwd | grep -q "^@testtablespace@/.*$"; then rm -f ' || pg_relation_filenode('checkmissing_heap_usr_ts') || '; fi';
+select 'if pwd | grep -q "^@testtablespace@/.*$"; then rm -f ' || pg_relation_filenode('checkmissing_ao_usr_ts') || '; fi';
+select 'if pwd | grep -q "^@testtablespace@/.*$"; then rm -f ' || pg_relation_filenode('checkmissing_co_usr_ts') || '; fi';
+\o
+\! bash @testtablespace@/rm_files.sh
+commit;
+-- go to the seg1's directory
 \cd @testtablespace@
 select dbid from gp_segment_configuration where content = 1 and role = 'p' \gset
 \cd :dbid
@@ -142,55 +583,162 @@ select get_tablespace_version_directory_name() as version_dir \gset
 \cd :version_dir
 select oid from pg_database where datname = current_database() \gset
 \cd :oid
---
--- Tests for missing files
---
--- Now remove the data file for the table we just created.
--- But check to see if the working directory is what we expect (under
--- the test tablespace). Also just delete one and only one file that
--- is number-named.
-\! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+' -exec rm {} \; -quit; fi
--- now create AO/CO tables and delete only their extended files
-CREATE TABLE checkmissing_ao(a int, b int, c int) using ao_row;
-CREATE TABLE checkmissing_co(a int, b int, c int) using ao_column;
-insert into checkmissing_ao select i,i,i from generate_series(1,100)i;
-insert into checkmissing_co select i,i,i from generate_series(1,100)i;
--- Now remove the extended data file '.1' for the AO/CO tables we just created.
--- Still, check to see if the working directory is what we expect, and only
--- delete exact two '.1' files.
-\! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+\.1' -exec rm {} \; -quit; fi
-\! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+\.1' -exec rm {} \; -quit; fi
--- create some normal tables
-CREATE TABLE checknormal_heap(a int, b int, c int);
-CREATE TABLE checknormal_ao(a int, b int, c int) using ao_row;
-CREATE TABLE checknormal_co(a int, b int, c int) using ao_column;
-insert into checknormal_heap select i,i,i from generate_series(1,100)i;
-insert into checknormal_ao select i,i,i from generate_series(1,100)i;
-insert into checknormal_co select i,i,i from generate_series(1,100)i;
--- check non-extended missing files
+-- lock all tables in one transaction and remove files
+begin;
+lock table checkmissing_heap_usr_ts, checkmissing_ao_usr_ts, checkmissing_co_usr_ts in access exclusive mode;
+-- write rm commands into script (remove extended files for AO/CO)
+\o @testtablespace@/rm_files.sh
+select 'if pwd | grep -q "^@testtablespace@/.*$"; then rm -f ' || relfilenode || '; fi'
+from gp_dist_random('pg_class') 
+where relname = 'checkmissing_heap_usr_ts' AND gp_segment_id = 1;
+select 'if pwd | grep -q "^@testtablespace@/.*$"; then rm -f ' || relfilenode || '.1; fi'
+from gp_dist_random('pg_class') 
+where relname = 'checkmissing_ao_usr_ts' AND gp_segment_id = 1;
+select 'if pwd | grep -q "^@testtablespace@/.*$"; then rm -f ' || relfilenode || '.1; fi'
+from gp_dist_random('pg_class') 
+where relname = 'checkmissing_co_usr_ts' AND gp_segment_id = 1;
+\o
+\! bash @testtablespace@/rm_files.sh
+commit;
+-- remove data inside pg_default
+-- go to the master's directory
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir/base
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+-- lock all tables in one transaction and remove files with script
+begin;
+lock table checkmissing_heap_def_ts, checkmissing_ao_def_ts, checkmissing_co_def_ts in access exclusive mode;
+-- write rm commands into script (no extended files for AO/CO in master)
+\o @testtablespace@/rm_files.sh
+select 'if pwd | grep -q "^' || :'datadir' || '/base/' || :'oid' || '$"; then rm -f ' || pg_relation_filenode('checkmissing_heap_def_ts') || '; fi';
+select 'if pwd | grep -q "^' || :'datadir' || '/base/' || :'oid' || '$"; then rm -f ' || pg_relation_filenode('checkmissing_ao_def_ts') || '; fi';
+select 'if pwd | grep -q "^' || :'datadir' || '/base/' || :'oid' || '$"; then rm -f ' || pg_relation_filenode('checkmissing_co_def_ts') || '; fi';
+\o
+\! bash @testtablespace@/rm_files.sh
+commit;
+-- go to the seg1's directory
+select datadir from gp_segment_configuration where content = 1 and role = 'p' \gset
+\cd :datadir/base
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+-- lock all tables in one transaction and remove files with script
+begin;
+lock table checkmissing_heap_def_ts, checkmissing_ao_def_ts, checkmissing_co_def_ts in access exclusive mode;
+-- write rm commands into script (remove extended files for AO/CO)
+\o @testtablespace@/rm_files.sh
+select 'if pwd | grep -q "^' || :'datadir' || '/base/' || :'oid' || '$"; then rm -f ' || relfilenode || '; fi'
+from gp_dist_random('pg_class')
+where relname = 'checkmissing_heap_def_ts' and gp_segment_id = 1;
+select 'if pwd | grep -q "^' || :'datadir' || '/base/' || :'oid' || '$"; then rm -f ' || relfilenode || '.1; fi'
+from gp_dist_random('pg_class')
+where relname = 'checkmissing_ao_def_ts' and gp_segment_id = 1;
+select 'if pwd | grep -q "^' || :'datadir' || '/base/' || :'oid' || '$"; then rm -f ' || relfilenode || '.1; fi'
+from gp_dist_random('pg_class')
+where relname = 'checkmissing_co_def_ts' and gp_segment_id = 1;
+\o
+\! bash @testtablespace@/rm_files.sh
+commit;
+-- restore formatting
+\pset format aligned
+\pset tuples_only off
+-- check non-extended files
 select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_toolkit.gp_check_missing_files;
- gp_segment_id | regexp_replace |      relname      
----------------+----------------+-------------------
-             1 | x              | checkmissing_heap
-(1 row)
+ gp_segment_id | regexp_replace |         relname          
+---------------+----------------+--------------------------
+             1 | x              | checkmissing_heap_usr_ts
+             1 | x              | checkmissing_heap_def_ts
+            -1 | x              | checkmissing_heap_usr_ts
+            -1 | x              | checkmissing_heap_def_ts
+            -1 | x              | checkmissing_ao_usr_ts
+            -1 | x              | checkmissing_co_usr_ts
+            -1 | x              | checkmissing_ao_def_ts
+            -1 | x              | checkmissing_co_def_ts
+(8 rows)
 
-SET client_min_messages = ERROR;
+set client_min_messages = ERROR;
 -- check extended files
 select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_toolkit.gp_check_missing_files_ext;
- gp_segment_id | regexp_replace |      relname      
----------------+----------------+-------------------
-             1 | x              | checkmissing_heap
-             1 | x.1            | checkmissing_ao
-             1 | x.1            | checkmissing_co
-(3 rows)
+ gp_segment_id | regexp_replace |         relname          
+---------------+----------------+--------------------------
+             1 | x              | checkmissing_heap_def_ts
+             1 | x              | checkmissing_heap_usr_ts
+             1 | x.1            | checkmissing_co_def_ts
+             1 | x.1            | checkmissing_ao_def_ts
+             1 | x.1            | checkmissing_co_usr_ts
+             1 | x.1            | checkmissing_ao_usr_ts
+            -1 | x              | checkmissing_heap_usr_ts
+            -1 | x              | checkmissing_heap_def_ts
+            -1 | x              | checkmissing_ao_usr_ts
+            -1 | x              | checkmissing_co_usr_ts
+            -1 | x              | checkmissing_ao_def_ts
+            -1 | x              | checkmissing_co_def_ts
+(12 rows)
 
-RESET client_min_messages;
--- cleanup
-drop table checkmissing_heap;
-drop table checkmissing_ao;
-drop table checkmissing_co;
-drop table checknormal_heap;
-drop table checknormal_ao;
-drop table checknormal_co;
-\! rm -rf @testtablespace@/*;
+reset client_min_messages;
+--
+-- Cleanup
+--
+--drop helper functions
+drop function run_with_retry(text);
+drop function run_orphaned_files_view();
+drop function mv_files_wrp(text);
+drop function mv_files_by_ts_wrp(oid, text);
+drop function mv_files_by_ts_wrp(text[]);
+-- drop tables
+drop table checkmissing_heap_usr_ts;
+drop table checkmissing_heap_def_ts;
+drop table checkmissing_ao_usr_ts;
+drop table checkmissing_ao_def_ts;
+drop table checkmissing_co_usr_ts;
+drop table checkmissing_co_def_ts;
+drop table checknormal_heap_usr_ts;
+drop table checknormal_heap_def_ts;
+drop table checknormal_ao_usr_ts;
+drop table checknormal_ao_def_ts;
+drop table checknormal_co_usr_ts;
+drop table checknormal_co_def_ts;
+-- remove masterdir used to store moved orphaned files
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir
+\! rm -r moving_orphaned_file_test
+-- cleanup testtablespace dirrectory
+\! rm @testtablespace@/rm_files.sh
+\! rm -r @testtablespace@/moving_orphaned_file_test
+-- cleanup orphaned files if they still exist
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir/global
+\! rm -f 4000000000 4000000000.3
+select datadir from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :datadir/global
+\! rm -f 4000000000 4000000000.42
+select datadir from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :datadir/base
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! rm -f 4000000001 4000000001.3
+select datadir from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :datadir/base
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! rm -f 4000000001 4000000001.42
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content = -1 and role = 'p' \gset
+\cd :dbid
+select get_tablespace_version_directory_name() as version_dir \gset
+\cd :version_dir
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! rm -f 4000000002 4000000002.3
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content =  1 and role = 'p' \gset
+\cd :dbid
+select get_tablespace_version_directory_name() as version_dir \gset
+\cd :version_dir
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+\! rm -f 4000000002 4000000002.42
+-- drop database and tablespace
+\c regression
+DROP DATABASE checkfile_db;
 DROP TABLESPACE checkfile_ts;


### PR DESCRIPTION
Adopt patch 7bdf316b6 from our 6.x branch to 7.x.

Functions from extension worked very badly with custom tablespaces.
This patch fixes all known related issues and adds tests to cover them.

1. gp_check_orphaned_files did not handle absent directories

gp_check_orphaned_files failed when it encountered tablespaces whose physical 
directories were not yet created for a database (e.g.
pg_tblspc/<tablespace_oid>/<GPDB_version>/<db_oid> or base/<db_oid>).

Set missing_ok=true parameter for pg_ls_dir() inside __get_exist_files, so it
returns an empty set instead of raising an error when the directory is missing.

2. gp_check_orphaned_files returned duplicate `global//…` paths

Normalise the literal `global/` to `global` inside __get_exist_files.

3. False orphan/missing-file reports for databases in non-default tablespaces

The extension reported phantom orphan and missing files whenever a database
lived in a user-defined tablespace rather than pg_default.  Helper views
hard-coded tablespace OID `0`, ignoring the database’s real default tablespace
(pg_database.dattablespace).

__get_exist_files now uses the real pg_default OID.

__get_expect_files uses pg_database.dattablespace when `reltablespace = 0`, so
expected locations match the actual default tablespace.

__get_expect_files_ext introduces a CTE class_info that pre-computes the
correct tablespace value and joins AO/CO branches to it.

4. __gp_check_orphaned_files_func used NOWAIT ineffectively

In GPDB, NOWAIT inside PL/pgSQL did not throw an exception when attempting to
lock pg_class; it waited silently. The problem is reproduced even in PostgreSQL
17.

It should be fixed in the future. For now, remove NOWAIT and the associated
exception handling from __gp_check_orphaned_files_func and
gp_move_orphaned_files to prevent misunderstanding.

5. gp_move_orphaned_files failed when orphaned files were located across
different filesystems

The function relied on the rename syscall, which cannot cross filesystems,
causing an “Invalid cross-device link”.

Add gp_move_orphaned_files_by_tablespace_location, allowing users to specify a
target directory per tablespace; plus an internal helper called by wrappers.
Catch errors during renaming and emit a hint explaining with instructions for
user.

6.  __get_exist_files used hardcoded tablespace OIDs and condition
tablespace.oid > 1664 to identify user-defined tablespaces.

Replace OIDs with subqueries using pg_tablespace.spcname to dynamically resolve
pg_default and pg_global OIDs.  Updated the user-defined tablespace filter to
spcname NOT IN ('pg_default', 'pg_global'). According to PostgreSQL
documentation, only pg_default and pg_global are built-in; all others are
user-defined.

Changes caused by the new 7.x code:

- Use relkind != 'v' instead of relstorage; add AM via pg_am. Foreign and partitioned
relations have no storage, so we don’t explicitly exclude them.

- Simplify the activity probe to gp_stat_activity with a backend_type filter; remove
UNIONs with gp_dist_random('pg_stat_activity').

- Join gp_settings by gp_segment_id (instead of pg_settings hacks) in move functions.

- Set search_path = pg_catalog, pg_temp for safety.

- Remove the test workaround; the issue does not reproduce on 7.x.

Ticket: ADBDEV-7719