### PR TITLE
ADBEDV-9169: Backport prohibit skip-level correlated queries in Postgres planner for 6.x

### DIFF
--- a/src/include/optimizer/subselect.h
+++ b/src/include/optimizer/subselect.h
@@ -50,6 +50,7 @@ extern void check_multi_subquery_correlated(PlannerInfo *root, Var *var);
 extern List *generate_subquery_vars(PlannerInfo *root, List *tlist,
 					   Index varno);
 extern bool QueryHasDistributedRelation(Query *q, bool recursive);
+extern bool QueryHasMasterOnlyRelation(Query *q);
 
 extern bool cte_contains_dml(Node *ctequery, PlannerInfo *root);
 

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3911,14 +3911,14 @@ DROP TABLE skip_correlated_t4;
 reset optimizer_join_order;
 reset optimizer_trace_fallback;
 --------------------------------------------------------------------------------
--- ORCA should be able to plan and execute correctly one skip-level queries, but
--- not with master-only tables. Postgres Legacy planner should give an error to 
--- any skip-level query.
+-- ORCA should be able to plan and execute correctly skip-level queries, but not
+-- with master-only. Postgres Legacy planner should give an error to skip-level 
+-- query involving distributed or replicated tables.
 --------------------------------------------------------------------------------
-CREATE TABLE skip_correlated_partitioned (
+CREATE TABLE skip_correlated_distributed (
     a INT
 ) DISTRIBUTED BY (a);
-INSERT INTO skip_correlated_partitioned VALUES (1), (2), (3);
+INSERT INTO skip_correlated_distributed VALUES (1), (2), (3);
 CREATE TABLE skip_correlated_random (
     b INT
 ) DISTRIBUTED RANDOMLY;
@@ -3931,13 +3931,13 @@ INSERT INTO skip_correlated_replicated VALUES(1), (2), (3);
 EXPLAIN (COSTS OFF)
 SELECT (
     SELECT (
-        SELECT a FROM skip_correlated_partitioned WHERE a = c
+        SELECT a FROM skip_correlated_distributed WHERE a = c
     )
 ) FROM skip_correlated_replicated;
 ERROR:  correlated subquery with skip-level correlations is not supported
 SELECT (
     SELECT (
-        SELECT a FROM skip_correlated_partitioned WHERE a = c
+        SELECT a FROM skip_correlated_distributed WHERE a = c
     )
 ) FROM skip_correlated_replicated ORDER BY a;
 ERROR:  correlated subquery with skip-level correlations is not supported
@@ -3946,40 +3946,40 @@ SELECT (
     SELECT (
         SELECT b FROM skip_correlated_random WHERE b = a
     )
-) FROM skip_correlated_partitioned;
+) FROM skip_correlated_distributed;
 ERROR:  correlated subquery with skip-level correlations is not supported
 SELECT (
     SELECT (
         SELECT b FROM skip_correlated_random WHERE b = a
     )
-) FROM skip_correlated_partitioned ORDER BY b;
+) FROM skip_correlated_distributed ORDER BY b;
 ERROR:  correlated subquery with skip-level correlations is not supported
 EXPLAIN (COSTS OFF)
 SELECT (
     SELECT (
         SELECT c FROM skip_correlated_replicated WHERE c = a
     )
-) FROM skip_correlated_partitioned;
+) FROM skip_correlated_distributed;
 ERROR:  correlated subquery with skip-level correlations is not supported
 SELECT (
     SELECT (
         SELECT c FROM skip_correlated_replicated WHERE c = a
     )
-) FROM skip_correlated_partitioned ORDER BY c;
+) FROM skip_correlated_distributed ORDER BY c;
 ERROR:  correlated subquery with skip-level correlations is not supported
 EXPLAIN (COSTS OFF)
 SELECT (
     SELECT (
         SELECT dbid FROM gp_segment_configuration WHERE dbid = a
     )
-) FROM skip_correlated_partitioned;
+) FROM skip_correlated_distributed;
 ERROR:  correlated subquery with skip-level correlations is not supported
 -- hard cases
 EXPLAIN (COSTS OFF)
 SELECT (
     SELECT (
         SELECT (
-            SELECT a FROM skip_correlated_partitioned WHERE a = c
+            SELECT a FROM skip_correlated_distributed WHERE a = c
         ) 
     )
 ) AS l1 FROM skip_correlated_replicated ORDER BY l1;
