### PR TITLE
GG-205 Save resgroup artifacts for cancelled steps (7.x)

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -95,7 +95,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v13
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v22
     with:
       version: 7
       target_os: ${{ matrix.target_os }}

--- a/ci/scripts/resgroup_collect_logs.bash
+++ b/ci/scripts/resgroup_collect_logs.bash
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -eox pipefail
+
+echo "[log-sync] started on $(hostname) at $(date)" >&2
+
+LOG_SYNC_INTERVAL=10
+HOST_LOG_DIR="/logs"
+BASE_DIR="/home/gpadmin"
+GPDB_SRC_DIR="gpdb_src"
+
+mkdir -p "$HOST_LOG_DIR"
+
+LOG_DIRS=(
+  "${BASE_DIR}/gpAdminLogs"
+  "${BASE_DIR}/${GPDB_SRC_DIR}/gpAux/gpdemo/datadirs/gpAdminLogs"
+  "${BASE_DIR}/${GPDB_SRC_DIR}/gpAux/gpdemo/datadirs/qddir/demoDataDir-1/log"
+  "${BASE_DIR}/${GPDB_SRC_DIR}/gpAux/gpdemo/datadirs/standby/log"
+  "${BASE_DIR}/${GPDB_SRC_DIR}/src/test/isolation2/results/resgroup"
+  "${BASE_DIR}/${GPDB_SRC_DIR}/src/test/isolation2/regression.diffs"
+  "${BASE_DIR}/${GPDB_SRC_DIR}/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/log"
+  "${BASE_DIR}/${GPDB_SRC_DIR}/gpAux/gpdemo/datadirs/dbfast2/demoDataDir1/log"
+  "${BASE_DIR}/${GPDB_SRC_DIR}/gpAux/gpdemo/datadirs/dbfast3/demoDataDir2/log"
+  "${BASE_DIR}/${GPDB_SRC_DIR}/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0/log"
+  "${BASE_DIR}/${GPDB_SRC_DIR}/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1/log"
+  "${BASE_DIR}/${GPDB_SRC_DIR}/gpAux/gpdemo/datadirs/dbfast_mirror3/demoDataDir2/log"
+)
+
+sync_logs(){
+  rsync -av --relative --inplace --whole-file \
+    --ignore-missing-args \
+    "${LOG_DIRS[@]}" \
+    "$HOST_LOG_DIR/" 2>/dev/null || true
+}
+
+if [[ "$LOG_SYNC_MODE" = "once" ]]; then
+  sync_logs
+  exit 0
+fi
+
+while true; do
+  sync_logs
+  sleep "$LOG_SYNC_INTERVAL"
+done &

--- a/ci/scripts/resgroup_collect_logs.bash
+++ b/ci/scripts/resgroup_collect_logs.bash
@@ -26,7 +26,7 @@ LOG_DIRS=(
 )
 
 sync_logs(){
-  rsync -av --relative --inplace --whole-file \
+  rsync -a --relative --inplace --whole-file \
     --ignore-missing-args \
     "${LOG_DIRS[@]}" \
     "$HOST_LOG_DIR/" 2>/dev/null || true

--- a/ci/scripts/run_resgroup_test.bash
+++ b/ci/scripts/run_resgroup_test.bash
@@ -26,6 +26,8 @@ mkdir /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb
 chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb
 chown -R gpadmin:gpadmin /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb
 
+gpdb_src/ci/scripts/resgroup_collect_logs.bash &
+
 sudo -u gpadmin -- bash -c "
   set -ex
   source \$GPHOME/greengage_path.sh
@@ -34,16 +36,8 @@ sudo -u gpadmin -- bash -c "
   make PGOPTIONS='-c optimizer=$OPTIMIZER -c statement_mem=$STATEMENT_MEM' installcheck-resgroup -C gpdb_src/
 " && exitcode=0
 
-params=(
-  "./ d gpAdminLogs"
-  "gpdb_src/src/test/ d results"
-  "gpdb_src/src/test/ f regression.diffs"
-  "gpdb_src/gpAux/gpdemo/datadirs/ d log"
-)
-for param in "\${params[@]}"; do
-  read -r path type name <<< "\$param"
-  find \$path -name \$name -type \$type -exec bash -c "tar -rf '/logs/\$name.tar' '{}' ; [ '\$name' == 'regression.diffs' ] && cat '{}' || true" \;
-done
+LOG_SYNC_MODE=once gpdb_src/ci/scripts/resgroup_collect_logs.bash
+
 chmod -R a+rwX /logs
 
 echo \$exitcode > /logs/.exitcode


### PR DESCRIPTION
Save resgroup artifacts for cancelled steps (7.x) (#265)

- bump greengage-reusable-tests-resgroup workflow to v22;
- introduce new script `resgroup_collect_logs.bash`: collects resgroup logs
in background during test execution; performs final collection once after
all tests are finished (some resgroup logs only appear post-test);
- remove old log collection logic from run_resgroup_test script;
- update test execution flow: start resgroup_collect_logs cluster is started; run
final collection after tests completion.

Task: GG-180