### PR TITLE
ADBDEV-8790: Move dispatch result checking to exector finish

### DIFF
--- a/contrib/auto_explain/auto_explain.c
+++ b/contrib/auto_explain/auto_explain.c
@@ -387,10 +387,6 @@ explain_ExecutorEnd(QueryDesc *queryDesc)
 		MemoryContext oldcxt;
 		double		msec;
 
-		/* Wait for completion of all qExec processes. */
-		if (queryDesc->estate->dispatcherState && queryDesc->estate->dispatcherState->primaryResults)
-			cdbdisp_checkDispatchResult(queryDesc->estate->dispatcherState, DISPATCH_WAIT_NONE);
-
 		/*
 		 * Make sure we operate in the per-query context, so any cruft will be
 		 * discarded later during ExecutorEnd.

--- a/contrib/pg_stat_statements/expected/pg_stat_statements.out
+++ b/contrib/pg_stat_statements/expected/pg_stat_statements.out
@@ -203,15 +203,15 @@ SELECT * FROM test WHERE a IN (1, 2, 3, 4, 5);
 SELECT query, calls, rows FROM pg_stat_statements ORDER BY query COLLATE "C";
                             query                            | calls | rows 
 -------------------------------------------------------------+-------+------
- DELETE FROM test WHERE a > $1                               |     1 |    0
- INSERT INTO test (a, b) VALUES ($1, $2), ($3, $4), ($5, $6) |     1 |    0
- INSERT INTO test VALUES(generate_series($1, $2), $3)        |     1 |    0
+ DELETE FROM test WHERE a > $1                               |     1 |    1
+ INSERT INTO test (a, b) VALUES ($1, $2), ($3, $4), ($5, $6) |     1 |    3
+ INSERT INTO test VALUES(generate_series($1, $2), $3)        |     1 |   10
  SELECT * FROM test ORDER BY a, b                            |     1 |   12
  SELECT * FROM test WHERE a > $1 ORDER BY a                  |     2 |    4
  SELECT * FROM test WHERE a IN ($1, $2, $3, $4, $5)          |     1 |    8
  SELECT pg_stat_statements_reset()                           |     1 |    1
- UPDATE test SET b = $1 WHERE a = $2                         |     6 |    0
- UPDATE test SET b = $1 WHERE a > $2                         |     1 |    0
+ UPDATE test SET b = $1 WHERE a = $2                         |     6 |    6
+ UPDATE test SET b = $1 WHERE a > $2                         |     1 |    3
 (9 rows)
 
 --

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -708,24 +708,6 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
 		/* run the plan */
 		ExecutorRun(queryDesc, dir, 0L, true);
 
-		/* Wait for completion of all qExec processes. */
-		if (queryDesc->estate->dispatcherState && queryDesc->estate->dispatcherState->primaryResults)
-		{
-			cdbdisp_checkDispatchResult(queryDesc->estate->dispatcherState, DISPATCH_WAIT_NONE);
-			/*
-			 * If some QE throw errors, we might not receive stats from QEs,
-			 * In ExecutorEnd we will reThrow QE's error, In this situation,
-			 * there is no need to execute ExplainPrintPlan. reThrow error in advance.
-			 */
-			ErrorData  *qeError = NULL;
-			cdbdisp_getDispatchResults(queryDesc->estate->dispatcherState, &qeError);
-			if (qeError)
-			{
-				FlushErrorState();
-				ThrowErrorData(qeError);
-			}
-		}
-
 		/* run cleanup too */
 		ExecutorFinish(queryDesc);
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1182,6 +1182,25 @@ standard_ExecutorFinish(QueryDesc *queryDesc)
 	if (queryDesc->totaltime)
 		InstrStopNode(queryDesc->totaltime, 0);
 
