### PR TITLE
[GG-157] Fix Python unit tests after PyGreSQL update

### DIFF
--- a/gpMgmt/bin/gpcheckcat_modules/repair_missing_extraneous.py
+++ b/gpMgmt/bin/gpcheckcat_modules/repair_missing_extraneous.py
@@ -49,7 +49,7 @@ class RepairMissingExtraneous:
         #   [(49401, 'cmax', "extra", [1,2]),
         #    (49401, 'cmax', "extra", [1,2])
 
-        all_seg_ids = set([str(seg_id) for seg_id in all_seg_ids])
+        all_seg_ids = set(all_seg_ids)
         oids_to_segment_mapping = {}
         for issue in self._issues:
 

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_reconfigurer.py
@@ -58,14 +58,17 @@ class SegmentReconfiguerTestCase(GpTestCase):
             )
 
     def test_it_retries_the_connection(self):
-        self.connect.configure_mock(side_effect=[pgdb.DatabaseError, pgdb.DatabaseError, self.conn])
+        ctx = MagicMock()
+        ctx.__enter__.return_value = self.conn
+        ctx.__exit__.return_value = False
+
+        self.connect.configure_mock(side_effect=[pgdb.DatabaseError, pgdb.DatabaseError, ctx])
 
         reconfigurer = SegmentReconfigurer(logger=self.logger,
                 worker_pool=self.worker_pool, timeout=self.timeout)
         reconfigurer.reconfigure()
 
         self.connect.assert_has_calls([call(self.db_url), call(self.db_url), call(self.db_url), ])
-        self.conn.close.assert_any_call()
 
     @patch('time.time')
     def test_it_gives_up_after_600_seconds(self, now_mock):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gparray.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gparray.py
@@ -150,8 +150,8 @@ class GpArrayTestCase(GpTestCase):
                                   mirror_list, mirror_portbase, dir_prefix)
         offset = len(hostlist) * len(primary_list) # need to continue numbering where the last createSegmentRows left off
         for row in rows:
-            gparray.addExpansionSeg(row.content+offset, 'p' if convert_bool(row.isprimary) else 'm', row.dbid+offset,
-                                    'p' if convert_bool(row.isprimary) else 'm', row.host, row.address, row.port, row.fulldir)
+            gparray.addExpansionSeg(row.content+offset, 'p' if row.isprimary else 'm', row.dbid+offset,
+                                    'p' if row.isprimary else 'm', row.host, row.address, row.port, row.fulldir)
         self._validate_get_segment_list(gparray, hostlist, expansion_hosts, primary_list)
 
 
@@ -197,9 +197,9 @@ class GpArrayTestCase(GpTestCase):
         
         for row in rows:
             newrow = Segment(content = row.content,
-                          preferred_role = 'p' if convert_bool(row.isprimary) else 'm',
+                          preferred_role = 'p' if row.isprimary else 'm',
                           dbid = row.dbid,
-                          role = 'p' if convert_bool(row.isprimary) else 'm',
+                          role = 'p' if row.isprimary else 'm',
                           mode = 's',
                           status = 'u',
                           hostname = row.host,
@@ -377,11 +377,6 @@ class GpArrayTestCase(GpTestCase):
             "6|-1|m|m|s|u|sdw3|sdw3|6432|/data/standby")
         return GpArray([self.coordinator, self.standby, self.primary0, self.primary1, self.mirror0, self.mirror1])
 
-def convert_bool(val):
-    if val == 't':
-        return True
-    else:
-        return False
 
 #------------------------------- Mainline --------------------------------
 if __name__ == '__main__':

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -67,7 +67,10 @@ class GpCheckCatTestCase(GpTestCase):
     def test_running_unique_index_violation_check__makes_the_check(self):
         self.subject.runOneCheck('unique_index_violation')
 
-        self.unique_index_violation_check.runCheck.assert_called_with(self.db_connection)
+        self.unique_index_violation_check.runCheck.assert_called()
+        (args, kwargs) = self.unique_index_violation_check.runCheck.call_args
+        wrapper = args[0]
+        self.assertIs(wrapper.db, self.db_connection)
 
     def test_running_unique_index_violation_check__when_no_violations_are_found__passes_the_check(self):
         self.subject.runOneCheck('unique_index_violation')
@@ -111,7 +114,10 @@ class GpCheckCatTestCase(GpTestCase):
 
         self.subject.drop_leaked_schemas(self.leaked_schema_dropper, self.db_connection)
 
