### PR TITLE
ADBDEV-7477: Ensure that creation of an empty relfile is fsync'd at checkpoint.

### DIFF
--- a/src/backend/access/transam/xlogutils.c
+++ b/src/backend/access/transam/xlogutils.c
@@ -313,6 +313,7 @@ XLogReadBufferExtended(RelFileNode rnode, ForkNumber forknum,
 
 	/* Open the relation at smgr level */
 	smgr = smgropen(rnode, InvalidBackendId);
+	smgr->smgr_which = RELSTORAGE_HEAP;
 
 	/*
 	 * Create the target file if it doesn't already exist.  This lets us cope

--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -266,6 +266,7 @@ AppendOnlyStorageWrite_TransactionCreateFile(AppendOnlyStorageWrite *storageWrit
 	SMgrRelation reln;
 
 	reln = smgropen(relFileNode->node, relFileNode->backend);
+	reln->smgr_which = RELSTORAGE_AOROWS;
 
 	/* The file might already exist. that's OK */
 	// WALREP_FIXME: Pass isRedo == true, so that you don't get an error if it

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -13156,6 +13156,7 @@ ATExecSetTableSpace(Oid tableOid, Oid newTableSpace, LOCKMODE lockmode)
 	newrnode.relNode = newrelfilenode;
 	newrnode.spcNode = newTableSpace;
 	dstrel = smgropen(newrnode, rel->rd_backend);
+	dstrel->smgr_which = rel->rd_rel->relstorage;
 
 	RelationOpenSmgr(rel);
 

--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -361,6 +361,7 @@ ReadBufferWithoutRelcache(RelFileNode rnode, ForkNumber forkNum,
 	bool		hit;
 
 	SMgrRelation smgr = smgropen(rnode, InvalidBackendId);
+	smgr->smgr_which = 0;
 
 	Assert(InRecovery);
 
@@ -2121,6 +2122,7 @@ FlushBuffer(volatile BufferDesc *buf, SMgrRelation reln)
 
 		reln = smgropen(buf->tag.rnode,
 						istemp ? TempRelBackendId : InvalidBackendId);
+		reln->smgr_which = 0;
 	}
 
 	TRACE_POSTGRESQL_BUFFER_FLUSH_START(buf->tag.forkNum,

--- a/src/backend/storage/buffer/localbuf.c
+++ b/src/backend/storage/buffer/localbuf.c
@@ -207,6 +207,7 @@ LocalBufferAlloc(SMgrRelation smgr, ForkNumber forkNum, BlockNumber blockNum,
 
 		/* Find smgr relation for buffer */
 		oreln = smgropen(bufHdr->tag.rnode, MyBackendId);
+		oreln->smgr_which = 0;
 
 		// GPDB_93_MERGE_FIXME: is this TODO comment still relevant?
 		// UNDONE: Unfortunately, I think we write temp relations to the mirror...

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -63,12 +63,14 @@ typedef struct SMgrRelationData
 
 	/* additional public fields may someday exist here */
 
+	/* Obsolete storage manager selector, should not be used for any particular purpose */
+	/* In GGDB, this field is used to store the table type: Heap or AO . */
+	int			smgr_which;
+
 	/*
 	 * Fields below here are intended to be private to smgr.c and its
 	 * submodules.  Do not touch them from elsewhere.
 	 */
-	/* Obsolete storage manager selector, should not be used for any particular purpose */
-	int			smgr_which;
 
 	/* for md.c; NULL for forks that are not open */
 	struct _MdfdVec *md_fd[MAX_FORKNUM + 1];

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -451,6 +451,9 @@ typedef struct ViewOptions
 #define RelationIsMapped(relation) \
 	((relation)->rd_rel->relfilenode == InvalidOid)
 
+#define RelationStorageIsAO(relation) \
+	(RelationIsAoRows(relation) || RelationIsAoCols(relation))
+
 /*
  * RelationOpenSmgr
  *		Open the relation at the smgr level, if not already done.
@@ -458,7 +461,10 @@ typedef struct ViewOptions
 #define RelationOpenSmgr(relation) \
 	do { \
 		if ((relation)->rd_smgr == NULL) \
-			smgrsetowner(&((relation)->rd_smgr), smgropen((relation)->rd_node, (relation)->rd_backend)); \
+		{                                                                                                          \
+			smgrsetowner(&((relation)->rd_smgr), smgropen((relation)->rd_node, (relation)->rd_backend));           \
+			(relation)->rd_smgr->smgr_which = RelationStorageIsAO(relation) ? RELSTORAGE_AOROWS : RELSTORAGE_HEAP; \
+		}                                                                                                          \
 	} while (0)
 
 /*


### PR DESCRIPTION
If you create a table and don't insert any data into it, the relation file is
never fsync'd. You don't lose data, because an empty table doesn't have any data
to begin with, but if you crash and lose the file, subsequent operations on the
table will fail with "could not open file" error.

To fix, register an fsync request in mdcreate(), like we do for mdwrite().

c request in mdcreate(), like we do for mdwrite().

Per discussion, we probably should also fsync the containing directory after
creating a new file. But that's a separate and much wider issue.

Backpatch to all supported versions.

Reviewed-by: Andres Freund, Thomas Munro
Discussion: https://www.postgresql.org/message-id/d47d8122-415e-425c-d0a2-e0160829702d%40iki.fi

6X changes:
In 6X, the smgr_which field is not used and not set. This patch adds setting
this field. To maintain binary compatibility, this field is set outside the
smgropen function.


(cherry picked from commit 1b4f1c6f8a6c0b764636f25e17d37d8cab7e82be)