### PR TITLE
GG-162: Test PR (DON'T MERGE!)

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -95,7 +95,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v13
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@ADBDEV-9130
     with:
       version: 6
       target_os: ${{ matrix.target_os }}

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -95,7 +95,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@ADBDEV-9130
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@CI-5305
     with:
       version: 6
       target_os: ${{ matrix.target_os }}

--- a/GG-162-Test.md
+++ b/GG-162-Test.md
@@ -1,0 +1,8 @@
+# Test external PR (DON'T MERGE!)
+
+This is test PR for following cases:
+
+- Amend the workflow build so that the developer's image is placed in the cache only for PRs from external repositories.
+- Ensure that the developer's image is always placed in only one place — the cache or the GHCR — and is always available.
+
+## Task: [GG-162](https://tracker.yandex.ru/GG-162)


### PR DESCRIPTION
## GG-162: Test PR (DON'T MERGE!)

Testing this cases:
- Amend the workflow build so that the developer's image is placed in the cache only for PRs from external repositories.
- Ensure that the developer's image is always placed in only one place — the cache or the GHCR — and is always available.