### PR TITLE
ADBDEV-8689: Don't create motion on QE slice

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -5702,6 +5702,13 @@ make_motion(PlannerInfo *root, Plan *lefttree,
 			Oid *sortOperators, Oid *collations, bool *nullsFirst,
 			bool useExecutorVarFormat)
 {
+	if (Gp_role != GP_ROLE_DISPATCH)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("cannot create Motion on QE slice")));
+	}
+
     Motion *node = makeNode(Motion);
     Plan   *plan = &node->plan;
 

--- a/src/test/regress/expected/qp_functions_in_select.out
+++ b/src/test/regress/expected/qp_functions_in_select.out
@@ -7673,3 +7673,15 @@ ERROR:  UPDATE is not allowed in a non-volatile function
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function func2_mod_int_stb(integer) line 3 at SQL statement
 rollback;
+-- Test motions are not allowed on QE
+create table d(i int) distributed by (i);
+insert into d select 1;
+create function f() returns int as $$
+    select 1 from gp_dist_random('pg_group') union all select 1 from pg_group;
+$$ language sql;
+-- error when execute such function on QE
+select f() from d;
+ERROR:  cannot create Motion on QE slice  (seg1 slice1 172.18.0.7:6003 pid=37574)
+CONTEXT:  SQL function "f" during startup
+drop table d;
+drop function f();

--- a/src/test/regress/sql/qp_functions_in_select.sql
+++ b/src/test/regress/sql/qp_functions_in_select.sql
@@ -2111,3 +2111,21 @@ rollback;
 begin;
 SELECT func1_mod_setint_stb(func2_mod_int_stb(5)) order by 1;
 rollback;
+
+-- Test motions are not allowed on QE
+--start_ignore
+drop table if exists d;
+drop function if exists f();
+--end_ignore
+create table d(i int) distributed by (i);
+insert into d select 1;
+
+create function f() returns int as $$
+    select 1 from gp_dist_random('pg_group') union all select 1 from pg_group;
+$$ language sql;
+
+-- error when execute such function on QE
+select f() from d;
+
+drop table d;
+drop function f();


### PR DESCRIPTION
Don't create motion on QE slice

The planner can execute some functions on segments. However, their contents
will also be planned on segments. Planning may create motions, which is
unacceptable on segments. Since the contents of functions may be unavailable
when planning the initial query (for example, a C-function with a call to SQL
in the SPI), it is sufficient to prevent motions from being created when
planning a function on a segment.

Ticket: ADBDEV-8689