### PR TITLE
[GG-89] Fix gpexpand behave tests

### DIFF
--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -524,7 +524,7 @@ def createSegmentRows( hostlist
     content = 0
 
     for host in hostlist:
-        isprimary='t'
+        isprimary=True
         port=primary_portbase
         index = 0
         for pdir in primary_list:
@@ -555,7 +555,7 @@ def createSegmentRows( hostlist
         #      this is a general problem for GPDB these days.
         #      best to have the interface mapping stuff 1st.
         content=0
-        isprimary='f'
+        isprimary=False
         num_hosts = len(hostlist)
         num_dirs=len(primary_list)
         if num_hosts <= num_dirs:
@@ -610,7 +610,7 @@ def createSegmentRows( hostlist
         #we'll pick our mirror host to be 1 host "ahead" of the primary.
         mirror_host_offset = 1
 
-        isprimary='f'
+        isprimary=False
         for host in hostlist:
             mirror_host = hostlist[mirror_host_offset % num_hosts]
             mirror_host_offset += 1
@@ -661,7 +661,7 @@ def createSegmentRowsFromSegmentList( newHostlist
     interfaceDict = {}
 
     for host in newHostlist:
-        isprimary='t'
+        isprimary=True
         port=primary_portbase
         index = 0
         for pSeg in primary_segment_list:
@@ -690,7 +690,7 @@ def createSegmentRowsFromSegmentList( newHostlist
         return rows
     elif mirror_type.lower().strip() == 'spread':
         content=0
-        isprimary='f'
+        isprimary=False
         num_hosts = len(newHostlist)
         num_dirs=len(primary_segment_list)
         if num_hosts <= num_dirs:
@@ -743,7 +743,7 @@ def createSegmentRowsFromSegmentList( newHostlist
         #we'll pick our mirror host to be 1 host "ahead" of the primary.
         mirror_host_offset = 1
 
-        isprimary='f'
+        isprimary=False
         for host in newHostlist:
             mirror_host = newHostlist[mirror_host_offset % num_hosts]
             mirror_host_offset += 1

--- a/gpMgmt/test/behave_utils/gpexpand_dml.py
+++ b/gpMgmt/test/behave_utils/gpexpand_dml.py
@@ -31,7 +31,7 @@ class TestDML(threading.Thread):
     def run(self):
         with dbconn.connect(dbconn.DbURL(dbname=self.dbname), unsetSearchPath=False) as conn:
             self.loop(conn)
-            self.verify()
+            self.verify(conn)
             conn.commit()
 
     def prepare(self):
@@ -83,7 +83,7 @@ class TestDML(threading.Thread):
 
         return self.retval, self.retmsg
 
-    def verify(self):
+    def verify(self, conn):
         pass
 
     def stop(self):


### PR DESCRIPTION
The previous commit (c0bc5c2e78b912bccfd709f6683cb025dd2b5d65) added a few
regressions. The regression was related to replacing the comparison condition of
the comparison with 't' with a truth check. This change is due to the fact that
in PyGreSQL 5, unlike the 4th version, it converts the bool values. But it was
not taken into account that such values can be set in Python code.
The error of calling verify in TestDML has also been fixed. The verify method
was called without passing a connection, and although the verify implementation
in the class itself does not require a connection, this function may be
overloaded in a child class.