+	/*
+	 * if needed, collect mpp dispatch results and tear down
+	 * all mpp specific resources (e.g. interconnect).
+	 */
+	PG_TRY();
+	{
+		mppExecutorFinishup(queryDesc);
+	}
+	PG_CATCH();
+	{
+		/*
+		 * we got an error. do all the necessary cleanup.
+		 */
+		mppExecutorCleanup(queryDesc);
+
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
 	MemoryContextSwitchTo(oldcontext);
 
 	estate->es_finished = true;
@@ -1276,44 +1295,14 @@ standard_ExecutorEnd(QueryDesc *queryDesc)
 		cdbexplain_sendExecStats(queryDesc);
 
 	/*
-	 * if needed, collect mpp dispatch results and tear down
-	 * all mpp specific resources (e.g. interconnect).
+	 * Free the results of all gangs.
 	 */
-	PG_TRY();
+	if (estate->dispatcherState && estate->dispatcherState->primaryResults)
 	{
-		mppExecutorFinishup(queryDesc);
+		CdbDispatcherState *ds = estate->dispatcherState;
+		estate->dispatcherState = NULL;
+		cdbdisp_destroyDispatcherState(ds);
 	}
-	PG_CATCH();
-	{
-		/*
-		 * we got an error. do all the necessary cleanup.
-		 */
-		mppExecutorCleanup(queryDesc);
-
-		/*
-		 * Remove our own query's motion layer.
-		 */
-		RemoveMotionLayer(estate->motionlayer_context);
-
-		/*
-		 * GPDB specific
-		 * Clean the special resources created by INITPLAN.
-		 * The resources have long life cycle and are used by the main plan.
-		 * It's too early to clean them in preprocess_initplans.
-		 */
-		if (list_length(queryDesc->plannedstmt->paramExecTypes) > 0)
-		{
-			postprocess_initplans(queryDesc);
-		}
-
-		/*
-		 * Release EState and per-query memory context.
-		 */
-		FreeExecutorState(estate);
-
-		PG_RE_THROW();
-	}
-	PG_END_TRY();
 
 	/*
 	 * GPDB specific

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1599,14 +1599,6 @@ void mppExecutorFinishup(QueryDesc *queryDesc)
 
 		/* sum up rejected rows if any (single row error handling only) */
 		cdbdisp_sumRejectedRows(pr);
-
-		/*
-		 * Check and free the results of all gangs. If any QE had an
-		 * error, report it and exit to our error handler via PG_THROW.
-		 * NB: This call doesn't wait, because we already waited above.
-		 */
-		estate->dispatcherState = NULL;
-		cdbdisp_destroyDispatcherState(ds);
 	}
 }
 

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -447,3 +447,10 @@ explain (slicetable, costs off, format json) SELECT * FROM explaintest;
  ]
 (1 row)
 
+-- explain should not hide error from segment
+-- error must be handled by executor earlier
+CREATE TABLE t1 (a int);
+EXPLAIN ANALYZE INSERT INTO t1 SELECT 1/gp_segment_id
+FROM gp_dist_random('gp_id');
+ERROR:  division by zero  (seg0 slice1 172.17.0.2:6002 pid=13088)
+DROP TABLE t1;

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -467,3 +467,10 @@ explain (slicetable, costs off, format json) SELECT * FROM explaintest;
  ]
 (1 row)
 
+-- explain should not hide error from segment
+-- error must be handled by executor earlier
+CREATE TABLE t1 (a int);
+EXPLAIN ANALYZE INSERT INTO t1 SELECT 1/gp_segment_id
+FROM gp_dist_random('gp_id');
+ERROR:  division by zero  (seg0 slice1 172.17.0.2:6002 pid=13088)
+DROP TABLE t1;

--- a/src/test/regress/expected/gp_query_id.out
+++ b/src/test/regress/expected/gp_query_id.out
@@ -726,8 +726,6 @@ NOTICE:  START ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 
 NOTICE:  END ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 108
 NOTICE:  START ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 108
 NOTICE:  END ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 108
-NOTICE:  START ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 108
-NOTICE:  END ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 108
 NOTICE:  END ExecutorRun | Q: select sirv_function(); | QUERY ID: 106
 ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg1 127.0.1.1:7003 pid=1429662)
 CONTEXT:  SQL statement "insert into test_data values (1, 1)"

--- a/src/test/regress/expected/gp_query_id_optimizer.out
+++ b/src/test/regress/expected/gp_query_id_optimizer.out
@@ -726,8 +726,6 @@ NOTICE:  START ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 
 NOTICE:  END ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 108
 NOTICE:  START ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 108
 NOTICE:  END ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 108