@@ -3987,7 +3987,7 @@ ERROR:  correlated subquery with skip-level correlations is not supported
 SELECT (
     SELECT (
         SELECT (
-            SELECT a FROM skip_correlated_partitioned WHERE a = c
+            SELECT a FROM skip_correlated_distributed WHERE a = c
         ) 
     )
 ) AS l1 FROM skip_correlated_replicated ORDER BY l1;
@@ -3996,7 +3996,7 @@ EXPLAIN (COSTS OFF)
 SELECT (
     SELECT (
         SELECT (
-            SELECT a FROM skip_correlated_partitioned WHERE a = c and a = b
+            SELECT a FROM skip_correlated_distributed WHERE a = c and a = b
         ) as l3 FROM skip_correlated_random ORDER BY l3 LIMIT 1
     )
 ) AS l1 FROM skip_correlated_replicated ORDER BY l1;
@@ -4004,12 +4004,30 @@ ERROR:  correlated subquery with skip-level correlations is not supported
 SELECT (
     SELECT (
         SELECT (
-            SELECT a FROM skip_correlated_partitioned WHERE a = c and a = b
+            SELECT a FROM skip_correlated_distributed WHERE a = c and a = b
         ) as l3 FROM skip_correlated_random ORDER BY l3 LIMIT 1
     )
 ) AS l1 FROM skip_correlated_replicated ORDER BY l1;
 ERROR:  correlated subquery with skip-level correlations is not supported
-DROP TABLE skip_correlated_partitioned;
+EXPLAIN (COSTS OFF)
+SELECT (                                  
+    SELECT (
+        SELECT dbid FROM gp_segment_configuration WHERE dbid = numsegments LIMIT 1
+    )                                                        
+) FROM gp_distribution_policy;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Seq Scan on gp_distribution_policy
+   SubPlan 2
+     ->  Result
+           InitPlan 1 (returns $1)
+             ->  Limit
+                   ->  Seq Scan on gp_segment_configuration
+                         Filter: (dbid = gp_distribution_policy.numsegments)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+DROP TABLE skip_correlated_distributed;
 DROP TABLE skip_correlated_random;
 DROP TABLE skip_correlated_replicated;
 --------------------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -4061,14 +4061,14 @@ DROP TABLE skip_correlated_t4;
 reset optimizer_join_order;
 reset optimizer_trace_fallback;
 --------------------------------------------------------------------------------
--- ORCA should be able to plan and execute correctly one skip-level queries, but
--- not with master-only tables. Postgres Legacy planner should give an error to 
--- any skip-level query.
+-- ORCA should be able to plan and execute correctly skip-level queries, but not
+-- with master-only. Postgres Legacy planner should give an error to skip-level 
+-- query involving distributed or replicated tables.
 --------------------------------------------------------------------------------
