### PR TITLE
GG-160: Report resource groups to pg_stat_activity for segment backends

### DIFF
--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -3530,6 +3530,8 @@ pgstat_report_resgroup(Oid groupid)
 	beentry->st_rsgid = groupid;
 	beentry->st_changecount++;
 	Assert((beentry->st_changecount & 1) == 0);
+
+	elog(DEBUG1, "Reported resource group ID of %d", groupid);
 }
 
 /* ----------

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1709,6 +1709,8 @@ SwitchResGroupOnSegment(const char *buf, int len)
 		cgroupOpsRoutine->attachcgroup(bypassedGroup->groupId, MyProcPid,
 									   caps.cpuMaxPercent == CPU_MAX_PERCENT_DISABLED);
 
+		pgstat_report_resgroup(bypassedSlot.groupId);
+
 		return;
 	}
 
@@ -1775,6 +1777,8 @@ SwitchResGroupOnSegment(const char *buf, int len)
 	/* Add into cgroup */
 	cgroupOpsRoutine->attachcgroup(self->groupId, MyProcPid,
 								   self->caps.cpuMaxPercent == CPU_MAX_PERCENT_DISABLED);
+
+	pgstat_report_resgroup(group->groupId);
 }
 
 /*
@@ -3239,7 +3243,7 @@ HandleMoveResourceGroup(void)
 	ResGroupSlotData *slot;
 	ResGroupData *group;
 	ResGroupData *oldGroup;
-	Oid			groupId;
+	Oid			groupId = InvalidOid;
 	pid_t		callerPid;
 
 	Assert(Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE);
@@ -3332,8 +3336,6 @@ HandleMoveResourceGroup(void)
 		 */
 		cgroupOpsRoutine->attachcgroup(self->groupId, MyProcPid,
 									   self->caps.cpuMaxPercent == CPU_MAX_PERCENT_DISABLED);