-NOTICE:  START ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 108
-NOTICE:  END ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 108
 NOTICE:  END ExecutorRun | Q: select sirv_function(); | QUERY ID: 106
 ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg1 127.0.1.1:7003 pid=1445883)
 CONTEXT:  SQL statement "insert into test_data values (1, 1)"

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -202,3 +202,10 @@ explain (slicetable, costs off) SELECT * FROM explaintest;
 
 -- same in JSON format
 explain (slicetable, costs off, format json) SELECT * FROM explaintest;
+
+-- explain should not hide error from segment
+-- error must be handled by executor earlier
+CREATE TABLE t1 (a int);
+EXPLAIN ANALYZE INSERT INTO t1 SELECT 1/gp_segment_id
+FROM gp_dist_random('gp_id');
+DROP TABLE t1;


### PR DESCRIPTION
Move dispatch result checking to exector finish

This patch synchronizes executor state on the coordinator between
ExecutorFinish and ExecutorEnd with upstream Postgres. Instrumentation
should be ready to analyze between these calls. Before these changes,
the executor on coordinator could finish earlier than executors on segments
(e.g. during insert). This is why we were needed to wait for dispatch results
outside of executor functions. There were at least two consequences:

1. We must check errors in dispatch results not only dispatch results presence.
Currently, explain analyze doesn't handle errors on segments and try to handle
partial instrumentation. It may fail to apply instrumentation in case of
an error on the content with id 0 and mask an original error from the segment
with the confusing error message. Moreover, such manipulations are useless
because the error will be detected later during the ExecutorEnd phase, and
explain output will be discarded.
2. We break executor hooks flow. gpdb handles query cancel flag only inside
mppExecutorCleanup inside every executor stage (Start, Run, Finish, End).
Errors generated by CHECK_FOR_INTERRUPTS calls (e.g. inside
checkDispatchResults) outside the executor functions will be not handled
properly and won't notify monitoring systems.

I propose moving mppFinishQuery to ExecutorFinish to solve both of these
problems. The coordinator will wait for dispatch results and handle errors
on segments before `explain analyze` processing. Destroying of dispatcher
state stay in the ExecutorEnd because is required for `explain analyze`.
Comment above the destroyDispatcherState call removed by me was inherited
from the previous implementation with `cdbdisp_finishCommand`.
destroyDispatcherState doesn't use checkDispatchResult, and shouldn't be
interruptable because frees memory allocated by the standard library allocator.

Cherry-picked-from: 0b4aa66877f1b720763af3724dd5845dcb17e369
to solve conflicts with: c0e45fd39de616796a847d287a517fd007f8eeac and a5d36791329a80ad3471808e166c0bb05ee7c0d0

Changes from original commit:
- Fixed gp_query_id test output.
- Fixed pg_stat_statements test output.

(cherry picked from commit bbf9fbae88b46cbc2898bab3247f74925a1ca154)

---

Note: should work test with adcc-extension, both in its current state and also after applying this diff to it to remove the wait condition
```diff
diff --git a/adcc-extension/src/hook/adcc_ExecutorEnd.c b/adcc-extension/src/hook/adcc_ExecutorEnd.c
index 57a2fb351..72d34d43c 100644
--- a/adcc-extension/src/hook/adcc_ExecutorEnd.c
+++ b/adcc-extension/src/hook/adcc_ExecutorEnd.c
@@ -67,12 +67,6 @@ adcc_ExecutorEnd_hook_pre(hook_data_t * data)
 	{
 		double		msec;
 
-		/* Wait for completion of all qExec processes. */
-		if (queryDesc->estate->dispatcherState &&
-			queryDesc->estate->dispatcherState->primaryResults)
-			cdbdisp_checkDispatchResult(queryDesc->estate->dispatcherState,
-										DISPATCH_WAIT_NONE);
-
 		/*
 		 * Make sure stats accumulation is done. (Note: it's okay if several
 		 * levels of hook all do this.)
```

Note: do not squash to preserve authorship