-CREATE TABLE skip_correlated_partitioned (
+CREATE TABLE skip_correlated_distributed (
     a INT
 ) DISTRIBUTED BY (a);
-INSERT INTO skip_correlated_partitioned VALUES (1), (2), (3);
+INSERT INTO skip_correlated_distributed VALUES (1), (2), (3);
 CREATE TABLE skip_correlated_random (
     b INT
 ) DISTRIBUTED RANDOMLY;
@@ -4081,7 +4081,7 @@ INSERT INTO skip_correlated_replicated VALUES(1), (2), (3);
 EXPLAIN (COSTS OFF)
 SELECT (
     SELECT (
-        SELECT a FROM skip_correlated_partitioned WHERE a = c
+        SELECT a FROM skip_correlated_distributed WHERE a = c
     )
 ) FROM skip_correlated_replicated;
                                     QUERY PLAN                                    
@@ -4091,16 +4091,16 @@ SELECT (
          ->  Seq Scan on skip_correlated_replicated
    SubPlan 1  (slice0)
      ->  Result
-           Filter: (skip_correlated_partitioned.a = skip_correlated_replicated.c)
+           Filter: (skip_correlated_distributed.a = skip_correlated_replicated.c)
            ->  Materialize
                  ->  Gather Motion 3:1  (slice2; segments: 3)
-                       ->  Seq Scan on skip_correlated_partitioned
+                       ->  Seq Scan on skip_correlated_distributed
  Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
 
 SELECT (
     SELECT (
-        SELECT a FROM skip_correlated_partitioned WHERE a = c
+        SELECT a FROM skip_correlated_distributed WHERE a = c
     )
 ) FROM skip_correlated_replicated ORDER BY a;
  a 
@@ -4115,15 +4115,15 @@ SELECT (
     SELECT (
         SELECT b FROM skip_correlated_random WHERE b = a
     )
-) FROM skip_correlated_partitioned;
+) FROM skip_correlated_distributed;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Result
-         ->  Seq Scan on skip_correlated_partitioned
+         ->  Seq Scan on skip_correlated_distributed
          SubPlan 1  (slice2; segments: 3)
            ->  Result
-                 Filter: (skip_correlated_random.b = skip_correlated_partitioned.a)
+                 Filter: (skip_correlated_random.b = skip_correlated_distributed.a)
                  ->  Materialize
                        ->  Broadcast Motion 3:3  (slice1; segments: 3)
                              ->  Seq Scan on skip_correlated_random
@@ -4134,7 +4134,7 @@ SELECT (
     SELECT (
         SELECT b FROM skip_correlated_random WHERE b = a
     )
-) FROM skip_correlated_partitioned ORDER BY b;
+) FROM skip_correlated_distributed ORDER BY b;
  b 
 ---
  1
@@ -4147,15 +4147,15 @@ SELECT (
     SELECT (
         SELECT c FROM skip_correlated_replicated WHERE c = a
     )
-) FROM skip_correlated_partitioned;
+) FROM skip_correlated_distributed;
                          QUERY PLAN                          
 -------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Result
-         ->  Seq Scan on skip_correlated_partitioned
+         ->  Seq Scan on skip_correlated_distributed
          SubPlan 1  (slice1; segments: 3)
            ->  Seq Scan on skip_correlated_replicated
-                 Filter: (c = skip_correlated_partitioned.a)
+                 Filter: (c = skip_correlated_distributed.a)
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
@@ -4163,7 +4163,7 @@ SELECT (
     SELECT (
         SELECT c FROM skip_correlated_replicated WHERE c = a
     )
-) FROM skip_correlated_partitioned ORDER BY c;
+) FROM skip_correlated_distributed ORDER BY c;
  c 
 ---
  1
@@ -4176,14 +4176,14 @@ SELECT (
     SELECT (
         SELECT dbid FROM gp_segment_configuration WHERE dbid = a
     )
-) FROM skip_correlated_partitioned;
+) FROM skip_correlated_distributed;
 ERROR:  correlated subquery with skip-level correlations is not supported
 -- hard cases
 EXPLAIN (COSTS OFF)
 SELECT (
     SELECT (
         SELECT (
-            SELECT a FROM skip_correlated_partitioned WHERE a = c
+            SELECT a FROM skip_correlated_distributed WHERE a = c
         ) 
     )
 ) AS l1 FROM skip_correlated_replicated ORDER BY l1;
