### PR TITLE
ADBDEV-8988: Fix orphaned segment files for added and rolled back columns for AOCS tables

### DIFF
--- a/src/include/catalog/pg_attribute_encoding.h
+++ b/src/include/catalog/pg_attribute_encoding.h
@@ -77,6 +77,7 @@ extern void UpdateOrAddAttributeEncodingsAttoptionsOnly(Relation rel, List *new_
 extern void ClearAttributeEncodingLastrownums(Oid relid);
 extern void ClearAttributeEncodingLastrownumsByAttnum(Oid relid, int attnum);
 extern FileNumber GetFilenumForAttribute(Oid relid, AttrNumber attnum);
+extern AttrNumber GetAttnumForFilenum(Oid relid, FileNumber filenum);
 extern FileNumber GetFilenumForRewriteAttribute(Oid relid, AttrNumber attnum);
 extern List *GetNextNAvailableFilenums(Oid relid, int n);
 extern int64 *GetAttnumToLastrownumMapping(Oid relid, int natts);

--- a/src/test/regress/expected/vacuum_full_ao.out
+++ b/src/test/regress/expected/vacuum_full_ao.out
@@ -48,13 +48,83 @@ select current_setting('gp_contentid')::smallint, pg_relation_filepath(t)
 $function$
 language sql
 execute on all segments;
-select '\! (stat --format=''%s'' ' || string_agg(full_path_relfilenode, ' ') || ' 2>/dev/null || echo 0) | awk ''{sum += $1} END {print sum}''' check_segfiles_size from 
-(select d.datadir || '/' || f.filepath || '.*' as full_path_relfilenode from getTableSegFiles('table_ao_col'::regclass) f join gp_segment_configuration d
-on f.gp_contentid = d.content where d.content <> -1 and d.role = 'p')t
+create or replace function cmdCheckSegmentFileSizes(table_name text) returns text as
+$$
+declare
+  cmd text;
+begin
+  select '\! (stat --format=''%s'' ' || string_agg(full_path_relfilenode, ' ') || ' 2>/dev/null || echo 0) | awk ''{sum += $1} END {print sum}'''
+  into cmd
+  from
+  (select d.datadir || '/' || f.filepath || '.*' as full_path_relfilenode from getTableSegFiles(table_name::regclass) f join gp_segment_configuration d
+    on f.gp_contentid = d.content where d.content <> -1 and d.role = 'p')t;
+
+  return cmd;
+end
+$$ language plpgsql;
+select cmdCheckSegmentFileSizes('table_ao_col') check_segfiles_size
 \gset
 delete from table_ao_col where true;
 vacuum table_ao_col;
 :check_segfiles_size
 0
-drop function getTableSegFiles(t regclass, out gp_contentid smallint, out filepath text);
 drop table table_ao_col;
+-- Test that vacuum can process segment files created for a new column in an aborted transaction (case 1)
+create table table_ao_col_1 (i int, j int, k int) with (appendonly='true', orientation="column");
+insert into table_ao_col_1 select i, i + 1, i + 2 from generate_series(1, 20) i;
+alter table table_ao_col_1 alter column j type bigint;
+select attnum, filenum from gp_dist_random('pg_attribute_encoding') where gp_segment_id = 0 and attrelid = 'table_ao_col_1'::regclass;
+ attnum | filenum 
+--------+---------
+      1 |       1
+      3 |       3
+      2 |    1602
+(3 rows)
+
+begin;
+alter table table_ao_col_1 add column a int;
+alter table table_ao_col_1 add column b int;
+update table_ao_col_1 set a = 1, b = 2 where true;
+alter table table_ao_col_1 alter column a type bigint;
+select attnum, filenum from gp_dist_random('pg_attribute_encoding') where gp_segment_id = 0 and attrelid = 'table_ao_col_1'::regclass;
+ attnum | filenum 
+--------+---------
+      1 |       1
+      2 |    1602
+      3 |       3
+      4 |    1604
+      5 |       5
+(5 rows)
+
+rollback;
+select cmdCheckSegmentFileSizes('table_ao_col_1') check_segfiles_size_1
+\gset
+delete from table_ao_col_1 where true;
+vacuum table_ao_col_1;
+:check_segfiles_size_1
+0
+drop table table_ao_col_1;
+-- Test that vacuum can process segment files created for a new column in an aborted transaction (case 2)
+create table table_ao_col_2 (i int, j int, k int) with (appendonly='true', orientation="column");
+begin;
+insert into table_ao_col_2 select i, i + 1, i + 2 from generate_series(1, 20) i;
+alter table table_ao_col_2 alter column j type bigint;
+select attnum, filenum from gp_dist_random('pg_attribute_encoding') where gp_segment_id = 0 and attrelid = 'table_ao_col_2'::regclass;
+ attnum | filenum 
+--------+---------
+      1 |       1
+      3 |       3
+      2 |    1602
+(3 rows)
+
+alter table table_ao_col_2 add column a int;
+update table_ao_col_2 set a = 1 where true;
+rollback;
+select cmdCheckSegmentFileSizes('table_ao_col_2') check_segfiles_size_2
+\gset
+vacuum table_ao_col_2;
+:check_segfiles_size_2
+0
+drop table table_ao_col_2;
+drop function cmdCheckSegmentFileSizes(table_name text);
+drop function getTableSegFiles(t regclass, out gp_contentid smallint, out filepath text);


### PR DESCRIPTION
Fix orphaned segment files for added and rolled back columns for AOCS tables

Problem description:
In case we added a new column to a AOCS table in a transaction that was later
rolled back, a non-empty segment file could be left, and vacuum didn't truncate
it.

Root cause:
Vacuum does truncation of AOCS segment files in 2 places:
1. In AOCSSegmentFileTruncateToEOF(). It iterated over 'vpinfo.nEntry', which
doesn't count the added and rolled back attribute, so its segment file was not
processed here.
2. In AOCSCompaction_DropSegmentFile() function (if compaction is required for
the segment). It iterates over attributes retrieved by
RelationGetNumberOfAttributes(). But, the added and rolled back attribute is not
counted by RelationGetNumberOfAttributes(), so its segment file was not
processed here as well.

Fix:
In AOCSSegmentFileTruncateToEOF() iterate and truncate all segment files for
a given 'segno' until they exist. We stop once we didn't find a file and column
number is above 'vpinfo.nEntry'. We assume that the segment files exist or stop
existing for all columns thereafter - similar logic we already use in
ao_foreach_extent_file().

We do it not in AOCSCompaction_DropSegmentFile(), as it will not be called if
compaction is not required, while the orphaned segment files may still exist in
this case.

Changes from original commit:
We cannot use 'attnum' to iterate through segment files, since in GPDB 7 the
filenumber is stored explicitly in 'pg_attribute_encoding' system table.
Changes to this table are also rolled back, so we won't be able to find an
entry for the 'attnum' in there. Instead, iterate through possible filenums
and find the corresponding 'attnum'. If the file exists but has no entry in
'pg_attribute_encoding', it's safe to drop.
Notably, we can only stop when both filenum and filenum+1600 are missing,
since table rewrites can replace filenum with filenum+1600. This means we
must check filenums in order 1, 1601, 2, 1602, 3, 1603 etc. to ensure we
don't miss any.
Since filenums are allocated in order, for N-column table it's enough to
check filenums up to N and N+1600, and then more only if they exist.
(cherry picked from commit b5f63c6571e4300187a1d88e266520d0187fdd82)

Co-authored-by: Maxim Michkov <m.michkov@arenadata.io>

---
Note: Do not squash to preserve authorship