### PR TITLE
GG-98: Implement Always run the Allure renderer for 6X

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -41,7 +41,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v9
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v14
     with:
       version: 6
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
### Implement Always run the Allure renderer for 6X (#188)
Bump `greengage-reusable-tests-behave.yml` version to `v14` 
Fixed a bug where the Allure report was not generated if one of the Behave tests failed. 
Now all reports are generated and exported to artifacts regardless of the Behave tests completion status.

- Tests passed:
  - for [success](https://github.com/uaqq/greengage/actions/runs/21206189085/job/61003146133)
  - expected [fails](https://github.com/uaqq/greengage/actions/runs/21186326447)

Task: [GG-97](https://tracker.yandex.ru/GG-97)