-        self.leaked_schema_dropper.drop_leaked_schemas.assert_called_once_with(self.db_connection)
+        self.leaked_schema_dropper.drop_leaked_schemas.assert_called_once()
+        (args, kwargs) = self.leaked_schema_dropper.drop_leaked_schemas.call_args
+        wrapper = args[0]
+        self.assertIs(wrapper.db, self.db_connection)
 
     def test_drop_leaked_schemas__when_leaked_schemas_exist__passes_gpcheckcat(self):
         self.leaked_schema_dropper.drop_leaked_schemas.return_value = ['schema1', 'schema2']
@@ -191,7 +197,10 @@ class GpCheckCatTestCase(GpTestCase):
         self.assertTrue(self.subject.GV.foreignKeyStatus)
         self.subject.setError.assert_any_call(self.subject.ERROR_REMOVE)
         self.foreign_key_check.runCheck.assert_called_once_with(cat_tables)
-        fast_seq_mock.assert_called_once_with(self.db_connection)
+        fast_seq_mock.assert_called_once()
+        (args, kwargs) = fast_seq_mock.call_args
+        wrapper = args[0]
+        self.assertIs(wrapper.db, self.db_connection)
 
     @patch('gpcheckcat.processForeignKeyResult')
     def test_checkForeignKey__with_arg(self, process_foreign_key_mock):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
@@ -483,7 +483,9 @@ class DifferentialRecoveryClsTestCase(GpTestCase):
            return_value='/data/mytblspace1/2')
     @patch('os.listdir')
     @patch('os.symlink')
-    def test_sync_tablespaces_outside_data_dir(self, mock1,mock2,mock3,mock4):
+    @patch('gppylib.db.dbconn.GgdbCursor',
+           side_effect=lambda conn: conn.cursor())
+    def test_sync_tablespaces_outside_data_dir(self, mock1,mock2,mock3,mock4,mock5):
         self.diff_recovery_cmd.sync_tablespaces()
         self.assertEqual(2, self.mock_rsync_init.call_count)
         self.assertEqual(2, self.mock_rsync_run.call_count)
@@ -495,7 +497,9 @@ class DifferentialRecoveryClsTestCase(GpTestCase):
            return_value=[['1234','/data/primary0']])
     @patch('os.listdir')
     @patch('os.symlink')
-    def test_sync_tablespaces_within_data_dir(self, mock, mock2,mock3):
+    @patch('gppylib.db.dbconn.GgdbCursor',
+           side_effect=lambda conn: conn.cursor())
+    def test_sync_tablespaces_within_data_dir(self, mock, mock2,mock3,mock4):
         self.diff_recovery_cmd.sync_tablespaces()
         self.assertEqual(0, self.mock_rsync_init.call_count)
         self.assertEqual(0, self.mock_rsync_run.call_count)
@@ -508,7 +512,9 @@ class DifferentialRecoveryClsTestCase(GpTestCase):
            return_value='/data/mytblspace1/2')
     @patch('os.listdir')
     @patch('os.symlink')
-    def test_sync_tablespaces_mix_data_dir(self, mock1, mock2, mock3,mock4):
+    @patch('gppylib.db.dbconn.GgdbCursor',
+           side_effect=lambda conn: conn.cursor())
+    def test_sync_tablespaces_mix_data_dir(self, mock1, mock2, mock3, mock4, mock5):
         self.diff_recovery_cmd.sync_tablespaces()
         self.assertEqual(1, self.mock_rsync_init.call_count)
         self.assertEqual(1, self.mock_rsync_run.call_count)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstop.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstop.py
@@ -587,7 +587,8 @@ class GpStopSmartModeTestCase(unittest.TestCase):
 
         subprocess_call.side_effect = _call
 
-    def test_stop_master_smart_issues_pg_ctl_stop(self, subprocess_call, dbconn_connect):
+    @patch('gppylib.db.dbconn.GgdbCursor', side_effect=lambda conn: conn.cursor())
+    def test_stop_master_smart_issues_pg_ctl_stop(self, cursor, subprocess_call, dbconn_connect):
         self._setup_subprocess(subprocess_call)
 
         self.gpstop.master_datadir = 'datadir'
@@ -601,7 +602,8 @@ class GpStopSmartModeTestCase(unittest.TestCase):
         with self.assertRaises(Exception):
             self.gpstop._stop_master_smart()
 