@@ -4196,17 +4196,17 @@ SELECT (
                ->  Seq Scan on skip_correlated_replicated
          SubPlan 1  (slice0)
            ->  Result
-                 Filter: (skip_correlated_partitioned.a = skip_correlated_replicated.c)
+                 Filter: (skip_correlated_distributed.a = skip_correlated_replicated.c)
                  ->  Materialize
                        ->  Gather Motion 3:1  (slice2; segments: 3)
-                             ->  Seq Scan on skip_correlated_partitioned
+                             ->  Seq Scan on skip_correlated_distributed
  Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
 SELECT (
     SELECT (
         SELECT (
-            SELECT a FROM skip_correlated_partitioned WHERE a = c
+            SELECT a FROM skip_correlated_distributed WHERE a = c
         ) 
     )
 ) AS l1 FROM skip_correlated_replicated ORDER BY l1;
@@ -4221,11 +4221,11 @@ EXPLAIN (COSTS OFF)
 SELECT (
     SELECT (
         SELECT (
-            SELECT a FROM skip_correlated_partitioned WHERE a = c and a = b
+            SELECT a FROM skip_correlated_distributed WHERE a = c and a = b
         ) as l3 FROM skip_correlated_random ORDER BY l3 LIMIT 1
     )
 ) AS l1 FROM skip_correlated_replicated ORDER BY l1;
-                                                                                 QUERY PLAN                                                                                 
+                                                                                 QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: ((SubPlan 2))
@@ -4242,17 +4242,17 @@ SELECT (
                                          ->  Seq Scan on skip_correlated_random
                              SubPlan 1  (slice0)
                                ->  Result
-                                     Filter: ((skip_correlated_partitioned.a = skip_correlated_replicated.c) AND (skip_correlated_partitioned.a = skip_correlated_random.b))
+                                     Filter: ((skip_correlated_distributed.a = skip_correlated_replicated.c) AND (skip_correlated_distributed.a = skip_correlated_random.b))
                                      ->  Materialize
                                            ->  Gather Motion 3:1  (slice3; segments: 3)
-                                                 ->  Seq Scan on skip_correlated_partitioned
+                                                 ->  Seq Scan on skip_correlated_distributed
  Optimizer: Pivotal Optimizer (GPORCA)
 (20 rows)
 
 SELECT (
     SELECT (
         SELECT (
-            SELECT a FROM skip_correlated_partitioned WHERE a = c and a = b
+            SELECT a FROM skip_correlated_distributed WHERE a = c and a = b
         ) as l3 FROM skip_correlated_random ORDER BY l3 LIMIT 1
     )
 ) AS l1 FROM skip_correlated_replicated ORDER BY l1;
@@ -4263,7 +4263,25 @@ SELECT (
   3
 (3 rows)
 
-DROP TABLE skip_correlated_partitioned;
+EXPLAIN (COSTS OFF)
+SELECT (                                  
+    SELECT (
+        SELECT dbid FROM gp_segment_configuration WHERE dbid = numsegments LIMIT 1
+    )                                                        
+) FROM gp_distribution_policy;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Seq Scan on gp_distribution_policy
+   SubPlan 2
+     ->  Result
+           InitPlan 1 (returns $1)
+             ->  Limit
+                   ->  Seq Scan on gp_segment_configuration
+                         Filter: (dbid = gp_distribution_policy.numsegments)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+DROP TABLE skip_correlated_distributed;
 DROP TABLE skip_correlated_random;
 DROP TABLE skip_correlated_replicated;
 --------------------------------------------------------------------------------

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -834,19 +834,19 @@ DROP TABLE skip_correlated_t4;
 reset optimizer_join_order;
 reset optimizer_trace_fallback;
 --------------------------------------------------------------------------------
--- ORCA should be able to plan and execute correctly one skip-level queries, but
--- not with master-only tables. Postgres Legacy planner should give an error to 
--- any skip-level query.
+-- ORCA should be able to plan and execute correctly skip-level queries, but not
+-- with master-only. Postgres Legacy planner should give an error to skip-level 
+-- query involving distributed or replicated tables.
 --------------------------------------------------------------------------------
 --start_ignore
-DROP TABLE IF EXISTS skip_correlated_partitioned;
+DROP TABLE IF EXISTS skip_correlated_distributed;
 DROP TABLE IF EXISTS skip_correlated_random;
 DROP TABLE IF EXISTS skip_correlated_replicated;
 --end_ignore
-CREATE TABLE skip_correlated_partitioned (
+CREATE TABLE skip_correlated_distributed (
     a INT
 ) DISTRIBUTED BY (a);
-INSERT INTO skip_correlated_partitioned VALUES (1), (2), (3);
+INSERT INTO skip_correlated_distributed VALUES (1), (2), (3);
 
 CREATE TABLE skip_correlated_random (
     b INT
@@ -862,12 +862,12 @@ INSERT INTO skip_correlated_replicated VALUES(1), (2), (3);
 EXPLAIN (COSTS OFF)
 SELECT (
     SELECT (
-        SELECT a FROM skip_correlated_partitioned WHERE a = c
+        SELECT a FROM skip_correlated_distributed WHERE a = c
     )
 ) FROM skip_correlated_replicated;
 SELECT (
     SELECT (
-        SELECT a FROM skip_correlated_partitioned WHERE a = c
+        SELECT a FROM skip_correlated_distributed WHERE a = c
     )
 ) FROM skip_correlated_replicated ORDER BY a;
 
@@ -876,45 +876,45 @@ SELECT (
     SELECT (
         SELECT b FROM skip_correlated_random WHERE b = a
     )
-) FROM skip_correlated_partitioned;
+) FROM skip_correlated_distributed;
 SELECT (
     SELECT (
         SELECT b FROM skip_correlated_random WHERE b = a
     )
-) FROM skip_correlated_partitioned ORDER BY b;
+) FROM skip_correlated_distributed ORDER BY b;
 
 EXPLAIN (COSTS OFF)
 SELECT (
     SELECT (
         SELECT c FROM skip_correlated_replicated WHERE c = a
     )
-) FROM skip_correlated_partitioned;
+) FROM skip_correlated_distributed;
 SELECT (
     SELECT (
         SELECT c FROM skip_correlated_replicated WHERE c = a
     )
-) FROM skip_correlated_partitioned ORDER BY c;
+) FROM skip_correlated_distributed ORDER BY c;
 
 EXPLAIN (COSTS OFF)
 SELECT (
     SELECT (
         SELECT dbid FROM gp_segment_configuration WHERE dbid = a
     )
-) FROM skip_correlated_partitioned;
+) FROM skip_correlated_distributed;
 
 -- hard cases
 EXPLAIN (COSTS OFF)
 SELECT (
     SELECT (
         SELECT (
-            SELECT a FROM skip_correlated_partitioned WHERE a = c
+            SELECT a FROM skip_correlated_distributed WHERE a = c
         ) 
     )
 ) AS l1 FROM skip_correlated_replicated ORDER BY l1;
 SELECT (
     SELECT (
         SELECT (
-            SELECT a FROM skip_correlated_partitioned WHERE a = c
+            SELECT a FROM skip_correlated_distributed WHERE a = c
         ) 
     )
 ) AS l1 FROM skip_correlated_replicated ORDER BY l1;
