### PR TITLE
GG-115: Fix the gprecoverseg keeps segment logs test

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -736,6 +736,8 @@ Feature: gprecoverseg tests
       And user can start transactions
       And the user runs "gprecoverseg -a"
       Then gprecoverseg should return a return code of 0
+      And the segments are synchronized
+      And the cluster is rebalanced
       And the "primary" segment pg_log directory content preserved
 
 


### PR DESCRIPTION
Fix the gprecoverseg keeps segment logs test

Commit d306009 added a new "gprecoverseg keeps segment logs" test to the
gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature file, which left the cluster
in an inconsistent state. Subsequent concourse_cluster tests would hang.
Restore the cluster at the end of the test.

Co-authored-by: Vasiliy Ivanov <ivi@arenadata.io>

Ticket: GG-115