### PR TITLE
GG-16: Actualize workflows v7

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -41,7 +41,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v8
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v9
     with:
       version: 7
       target_os: ${{ matrix.target_os }}
@@ -59,7 +59,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v8
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v9
     with:
       version: 7
       target_os: ${{ matrix.target_os }}
@@ -77,7 +77,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v8
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v9
     with:
       version: 7
       target_os: ${{ matrix.target_os }}
@@ -113,7 +113,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-jit.yml@v8
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-jit.yml@v9
     with:
       version: 7
       target_os: ${{ matrix.target_os }}
@@ -131,7 +131,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-upload.yml@v8
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-upload.yml@v9
     with:
       version: 7
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
## Actualize workflows
The following workflows using new composite action for restore&load cached docker image instead of couple of restore and load actions - https://github.com/GreengageDB/greengage-ci/commit/d3cf5d59623218f054dcb436efed3665405f506e

Update reusable workflows to v9:
- behave-tests
- regression-tests
- orca-tests
- jit-tests
- upload

Ticket: [GG-16](https://tracker.yandex.ru/GG-16)