-
-		pgstat_report_resgroup(self->groupId);
 	}
 
 	/*
@@ -3427,6 +3429,8 @@ HandleMoveResourceGroup(void)
 		cgroupOpsRoutine->attachcgroup(self->groupId, MyProcPid,
 									   self->caps.cpuMaxPercent == CPU_MAX_PERCENT_DISABLED);
 	}
+
+	pgstat_report_resgroup(groupId);
 }
 
 /*

--- a/src/test/isolation2/expected/resgroup/resgroup_bypass.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_bypass.out
@@ -276,6 +276,30 @@ SELECT gp_inject_fault('func_init_plan_end', 'reset', 1);
 1q: ... <quitting>
 2q: ... <quitting>
 
+--
+-- resource group should be shown in pg_stat_activity even when it's bypassed
+--
+
+1: SET gp_resource_group_bypass TO on;
+SET
+1&: SELECT pg_sleep(3) FROM gp_dist_random('gp_id');  <waiting ...>
+0U: SELECT query, rsgname FROM pg_stat_activity WHERE query LIKE '%gp_dist_random%';
+ query                                                                            | rsgname     
+----------------------------------------------------------------------------------+-------------
+ SELECT pg_sleep(3) FROM gp_dist_random('gp_id');                                 | admin_group 
+ SELECT query, rsgname FROM pg_stat_activity WHERE query LIKE '%gp_dist_random%'; | unknown     
+(2 rows)
+1<:  <... completed>
+ pg_sleep 
+----------
+          
+          
+          
+(3 rows)
+
+1q: ... <quitting>
+0Uq: ... <quitting>
+
 -- cleanup
 -- start_ignore
 DROP TABLE t_bypass;

--- a/src/test/isolation2/expected/resgroup/resgroup_move_query.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_move_query.out
@@ -373,11 +373,13 @@ SET
 -----------+-------------+------+---------+----------
  Greenplum | -1          | -1   | -1      |          
 (1 row)
+-- there are two backends on coordinator, the second one is for gather motion
 2<:  <... completed>
  pg_resgroup_move_query 
 ------------------------
  t                      
-(1 row)
+ t                      
+(2 rows)
 2: RESET gp_resource_group_move_timeout;
 RESET
 3: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND state = 'idle in transaction';
@@ -434,11 +436,13 @@ ERROR:  cannot send signal to process
 -----------+-------------+------+---------+----------
  Greenplum | -1          | -1   | -1      |          
 (1 row)
+-- there are two backends on coordinator, the second one is for gather motion
 2<:  <... completed>
  pg_resgroup_move_query 
 ------------------------
  t                      
-(1 row)
+ t                      
+(2 rows)
 3: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND state = 'idle in transaction';
  is_session_in_group 
 ---------------------
@@ -514,10 +518,28 @@ BEGIN
  Greenplum | -1          | -1   | -1      |          
 (1 row)
 1&: SELECT * FROM gp_dist_random('gp_id'), pg_sleep(3) LIMIT 1;  <waiting ...>
+-- segments should display the resource group name
+1U: SELECT rsgname, query FROM pg_stat_activity WHERE rsgname LIKE 'rg_move_query%';
+ rsgname             | query                                                       
+---------------------+-------------------------------------------------------------
+ rg_move_query_small | SELECT * FROM gp_dist_random('gp_id'), pg_sleep(3) LIMIT 1; 
+(1 row)
+-- there are two backends on coordinator, the second one is for gather motion
 2: SELECT pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query_small';
  pg_resgroup_move_query 
 ------------------------
  t                      
+ t                      
+(2 rows)
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
+1U: SELECT rsgname, query FROM pg_stat_activity WHERE rsgname LIKE 'rg_move_query%';
+ rsgname       | query                                                       
+---------------+-------------------------------------------------------------
+ rg_move_query | SELECT * FROM gp_dist_random('gp_id'), pg_sleep(3) LIMIT 1; 
 (1 row)
 1<:  <... completed>
  gpname    | numsegments | dbid | content | pg_sleep 
@@ -531,10 +553,26 @@ BEGIN
 (1 row)
 -- and check we can move it back right in the same transaction
 1&: SELECT * FROM gp_dist_random('gp_id'), pg_sleep(3) LIMIT 1;  <waiting ...>
+1U: SELECT rsgname, query FROM pg_stat_activity WHERE rsgname LIKE 'rg_move_query%';
+ rsgname       | query                                                       
+---------------+-------------------------------------------------------------
+ rg_move_query | SELECT * FROM gp_dist_random('gp_id'), pg_sleep(3) LIMIT 1; 
+(1 row)
 2: SELECT pg_resgroup_move_query(pid, 'rg_move_query_small') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query';
  pg_resgroup_move_query 
 ------------------------
  t                      
+ t                      
+(2 rows)
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
+1U: SELECT rsgname, query FROM pg_stat_activity WHERE rsgname LIKE 'rg_move_query%';
+ rsgname             | query                                                       
+---------------------+-------------------------------------------------------------
+ rg_move_query_small | SELECT * FROM gp_dist_random('gp_id'), pg_sleep(3) LIMIT 1; 
 (1 row)
 1<:  <... completed>
  gpname    | numsegments | dbid | content | pg_sleep 

--- a/src/test/isolation2/sql/resgroup/resgroup_bypass.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_bypass.sql
@@ -133,6 +133,18 @@ SELECT gp_inject_fault('func_init_plan_end', 'reset', 1);
 1q:
 2q:
 
+--
+-- resource group should be shown in pg_stat_activity even when it's bypassed
+--
+
+1: SET gp_resource_group_bypass TO on;
+1&: SELECT pg_sleep(3) FROM gp_dist_random('gp_id');
+0U: SELECT query, rsgname FROM pg_stat_activity WHERE query LIKE '%gp_dist_random%';
+1<:
+
+1q:
+0Uq:
+
 -- cleanup
 -- start_ignore
 DROP TABLE t_bypass;


### PR DESCRIPTION
Report resource groups to pg_stat_activity for segment backends (#218)

Current state of affairs, from upstream docs:

    When resource groups are enabled. Only query dispatcher (QD) processes will
    have a rsgid and rsgname. Other server processes such as a query executer
    (QE) process or session connection processes will have a rsgid value of 0
    and a rsgname value of unknown. QE processes are managed by the same
    resource group as the dispatching QD process.

As a developer, I encountered a need to see backend's resource group on the segment directly via utility mode for PARALLEL RETRIEVE CURSOR. I found no adequate reason why it was done this way.

1. Only the DISPATCHER and EXECUTOR roles change resource groups. UTILITY does not interact with resource groups.
2. The patch forces segments (EXECUTOR) to report their resource group status to `pg_stat_activity`.
3. Due to point above, processes with the EXECUTOR role on the coordinator (`IS_QUERY_DISPATCHER()`) now also receive a resource group.
4. `pg_resgroup_move_query()` sends a request from the coordinator to segment processes with the same session ID, which in turn is looked up by the PID in shared memory.
5. The resource group is set only for the duration of the request and detaches at the end of the request, resetting the value in `pg_stat_activity`. The queries need to be suspended/long enough to catch their resource group in `pg_stat_activity`.
6. The resource group attaches/detaches from the process with a slight delay. This leads to the backend seeming to see its resource group only for itself between requests when querying `pg_stat_activity`.

This patch makes it so resource group stats to `pg_stat_activity` on segment backends are reported, making `rsgid` and `rsgname` columns filled for the time of slice execution.

Changes from original commit:
- pgstat_report_resgroup doesn't have a timestamp argument in 7X
- Updated tests to match 7X
- Added second row to output in two more places in resgroup_move_query, in the
same way as in the original commit.
- Merge conflicts resolved

Ticket: GG-160
(cherry picked from commit a0457d258acec64a1140b350f3f03d795c7a0aeb)

---

Note: do not squash to preserve authorship