-    def test_stop_master_smart_calls_pg_ctl_status_until_server_stops(self, subprocess_call, dbconn_connect):
+    @patch('gppylib.db.dbconn.GgdbCursor', side_effect=lambda conn: conn.cursor())
+    def test_stop_master_smart_calls_pg_ctl_status_until_server_stops(self, cursor, subprocess_call, dbconn_connect):
         self._setup_subprocess(subprocess_call)
         self.gpstop.conn = dbconn_connect
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_repair_missing_extraneous.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_repair_missing_extraneous.py
@@ -13,13 +13,13 @@ class RepairMissingExtraneousTestCase(GpTestCase):
         self.catalog_table_obj.getTableName.return_value = self.table_name
 
     def test_get_segment_to_oid_mapping_with_both_extra_and_missing(self):
-        issues = [(49401, "extra", '{1,2}'),
-                  (49401, "extra", '{1,2}'),
-                  (49402, "missing", '{2,3}'),
-                  (49403, "extra", '{2,3}'),
-                  (49404, "missing", '{1}'),
-                  (49405, "extra", '{2,3}'),
-                  (49406, "missing", '{2}')]
+        issues = [(49401, "extra", [1,2]),
+                  (49401, "extra", [1,2]),
+                  (49402, "missing", [2,3]),
+                  (49403, "extra", [2,3]),
+                  (49404, "missing", [1]),
+                  (49405, "extra", [2,3]),
+                  (49406, "missing", [2])]
 
         self.subject = RepairMissingExtraneous(self.catalog_table_obj, issues, "attrelid")
         repair_sql_contents = self.subject.get_segment_to_oid_mapping(self.all_seg_ids)
@@ -32,10 +32,10 @@ class RepairMissingExtraneousTestCase(GpTestCase):
         self.assertEqual(repair_sql_contents[3], set([49403, 49404, 49405, 49406]))
 
     def test_get_segment_to_oid_mapping_with_only_extra(self):
-        issues = [(49401, 'cmax', "extra", '{1,2}'),
-                  (49401, 'cmax', "extra", '{1,2}'),
-                  (49403, 'cmax', "extra", '{2,3}'),
-                  (49405, 'cmax', "extra", '{2,3}')]
+        issues = [(49401, 'cmax', "extra", [1,2]),
+                  (49401, 'cmax', "extra", [1,2]),
+                  (49403, 'cmax', "extra", [2,3]),
+                  (49405, 'cmax', "extra", [2,3])]
 
         self.subject = RepairMissingExtraneous(self.catalog_table_obj, issues, "attrelid")
         repair_sql_contents = self.subject.get_segment_to_oid_mapping(self.all_seg_ids)
@@ -46,10 +46,10 @@ class RepairMissingExtraneousTestCase(GpTestCase):
         self.assertEqual(repair_sql_contents[3], set([49403, 49405]))
 
     def test_get_segment_to_oid_mapping_with_only_missing(self):
-        issues = [(49401, 'cmax', "missing", '{1,2}'),
-                  (49401, 'cmax', "missing", '{1,2}'),
-                  (49403, 'cmax', "missing", '{2,3}'),
-                  (49405, 'cmax', "missing", '{2,3}')]
+        issues = [(49401, 'cmax', "missing", [1,2]),
+                  (49401, 'cmax', "missing", [1,2]),
+                  (49403, 'cmax', "missing", [2,3]),
+                  (49405, 'cmax', "missing", [2,3])]
 
         self.subject = RepairMissingExtraneous(self.catalog_table_obj, issues, "attrelid")
         repair_sql_contents = self.subject.get_segment_to_oid_mapping(self.all_seg_ids)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_unique_index_violation_check.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_unique_index_violation_check.py
@@ -10,8 +10,8 @@ class UniqueIndexViolationCheckTestCase(GpTestCase):
 
         self.index_query_result = Mock()
         self.index_query_result.getresult.return_value = [
-            (9001, 'index1', 'table1', '{index1_column1,index1_column2}'),
-            (9001, 'index2', 'table1', '{index2_column1,index2_column2}')
+            (9001, 'index1', 'table1', ['index1_column1', 'index1_column2']),
+            (9001, 'index2', 'table1', ['index2_column1', 'index2_column2'])
         ]
 
         self.violated_segments_query_result = Mock()


### PR DESCRIPTION
- test_it_retries_the_connection: use mock object that support context managment
- GpArrayTestCase: use bool type instead str 't'/'f'
- GpCheckCatTestCase: check connection in DbWrapper.
- DifferentialRecoveryClsTestCase and GpStopSmartModeTestCase: mock GgdbCursor
to return connection.
- RepairMissingExtraneousTestCase and UniqueIndexViolationCheckTestCase: use
python arrays instead of string representation of Postgres arrays.

Also fix seg ids set in get_segment_to_oid_mapping. Since seg ids in issues are
now ints, we do not need to cast all_seg_ids array elements to strings.