### PR TITLE
GG-73: Port Orca CCTETest unit test changes to 6.x

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/CTEMergeGroupsCircularDeriveStats2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEMergeGroupsCircularDeriveStats2.mdp
@@ -366,7 +366,7 @@
     <dxl:Plan Id="0" SpaceSize="116">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.001083" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.001283" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="40" Alias="a">
@@ -392,7 +392,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.000993" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.001193" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="40" Alias="a">
@@ -424,7 +424,7 @@
           </dxl:HashCondList>
           <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000378" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000478" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="40" Alias="a">
@@ -446,7 +446,7 @@
             </dxl:HashExprList>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000359" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000459" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="40" Alias="a">


### PR DESCRIPTION
The patch fixes a test added in b5bdddabcd5e517948bbf23e9e0f039d62df05ba that was broken because of the
cost model changes related to hash join introduced in 810d51b4c5a2bf37b5a1f8f5b72b34a75f77f8a4.
As a result of these changes, both hash joins present in the test
are expected to have a higher cost.

The fix for the issue is a simple update of the plan cost reported by the test
that makes it comply with the current cost model.

(cherry picked from commit 5d7693ec9f9f19c5f76a4b93ca09bd6037f570c3)