### PR TITLE
ADBDEV-8908: Fix inconsistency DROP IF EXISTS command

### DIFF
--- a/.abi-check/7.4.0/postgres.symbols.ignore
+++ b/.abi-check/7.4.0/postgres.symbols.ignore
@@ -1,0 +1,1 @@
+ConfigureNamesBool_gp

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -324,6 +324,7 @@ def connect(user=None, password=None, host=None, port=None,
     '''Connect to DB using parameters in GV'''
     # unset search path due to CVE-2018-1058
     options = '-c search_path='
+    options += ' -c gp_dispatch_drop_always=on'
     if utilityMode:
         options += ' -c gp_role=utility'
     for val in GV.opt['-x']:

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -432,6 +432,8 @@ bool		gp_allow_date_field_width_5digits = false;
 
 bool		gp_track_pending_delete = true;
 
+bool		gp_dispatch_drop_always = false;
+
 /* GUCs for Just In Time (JIT) compilation */
 double		optimizer_jit_above_cost;
 double		optimizer_jit_inline_above_cost;
@@ -3067,6 +3069,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&gp_track_pending_delete,
 		true,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"gp_dispatch_drop_always", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Dispatch DROP if object doesn't exist on coordinator"),
+			NULL,
+			GUC_DISALLOW_IN_FILE | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_dispatch_drop_always,
+		false,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -593,6 +593,8 @@ extern bool gp_allow_date_field_width_5digits;
 
 extern bool gp_track_pending_delete;
 
+extern bool gp_dispatch_drop_always;
+
 extern bool gp_enable_blkdir_sampling;
 
 typedef enum

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -565,4 +565,5 @@
 		"xmlbinary",
 		"xmloption",
 		"gp_track_pending_delete",
+		"gp_dispatch_drop_always",
 		"max_slot_wal_keep_size",

--- a/src/test/isolation2/expected/drop_rename.out
+++ b/src/test/isolation2/expected/drop_rename.out
@@ -110,3 +110,98 @@ DROP TABLE
 ERROR:  relation "t3" does not exist
 LINE 1: select count(*) from t3;
                              ^
+
+-- Ensure DROP doesn't make inconsistency
+-- start_ignore
+drop table if exists t4;
+DROP TABLE
+-- end_ignore
+select gp_inject_fault('wait_before_drop_dispatch', 'suspend', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&:drop table if exists t4;  <waiting ...>
+create table t4 (a int, b text) distributed by (a);
+CREATE TABLE
+select gp_wait_until_triggered_fault('wait_before_drop_dispatch', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+select gp_inject_fault('wait_before_drop_dispatch', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1<:  <... completed>
+DROP TABLE
+table t4;
+ a | b 
+---+---
+(0 rows)
+drop table t4;
+DROP TABLE
+
+-- start_ignore
+drop type if exists t5;
+DROP TYPE
+-- end_ignore
+select gp_inject_fault('wait_before_drop_dispatch', 'suspend', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&:drop type if exists t5;  <waiting ...>
+create type t5 as (a int, b text);
+CREATE TYPE
+select gp_wait_until_triggered_fault('wait_before_drop_dispatch', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+select gp_inject_fault('wait_before_drop_dispatch', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1<:  <... completed>
+DROP TYPE
+select null::t5 from gp_dist_random('gp_id');
+ t5 
+----
+    
+    
+    
+(3 rows)
+drop type t5;
+DROP TYPE
+
+-- start_ignore
+drop schema if exists t6;
+DROP SCHEMA
+-- end_ignore
+select gp_inject_fault('wait_before_drop_dispatch', 'suspend', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&:drop schema if exists t6;  <waiting ...>
+create schema t6;
+CREATE SCHEMA
+select gp_wait_until_triggered_fault('wait_before_drop_dispatch', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+select gp_inject_fault('wait_before_drop_dispatch', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1<:  <... completed>
+DROP SCHEMA
+create table t6.t7 (a int, b text) distributed by (a);
+CREATE TABLE
+drop schema t6 cascade;
+DROP SCHEMA

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -74,7 +74,8 @@ test: deadlock_under_entry_db_singleton
 #  conflict when running in parallel with other cases.
 test: misc
 
-test: starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock bitmap_index_ao_sparse
+test: drop_rename
+test: starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa reader_waits_for_lock bitmap_index_ao_sparse
 
 test: create_index_deadlock
 

--- a/src/test/isolation2/sql/drop_rename.sql
+++ b/src/test/isolation2/sql/drop_rename.sql
@@ -54,3 +54,40 @@
 3<:
 2<:
 2:select count(*) from t3;
+
+-- Ensure DROP doesn't make inconsistency
+-- start_ignore
+drop table if exists t4;
+-- end_ignore
+select gp_inject_fault('wait_before_drop_dispatch', 'suspend', 1);
+1&:drop table if exists t4;
+create table t4 (a int, b text) distributed by (a);
+select gp_wait_until_triggered_fault('wait_before_drop_dispatch', 1, 1);
+select gp_inject_fault('wait_before_drop_dispatch', 'reset', 1);
+1<:
+table t4;
+drop table t4;
+
+-- start_ignore
+drop type if exists t5;
+-- end_ignore
+select gp_inject_fault('wait_before_drop_dispatch', 'suspend', 1);
+1&:drop type if exists t5;
+create type t5 as (a int, b text);
+select gp_wait_until_triggered_fault('wait_before_drop_dispatch', 1, 1);
+select gp_inject_fault('wait_before_drop_dispatch', 'reset', 1);
+1<:
+select null::t5 from gp_dist_random('gp_id');
+drop type t5;
+
+-- start_ignore
+drop schema if exists t6;
+-- end_ignore
+select gp_inject_fault('wait_before_drop_dispatch', 'suspend', 1);
+1&:drop schema if exists t6;
+create schema t6;
+select gp_wait_until_triggered_fault('wait_before_drop_dispatch', 1, 1);
+select gp_inject_fault('wait_before_drop_dispatch', 'reset', 1);
+1<:
+create table t6.t7 (a int, b text) distributed by (a);
+drop schema t6 cascade;

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -630,7 +630,6 @@ INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL cont
 -- the tests will fail.
 drop table if exists bar_randDistr;
 NOTICE:  table "bar_randdistr" does not exist, skipping
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 create table bar_randDistr(col1 int, col2 int) distributed randomly;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
@@ -1079,7 +1078,6 @@ INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 0
 --test direct dispatch if distribution column is of varchar type
 drop table if exists t1_varchar;
 NOTICE:  table "t1_varchar" does not exist, skipping
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 create table t1_varchar(col1_varchar varchar, col2_int int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1_varchar' as the Greengage Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -1312,7 +1310,6 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 --No direct dispatch case, scenario: cast exists but not binary coercible
 drop table if exists t3;
 NOTICE:  table "t3" does not exist, skipping
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 create table t3 (c1 timestamp without time zone);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greengage Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -1346,10 +1343,8 @@ INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL cont
 --check direct dispatch working based on the distribution policy of relation
 drop extension if exists citext cascade;
 NOTICE:  extension "citext" does not exist, skipping
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 drop table if exists srt_dd;
 NOTICE:  table "srt_dd" does not exist, skipping
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 CREATE EXTENSION citext;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
@@ -1406,7 +1401,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 drop table if exists srt_dd;
 NOTICE:  table "srt_dd" does not exist, skipping
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 -- test direct dispatch via SQLValueFunction and FuncExpr for single row insertion.
 create table t_sql_value_function1 (a int, b date);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greengage Database data distribution key for this table.

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -647,7 +647,6 @@ INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL cont
 -- the tests will fail.
 drop table if exists bar_randDistr;
 NOTICE:  table "bar_randdistr" does not exist, skipping
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 create table bar_randDistr(col1 int, col2 int) distributed randomly;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
@@ -1094,7 +1093,6 @@ INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
 --test direct dispatch if distribution column is of varchar type
 drop table if exists t1_varchar;
 NOTICE:  table "t1_varchar" does not exist, skipping
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 create table t1_varchar(col1_varchar varchar, col2_int int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1_varchar' as the Greengage Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -1327,7 +1325,6 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 --No direct dispatch case, scenario: cast exists but not binary coercible
 drop table if exists t3;
 NOTICE:  table "t3" does not exist, skipping
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 create table t3 (c1 timestamp without time zone);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greengage Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -1361,10 +1358,8 @@ INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL cont
 --check direct dispatch working based on the distribution policy of relation
 drop extension if exists citext cascade;
 NOTICE:  extension "citext" does not exist, skipping
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 drop table if exists srt_dd;
 NOTICE:  table "srt_dd" does not exist, skipping
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 CREATE EXTENSION citext;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
@@ -1420,7 +1415,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 drop table if exists srt_dd;
 NOTICE:  table "srt_dd" does not exist, skipping
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 -- test direct dispatch via SQLValueFunction and FuncExpr for single row insertion.
 create table t_sql_value_function1 (a int, b date);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greengage Database data distribution key for this table.


### PR DESCRIPTION
Fix inconsistency DROP IF EXISTS command

When the DROP IF EXISTS command is called, it is unconditionally dispatched to
the segments, even if the object doesn't exist on the coordinator. This can
lead to inconsistencies, for example:

- the first session starts a table drop on the coordinator. Even though the
table doesn't exist, the drop is still dispatched to the segments.

- at the same time, the second session creates the table (on the coordinator
and on the segments).

- the first session (on the segments) already sees the table and therefore
deletes it.

Don't dispatch DROP if object doesn't exist on coordinator. Exclude the
drop_rename test from the parallel group because it contains fault-injectors.
Add a new GUC, gp_dispatch_drop_always, for unconditional DROP dispatch even if
the object isn't present on the coordinator, as this functionality is used by
the gpcheckcat utility, for example, in the orphan_temp_table test.

(cherry picked from commit 3bd88175e9906db0bef54b64ac944cc5eda0f32c)

Changes:

1) The RemoveObjects function no longer has the local variable cell2 and the
condition with stmt->arguments to fill it.

2) The ExecDropStmt function no longer has the OBJECT_EXTTABLE case.

3) The condition on stmt->removeType in the ExecDropStmt function has been
generalized using the shouldDispatchForObject function.

4) The output has been adapted in the drop_rename and direct_dispatch tests.

5) Improved issue reproduction in the drop_rename test.

Ticket: ADBDEV-8908

---
!!! REBASE !!!