### PR TITLE
GG-167: Fix tautological undefined compare

### DIFF
--- a/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
@@ -455,7 +455,6 @@ CBucket::MakeBucketCopy(CMemoryPool *mp)
 BOOL
 CBucket::Equals(const CBucket *bucket)
 {
-	GPOS_ASSERT(this != NULL);
 	GPOS_ASSERT(bucket != NULL);
 	if (this->GetLowerBound()->Equals(bucket->GetLowerBound()) &&
 		this->IsLowerClosed() == bucket->IsLowerClosed() &&


### PR DESCRIPTION
```
Fix tautological undefined compare

The compiler is right, 'this' is defined to be never null. We fixed something
like this in commit b111104 but this recently slipped through the cracks.

Example error message (varies between versions and compilers):

> libnaucrates/src/statistics/CBucket.cpp:453:14: error: 'this' pointer cannot
> be null in well-defined C++ code; comparison may be assumed to always
> evaluate to true [-Werror,-Wtautological-undefined-compare]

(cherry picked from commit a4274d9)
```

Modern compilers (e.g. gcc 13.3.0) produce an error like: error: 'nonnull' argument 'this' compared to NULL [-Werror=nonnull-compare]
It's clean cherry-pick and should be merged by rebase.