### PR TITLE
ADBDEV-8452: Fix the 'max_tm_gxacts' value after fault injection

### DIFF
--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -643,11 +643,17 @@ redoDistributedCommitRecord(TMGXACT_LOG *gxact_log)
 	if (i == *shmNumCommittedGxacts)
 	{
 #ifdef FAULT_INJECTOR
+		static int save_max_tm_gxacts = -1;
+		if (save_max_tm_gxacts < 0)
+			save_max_tm_gxacts = max_tm_gxacts;
+
 		if (SIMPLE_FAULT_INJECTOR("standby_gxacts_overflow") == FaultInjectorTypeSkip)
 		{
 			max_tm_gxacts = 1;
 			elog(LOG, "Committed gid array length: %d", *shmNumCommittedGxacts);
 		}
+		else
+			max_tm_gxacts = save_max_tm_gxacts;
 #endif
 
 		/*

--- a/src/test/isolation2/expected/standby_replay_dtx_info.out
+++ b/src/test/isolation2/expected/standby_replay_dtx_info.out
@@ -95,5 +95,41 @@ select gp_inject_fault_infinite('standby_gxacts_overflow', 'reset', dbid) from g
 (1 row)
 drop table test_dtx_standby_tbl;
 DROP
+
+-- Verify that max_tm_gxacts is reset from 1. In order to do so,
+-- create 2 distributed transactions that are postponed before the point where
+-- 'distributed forget' is inserted into the WAL, and check that standby can
+-- successfully replay the WAL.
+select gp_inject_fault_infinite('dtm_before_insert_forget_comitted', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+1&: create table test1(a int) distributed by (a);  <waiting ...>
+2&: create table test2(a int) distributed by (a);  <waiting ...>
+
+-- Ensure that replay on standby is ok.
+select wait_for_standby_replay(1200);
+ wait_for_standby_replay 
+-------------------------
+ t                       
+(1 row)
+
+select gp_inject_fault_infinite('dtm_before_insert_forget_comitted', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+1<:  <... completed>
+CREATE
+2<:  <... completed>
+CREATE
+
+drop table test1;
+DROP
+drop table test2;
+DROP
 drop function wait_for_standby_replay(int);
 DROP

--- a/src/test/isolation2/sql/standby_replay_dtx_info.sql
+++ b/src/test/isolation2/sql/standby_replay_dtx_info.sql
@@ -72,4 +72,26 @@ select wait_for_standby_replay(1200);
 
 select gp_inject_fault_infinite('standby_gxacts_overflow', 'reset', dbid) from gp_segment_configuration where content = -1 and role = 'm';
 drop table test_dtx_standby_tbl;
+
+-- Verify that max_tm_gxacts is reset from 1. In order to do so,
+-- create 2 distributed transactions that are postponed before the point where
+-- 'distributed forget' is inserted into the WAL, and check that standby can
+-- successfully replay the WAL.
+select gp_inject_fault_infinite('dtm_before_insert_forget_comitted', 'suspend', dbid)
+from gp_segment_configuration where role = 'p' and content = -1;
+
+1&: create table test1(a int) distributed by (a);
+2&: create table test2(a int) distributed by (a);
+
+-- Ensure that replay on standby is ok.
+select wait_for_standby_replay(1200);
+
+select gp_inject_fault_infinite('dtm_before_insert_forget_comitted', 'reset', dbid)
+from gp_segment_configuration where role = 'p' and content = -1;
+
+1<:
+2<:
+
+drop table test1;
+drop table test2;
 drop function wait_for_standby_replay(int);


### PR DESCRIPTION
Fix the 'max_tm_gxacts' value after fault injection

Problem description:
After sequential execution of isolation2 tests 'standby_replay_dtx_info' and
'ao_unique_index' the coordinator's standby postmaster process together with
its children processes were terminated.

Root cause:
Test 'standby_replay_dtx_info' sets fault injection 'standby_gxacts_overflow'
on coordinator's standby, which updates the global var 'max_tm_gxacts' (the
limit of distributed transactions) to 1, but at the reset of this fault the
value of 'max_tm_gxacts' was not updated to its original value. Therefore, on
any next test that created more than 2 distributed transactions that were
replayed on the standby, the standby encountered the fatal error "the limit of 1
distributed transactions has been reached" and it was terminated.

Fix:
Set 'max_tm_gxacts' to its original value when fault injection
'standby_gxacts_overflow' is not set.

(cherry picked from commit 423cc57b779bfb8f048f47425b428091a7d959a9)