### PR TITLE
ADBDEV-9025: Prohibit skip-level correlated queries in Postgres planner

### DIFF
--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -420,7 +420,8 @@ get_first_col_type(Plan *plan, Oid *coltype, int32 *coltypmod,
 }
 
 /**
- * Returns true if query refers to any distributed table.
+ * Returns true if query refers to any table on this level or on some other
+ * subquery level, if recursive is true.
  */
 bool QueryHasDistributedRelation(Query *q, bool recursive)
 {

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3918,21 +3918,16 @@ reset optimizer_trace_fallback;
 CREATE TABLE skip_correlated_partitioned (
     a INT
 ) DISTRIBUTED BY (a);
-INSERT INTO skip_correlated_partitioned VALUES(1);
-INSERT INTO skip_correlated_partitioned VALUES(2);
-INSERT INTO skip_correlated_partitioned VALUES(3);
+INSERT INTO skip_correlated_partitioned VALUES (1), (2), (3);
 CREATE TABLE skip_correlated_random (
     b INT
 ) DISTRIBUTED RANDOMLY;
-INSERT INTO skip_correlated_random VALUES(1);
-INSERT INTO skip_correlated_random VALUES(2);
-INSERT INTO skip_correlated_random VALUES(3);
+INSERT INTO skip_correlated_random VALUES (1), (2), (3);
 CREATE TABLE skip_correlated_replicated (
     c INT
 ) DISTRIBUTED REPLICATED;
-INSERT INTO skip_correlated_replicated VALUES(1);
-INSERT INTO skip_correlated_replicated VALUES(2);
-INSERT INTO skip_correlated_replicated VALUES(3);
+INSERT INTO skip_correlated_replicated VALUES(1), (2), (3);
+-- easy cases
 EXPLAIN (COSTS OFF)
 SELECT (
     SELECT (
@@ -3978,6 +3973,41 @@ SELECT (
         SELECT dbid FROM gp_segment_configuration WHERE dbid = a
     )
 ) FROM skip_correlated_partitioned;
+ERROR:  correlated subquery with skip-level correlations is not supported
+-- hard cases
+EXPLAIN (COSTS OFF)
+SELECT (
+    SELECT (
+        SELECT (
+            SELECT a FROM skip_correlated_partitioned WHERE a = c
+        ) 
+    )
+) AS l1 FROM skip_correlated_replicated ORDER BY l1;
+ERROR:  correlated subquery with skip-level correlations is not supported
+SELECT (
+    SELECT (
+        SELECT (
+            SELECT a FROM skip_correlated_partitioned WHERE a = c
+        ) 
+    )
+) AS l1 FROM skip_correlated_replicated ORDER BY l1;
+ERROR:  correlated subquery with skip-level correlations is not supported
+EXPLAIN (COSTS OFF)
+SELECT (
+    SELECT (
+        SELECT (
+            SELECT a FROM skip_correlated_partitioned WHERE a = c and a = b
+        ) as l3 FROM skip_correlated_random ORDER BY l3 LIMIT 1
+    )
+) AS l1 FROM skip_correlated_replicated ORDER BY l1;
+ERROR:  correlated subquery with skip-level correlations is not supported
+SELECT (
+    SELECT (
+        SELECT (
+            SELECT a FROM skip_correlated_partitioned WHERE a = c and a = b
+        ) as l3 FROM skip_correlated_random ORDER BY l3 LIMIT 1
+    )
+) AS l1 FROM skip_correlated_replicated ORDER BY l1;
 ERROR:  correlated subquery with skip-level correlations is not supported
 DROP TABLE skip_correlated_partitioned;
 DROP TABLE skip_correlated_random;

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -4068,21 +4068,16 @@ reset optimizer_trace_fallback;
 CREATE TABLE skip_correlated_partitioned (
     a INT
 ) DISTRIBUTED BY (a);
-INSERT INTO skip_correlated_partitioned VALUES(1);
-INSERT INTO skip_correlated_partitioned VALUES(2);
-INSERT INTO skip_correlated_partitioned VALUES(3);
+INSERT INTO skip_correlated_partitioned VALUES (1), (2), (3);
 CREATE TABLE skip_correlated_random (
     b INT
 ) DISTRIBUTED RANDOMLY;
-INSERT INTO skip_correlated_random VALUES(1);
-INSERT INTO skip_correlated_random VALUES(2);
-INSERT INTO skip_correlated_random VALUES(3);
+INSERT INTO skip_correlated_random VALUES (1), (2), (3);
 CREATE TABLE skip_correlated_replicated (
     c INT
 ) DISTRIBUTED REPLICATED;
-INSERT INTO skip_correlated_replicated VALUES(1);
-INSERT INTO skip_correlated_replicated VALUES(2);
-INSERT INTO skip_correlated_replicated VALUES(3);
+INSERT INTO skip_correlated_replicated VALUES(1), (2), (3);
+-- easy cases
 EXPLAIN (COSTS OFF)
 SELECT (
     SELECT (
@@ -4183,6 +4178,91 @@ SELECT (
     )
 ) FROM skip_correlated_partitioned;
 ERROR:  correlated subquery with skip-level correlations is not supported
+-- hard cases
+EXPLAIN (COSTS OFF)
+SELECT (
+    SELECT (
+        SELECT (
+            SELECT a FROM skip_correlated_partitioned WHERE a = c
+        ) 
+    )
+) AS l1 FROM skip_correlated_replicated ORDER BY l1;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Sort
+   Sort Key: ((SubPlan 1))
+   ->  Result
+         ->  Gather Motion 1:1  (slice1; segments: 1)
+               ->  Seq Scan on skip_correlated_replicated
+         SubPlan 1  (slice0)
+           ->  Result
+                 Filter: (skip_correlated_partitioned.a = skip_correlated_replicated.c)
+                 ->  Materialize
+                       ->  Gather Motion 3:1  (slice2; segments: 3)
+                             ->  Seq Scan on skip_correlated_partitioned
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+SELECT (
+    SELECT (
+        SELECT (
+            SELECT a FROM skip_correlated_partitioned WHERE a = c
+        ) 
+    )
+) AS l1 FROM skip_correlated_replicated ORDER BY l1;
+ l1 
+----
+  1
+  2
+  3
+(3 rows)
+
+EXPLAIN (COSTS OFF)
+SELECT (
+    SELECT (
+        SELECT (
+            SELECT a FROM skip_correlated_partitioned WHERE a = c and a = b
+        ) as l3 FROM skip_correlated_random ORDER BY l3 LIMIT 1
+    )
+) AS l1 FROM skip_correlated_replicated ORDER BY l1;
+                                                                                 QUERY PLAN                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: ((SubPlan 2))
+   ->  Result
+         ->  Gather Motion 1:1  (slice1; segments: 1)
+               ->  Seq Scan on skip_correlated_replicated
+         SubPlan 2  (slice0)
+           ->  Limit
+                 ->  Sort
+                       Sort Key: ((SubPlan 1))
+                       ->  Result
+                             ->  Materialize
+                                   ->  Gather Motion 3:1  (slice2; segments: 3)
+                                         ->  Seq Scan on skip_correlated_random
+                             SubPlan 1  (slice0)
+                               ->  Result
+                                     Filter: ((skip_correlated_partitioned.a = skip_correlated_replicated.c) AND (skip_correlated_partitioned.a = skip_correlated_random.b))
+                                     ->  Materialize
+                                           ->  Gather Motion 3:1  (slice3; segments: 3)
+                                                 ->  Seq Scan on skip_correlated_partitioned
+ Optimizer: Pivotal Optimizer (GPORCA)
+(20 rows)
+
+SELECT (
+    SELECT (
+        SELECT (
+            SELECT a FROM skip_correlated_partitioned WHERE a = c and a = b
+        ) as l3 FROM skip_correlated_random ORDER BY l3 LIMIT 1
+    )
+) AS l1 FROM skip_correlated_replicated ORDER BY l1;
+ l1 
+----
+  1
+  2
+  3
+(3 rows)
+
 DROP TABLE skip_correlated_partitioned;
 DROP TABLE skip_correlated_random;
 DROP TABLE skip_correlated_replicated;

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -846,24 +846,19 @@ DROP TABLE IF EXISTS skip_correlated_replicated;
 CREATE TABLE skip_correlated_partitioned (
     a INT
 ) DISTRIBUTED BY (a);
-INSERT INTO skip_correlated_partitioned VALUES(1);
-INSERT INTO skip_correlated_partitioned VALUES(2);
-INSERT INTO skip_correlated_partitioned VALUES(3);
+INSERT INTO skip_correlated_partitioned VALUES (1), (2), (3);
 
 CREATE TABLE skip_correlated_random (
     b INT
 ) DISTRIBUTED RANDOMLY;
-INSERT INTO skip_correlated_random VALUES(1);
-INSERT INTO skip_correlated_random VALUES(2);
-INSERT INTO skip_correlated_random VALUES(3);
+INSERT INTO skip_correlated_random VALUES (1), (2), (3);
 
 CREATE TABLE skip_correlated_replicated (
     c INT
 ) DISTRIBUTED REPLICATED;
-INSERT INTO skip_correlated_replicated VALUES(1);
-INSERT INTO skip_correlated_replicated VALUES(2);
-INSERT INTO skip_correlated_replicated VALUES(3);
+INSERT INTO skip_correlated_replicated VALUES(1), (2), (3);
 
+-- easy cases
 EXPLAIN (COSTS OFF)
 SELECT (
     SELECT (
@@ -906,6 +901,39 @@ SELECT (
         SELECT dbid FROM gp_segment_configuration WHERE dbid = a
     )
 ) FROM skip_correlated_partitioned;
+
+-- hard cases
+EXPLAIN (COSTS OFF)
+SELECT (
+    SELECT (
+        SELECT (
+            SELECT a FROM skip_correlated_partitioned WHERE a = c
+        ) 
+    )
+) AS l1 FROM skip_correlated_replicated ORDER BY l1;
+SELECT (
+    SELECT (
+        SELECT (
+            SELECT a FROM skip_correlated_partitioned WHERE a = c
+        ) 
+    )
+) AS l1 FROM skip_correlated_replicated ORDER BY l1;
+
+EXPLAIN (COSTS OFF)
+SELECT (
+    SELECT (
+        SELECT (
+            SELECT a FROM skip_correlated_partitioned WHERE a = c and a = b
+        ) as l3 FROM skip_correlated_random ORDER BY l3 LIMIT 1
+    )
+) AS l1 FROM skip_correlated_replicated ORDER BY l1;
+SELECT (
+    SELECT (
+        SELECT (
+            SELECT a FROM skip_correlated_partitioned WHERE a = c and a = b
+        ) as l3 FROM skip_correlated_random ORDER BY l3 LIMIT 1
+    )
+) AS l1 FROM skip_correlated_replicated ORDER BY l1;
 
 DROP TABLE skip_correlated_partitioned;
 DROP TABLE skip_correlated_random;


### PR DESCRIPTION
Prohibit skip-level correlated queries in Postgres planner

What occurs?
Postgres planner creates an invalid plan with skip-level correlation involving
master-only and replicated tables. The plan fails to be executed during
execution.

Why it occurs?
Skip-level correlation (at least for distributed tables) seems to be prohibited
in Postgres planner due to rescanning issues that arise - they appear, because
the lowest level plan is made an initplan without correct motion node applied.
ORCA planner produces valid plans for such queries, but not with master-only
tables - it seems to lack a feature to work with them whatsoever.

How do we fix this?
Let's prohibit any skip-level correlation for Postgres Legacy planner as it
leads to rescan issues because of absent motions. 

Alternative fixes?
Changing some checks for initplans creation and enabling skip-level correlation
make Postgres produces correct plan - initplan is changed to subplan and
correct motions are applied. Yet, one test from rangefuncs fails. So, some
research is needed.

Tests?
Newly added tests check that ORCA is able to plan and execute simple skip-level
correlated plans, whereas Postgres planner outputs an error about lack of
skip-level correlation support.