### PR TITLE
GG-147: Fix gpssh behave tests on Python 3

### DIFF
--- a/gpMgmt/bin/gpssh_modules/gppxssh_wrapper.py
+++ b/gpMgmt/bin/gpssh_modules/gppxssh_wrapper.py
@@ -36,7 +36,7 @@ class PxsshWrapper(pxssh.pxssh):
         num_retries = self.sync_retries
         retry_attempt = 0
         success = False
-        while (not success) and retry_attempt <= num_retries:
+        while (not success) and num_retries and retry_attempt <= num_retries:
             # each retry will get an exponentially longer timeout interval
             sync_multiplier_for_this_retry = sync_multiplier * (RETRY_EXPONENT ** retry_attempt)
             start = time.time()
@@ -84,7 +84,7 @@ class PxsshWrapper(pxssh.pxssh):
             try:
                 prompt = self.read_nonblocking(size=1, timeout=0.01)
                 if DEBUG_VERBOSE_PRINTING:
-                    sys.stderr.write(prompt)
+                    sys.stderr.write(prompt.decode())
             except TIMEOUT:
                 break
         if DEBUG_VERBOSE_PRINTING:
@@ -106,7 +106,7 @@ class PxsshWrapper(pxssh.pxssh):
             sys.stderr.write('\nFinished wait_for_any_response() at %s\n' % datetime.now())
 
     def is_prompt_bad(self, prompt_output):
-        return len(prompt_output) == 0 or prompt_output == CRNL
+        return len(prompt_output) == 0 or prompt_output == CRNL.encode()
 
     def are_prompts_similar(self, prompt_one, prompt_two):
         if self.is_prompt_bad(prompt_one) or self.is_prompt_bad(prompt_two):


### PR DESCRIPTION
Fix gpssh behave tests on Python 3

gpssh behave tests didn't pass on Python 3.

1) Fix the error "TypeError: '<=' not supported between instances of 'int' and
'NoneType'" when comparing retry_attempt <= num_retries when num_retries is
None.

2) Fix the error "TypeError: write() argument must be str, not bytes" when
DEBUG_VERBOSE_PRINTING is True.

3) In Python 3, file operations return bytes, not strings, so the CRNL for
comparison must be in bytes.

Co-authored-by: Viktor Kurilko <v.kurilko@arenadata.io>

(cherry picked from commit 1b76372)

Changes from original commit:
- CRNL comparison adapted for both Python 2 and Python 3

Ticket: GG-147

---
!!!REBASE!!!