### PR TITLE
Fix typo: minor compiler warnings fixes (currently ATExecAddInherit)

### DIFF
--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerDynamicTableScan.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerDynamicTableScan.cpp
@@ -162,7 +162,7 @@ CParseHandlerDynamicTableScan::EndElement(const XMLCh *const,  // element_uri,
 			m_mp, table_descr, m_part_index_id, m_part_index_id_printable);
 
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, dxl_op);
-	// set statictics and physical properties
+	// set statistics and physical properties
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 	// add constructed children

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerGatherMotion.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerGatherMotion.cpp
@@ -160,7 +160,7 @@ CParseHandlerGatherMotion::EndElement(const XMLCh *const,  // element_uri,
 	GPOS_ASSERT(NULL != child_parse_handler);
 
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, m_dxl_op);
-	// set statictics and physical properties
+	// set statistics and physical properties
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerHashJoin.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerHashJoin.cpp
@@ -180,7 +180,7 @@ CParseHandlerHashJoin::EndElement(const XMLCh *const,  // element_uri,
 	GPOS_ASSERT(NULL != right_child_parse_handler);
 
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, m_dxl_op);
-	// set statictics and physical properties
+	// set statistics and physical properties
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 	// add children

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMaterialize.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMaterialize.cpp
@@ -150,7 +150,7 @@ CParseHandlerMaterialize::EndElement(const XMLCh *const,  // element_uri,
 	GPOS_ASSERT(NULL != child_parse_handler);
 
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, m_dxl_op);
-	// set statictics and physical properties
+	// set statistics and physical properties
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 	// add constructed children

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMergeJoin.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMergeJoin.cpp
@@ -180,7 +180,7 @@ CParseHandlerMergeJoin::EndElement(const XMLCh *const,	// element_uri,
 	GPOS_ASSERT(NULL != right_child_parse_handler);
 
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, m_dxl_op);
-	// set statictics and physical properties
+	// set statistics and physical properties
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 	// add children

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerNLJoin.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerNLJoin.cpp
@@ -194,7 +194,7 @@ CParseHandlerNLJoin::EndElement(const XMLCh *const,	 // element_uri,
 		m_dxl_op->SetNestLoopParamsColRefs(nest_params_colrefs);
 	}
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, m_dxl_op);
-	// set statictics and physical properties
+	// set statistics and physical properties
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 	// add constructed children

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPhysicalAbstractBitmapScan.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPhysicalAbstractBitmapScan.cpp
@@ -162,7 +162,7 @@ CParseHandlerPhysicalAbstractBitmapScan::EndElementHelper(
 	}
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, dxl_op);
 
-	// set statictics and physical properties
+	// set statistics and physical properties
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 	// add constructed children

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerRandomMotion.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerRandomMotion.cpp
@@ -160,7 +160,7 @@ CParseHandlerRandomMotion::EndElement(const XMLCh *const,  // element_uri,
 	GPOS_ASSERT(NULL != child_parse_handler);
 
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, m_dxl_op);
-	// set statictics and physical properties
+	// set statistics and physical properties
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 	// add children

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerRedistributeMotion.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerRedistributeMotion.cpp
@@ -176,7 +176,7 @@ CParseHandlerRedistributeMotion::EndElement(
 	GPOS_ASSERT(NULL != child_parse_handler);
 
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, m_dxl_op);
-	// set statictics and physical properties
+	// set statistics and physical properties
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 	// add children

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerResult.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerResult.cpp
@@ -178,7 +178,7 @@ CParseHandlerResult::EndElement(const XMLCh *const,	 // element_uri,
 	GPOS_ASSERT(NULL != one_time_filter_parse_handler);
 
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, m_dxl_op);
-	// set statictics and physical properties
+	// set statistics and physical properties
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 	// add constructed children

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerRoutedMotion.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerRoutedMotion.cpp
@@ -162,7 +162,7 @@ CParseHandlerRoutedMotion::EndElement(const XMLCh *const,  // element_uri,
 	GPOS_ASSERT(NULL != child_parse_handler);
 
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, m_dxl_op);
-	// set statictics and physical properties
+	// set statistics and physical properties
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 	// add children

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerSort.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerSort.cpp
@@ -181,7 +181,7 @@ CParseHandlerSort::EndElement(const XMLCh *const,  // element_uri,
 	GPOS_ASSERT(NULL != child_parse_handler);
 
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, m_dxl_op);
-	// set statictics and physical properties
+	// set statistics and physical properties
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 	// add children

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerSubqueryScan.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerSubqueryScan.cpp
@@ -146,7 +146,7 @@ CParseHandlerSubqueryScan::EndElement(const XMLCh *const,  // element_uri,
 	GPOS_ASSERT(NULL != child_parse_handler);
 
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, m_dxl_op);
-	// set statictics and physical properties
+	// set statistics and physical properties
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 	// add constructed children

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerTableScan.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerTableScan.cpp
@@ -189,7 +189,7 @@ CParseHandlerTableScan::EndElement(const XMLCh *const element_local_name,
 	m_dxl_op->SetTableDescriptor(table_descr);
 
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, m_dxl_op);
-	// set statictics and physical properties
+	// set statistics and physical properties
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 	// add constructed children


### PR DESCRIPTION
Currently, only fixes for compiler warnings related to ATExecAddInherit are included.
More minor warning fixes are planned for the future.