@@ -923,19 +923,26 @@ EXPLAIN (COSTS OFF)
 SELECT (
     SELECT (
         SELECT (
-            SELECT a FROM skip_correlated_partitioned WHERE a = c and a = b
+            SELECT a FROM skip_correlated_distributed WHERE a = c and a = b
         ) as l3 FROM skip_correlated_random ORDER BY l3 LIMIT 1
     )
 ) AS l1 FROM skip_correlated_replicated ORDER BY l1;
 SELECT (
     SELECT (
         SELECT (
-            SELECT a FROM skip_correlated_partitioned WHERE a = c and a = b
+            SELECT a FROM skip_correlated_distributed WHERE a = c and a = b
         ) as l3 FROM skip_correlated_random ORDER BY l3 LIMIT 1
     )
 ) AS l1 FROM skip_correlated_replicated ORDER BY l1;
 
-DROP TABLE skip_correlated_partitioned;
+EXPLAIN (COSTS OFF)
+SELECT (                                  
+    SELECT (
+        SELECT dbid FROM gp_segment_configuration WHERE dbid = numsegments LIMIT 1
+    )                                                        
+) FROM gp_distribution_policy;
+
+DROP TABLE skip_correlated_distributed;
 DROP TABLE skip_correlated_random;
 DROP TABLE skip_correlated_replicated;
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Backport prohibit skip-level correlated queries in Postgres

What occurs?
Postgres planner puts an error in case of master-only to master-only skip-level
correlation, but this was executed correctly before.

Why it occurs?
QueryHasDistributedRelation() bans any table, without regard of its
distribution.

How do we fix this?
Make a more soft condition: prohibit only replicated and distributed tables
inside QueryHasDistributedRelation(), but additionally check master-only with
replicated/distributed scenarios using QueryHasMasterOnlyRelation() inside
check_multi_subquery_correlated().

Tests?
Test to check the planning of master-only to master-only skip-level correlation
without error was added.

---------

Co-authored-by: Denis Kovalev <d.kovalev@arenadata.io>
(cherry picked from commit 623167954a2f25109c8420b4a7f659c5596fe3a8)