### PR TITLE
GG-267: [7X] Place pg_regress into test docker image

### DIFF
--- a/gpcontrib/gg_tables_tracking/isolation2/Makefile
+++ b/gpcontrib/gg_tables_tracking/isolation2/Makefile
@@ -1,8 +1,7 @@
 top_builddir = ../../../
-
-ISOLATION2_ROOT = $(top_builddir)src/test/isolation2
+include $(top_builddir)/src/Makefile.global
 
 installcheck:
-	cd $(ISOLATION2_ROOT) && ./pg_isolation2_regress $(EXTRA_REGRESS_OPTS) \
-	--dbname=trackingisolation --schedule=${CURDIR}/tracking_schedule --inputdir=${CURDIR} --outputdir=${CURDIR} \
+	$(pg_isolation2_regress_installcheck) \
+	--dbname=trackingisolation --schedule=tracking_schedule \
 	--load-extension=gp_inject_fault --load-extension=plpython3u

--- a/src/Makefile
+++ b/src/Makefile
@@ -32,6 +32,7 @@ SUBDIRS = \
 	makefiles \
 	test/regress \
 	test/isolation \
+	test/isolation2 \
 	test/perl
 
 ifeq ($(with_llvm), yes)

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -756,7 +756,7 @@ pg_regress_check = \
     $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS) $(FAULTINJECTOR_OPTS)
 pg_regress_installcheck = \
     $(faultinjector_prep) \
-    $(top_builddir)/src/test/regress/pg_regress \
+    $(pgxsdir)/src/test/regress/pg_regress \
     --inputdir=$(srcdir) \
     --bindir='$(bindir)' \
     $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS) $(FAULTINJECTOR_OPTS)
@@ -779,7 +779,7 @@ pg_isolation_regress_installcheck = \
 
 pg_isolation2_regress_installcheck = \
     $(faultinjector_prep) \
-    $(top_builddir)/src/test/isolation2/pg_isolation2_regress \
+    $(pgxsdir)/src/test/isolation2/pg_isolation2_regress \
     --inputdir=$(srcdir) \
     --bindir='$(bindir)' \
     $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS) $(FAULTINJECTOR_OPTS)

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -50,13 +50,15 @@ explain.pm:
 data:
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/data
 
+isolation2_regress.o: submake-libpgport
+
 pg_isolation2_regress$(X): isolation2_main.o pg_regress.o submake-libpq submake-libpgport
 	$(CC) $(CFLAGS) $(filter %.o,$^) $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@
 
 clean distclean:
 	rm -f pg_isolation2_regress$(X) $(OBJS) isolation2_main.o isolation2_regress.so
 	rm -f pg_regress.o test_parallel_retrieve_cursor_extended_query test_parallel_retrieve_cursor_extended_query_error
-	rm -f gpstringsubs.pl gpdiff.pl atmsort.pm explain.pm
+	rm -f gpstringsubs.pl gpdiff.pl GPTest.pm atmsort.pm explain.pm
 	rm -f data
 	rm -rf $(pg_regress_clean_files)
 
@@ -64,35 +66,52 @@ clean distclean:
 install-tests:
 	$(MAKE) -C $(top_builddir)/contrib/tsm_system_rows install
 
-install: all gpdiff.pl gpstringsubs.pl install-tests
+install: all install-tests gpdiff.pl gpstringsubs.pl
+	$(MKDIR_P) '$(DESTDIR)$(pgxsdir)/$(subdir)'
+	$(INSTALL_PROGRAM) pg_isolation2_regress$(X) '$(DESTDIR)$(pgxsdir)/$(subdir)/pg_isolation2_regress$(X)'
+	$(INSTALL_PROGRAM) sql_isolation_testcase.py '$(DESTDIR)$(pgxsdir)/$(subdir)/sql_isolation_testcase.py'
+	$(LN_S) -f '../regress/gpdiff.pl' '$(DESTDIR)$(pgxsdir)/$(subdir)/gpdiff.pl'
+	$(LN_S) -f '../regress/gpstringsubs.pl' '$(DESTDIR)$(pgxsdir)/$(subdir)/gpstringsubs.pl'
+	$(LN_S) -f '../regress/GPTest.pm' '$(DESTDIR)$(pgxsdir)/$(subdir)/GPTest.pm'
+	$(LN_S) -f '../regress/atmsort.pm' '$(DESTDIR)$(pgxsdir)/$(subdir)/atmsort.pm'
+	$(LN_S) -f '../regress/explain.pm' '$(DESTDIR)$(pgxsdir)/$(subdir)/explain.pm'
 
-installcheck: install installcheck-resource-queue installcheck-parallel-retrieve-cursor installcheck-ic-tcp installcheck-ic-proxy
+uninstall:
+	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/pg_isolation2_regress$(X)'
+	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/sql_isolation_testcase.py'
+	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/gpdiff.pl'
+	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/gpstringsubs.pl'
+	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/GPTest.pm'
+	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/atmsort.pm'
+	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/explain.pm'
+
+installcheck: installcheck-resource-queue installcheck-parallel-retrieve-cursor installcheck-ic-tcp installcheck-ic-proxy extended_protocol_test
 	$(pg_isolation2_regress_installcheck) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --schedule=$(srcdir)/isolation2_schedule
 
-installcheck-resgroup: install
+installcheck-resgroup: all-lib data
 	$(pg_isolation2_regress_installcheck) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_resgroup --dbname=isolation2resgrouptest --outputdir=resgroup --schedule=$(srcdir)/isolation2_resgroup_v1_schedule
 
-installcheck-resgroup-v2: install
+installcheck-resgroup-v2: all-lib data
 	$(pg_isolation2_regress_installcheck) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_resgroup --dbname=isolation2resgrouptest --outputdir=resgroup --schedule=$(srcdir)/isolation2_resgroup_v2_schedule
 
-installcheck-parallel-retrieve-cursor: install
+installcheck-parallel-retrieve-cursor: all-lib data test_parallel_retrieve_cursor_extended_query test_parallel_retrieve_cursor_extended_query_error
 	$(pg_isolation2_regress_installcheck) $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_parallel_retrieve_cursor --bindir='$(bindir)' --inputdir=$(srcdir) --dbname=isolation2parallelretrcursor --outputdir=parallelretrcursor --schedule=$(srcdir)/parallel_retrieve_cursor_schedule
 
-installcheck-mirrorless: install
+installcheck-mirrorless: all-lib data
 	$(pg_isolation2_regress_installcheck) $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --schedule=$(srcdir)/mirrorless_schedule --outputdir=mirrorless --dbname=isolation2-mirrorless
 
-installcheck-hot-standby: install
+installcheck-hot-standby: all-lib data
 	$(pg_isolation2_regress_installcheck) $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --schedule=$(srcdir)/hot_standby_schedule --outputdir=hot_standby --dbname=isolation2-hot-standby
 
-installcheck-ic-tcp: install
+installcheck-ic-tcp: all-lib data
 ifeq ($(findstring gp_interconnect_type=tcp,$(PGOPTIONS)),gp_interconnect_type=tcp)
 	$(pg_isolation2_regress_installcheck) $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --bindir='$(bindir)' --inputdir=$(srcdir) --outputdir=ic_tcp --schedule=$(srcdir)/isolation2_ic_tcp_schedule
 endif
 
-installcheck-ic-proxy: install
+installcheck-ic-proxy: all-lib data
 ifeq ($(findstring gp_interconnect_type=proxy,$(PGOPTIONS)),gp_interconnect_type=proxy)
 	$(pg_isolation2_regress_installcheck) $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --bindir='$(bindir)' --inputdir=$(srcdir) --outputdir=ic_proxy --schedule=$(srcdir)/isolation2_ic_proxy_schedule
 endif
 
-installcheck-resource-queue: install
+installcheck-resource-queue: all-lib data
 	$(pg_isolation2_regress_installcheck) $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2  --bindir='$(bindir)' --inputdir=$(srcdir) --dbname=isolation2resourcequeue --outputdir=resqueue --schedule=$(srcdir)/isolation2_resqueue_schedule


### PR DESCRIPTION
Install pg_isolation2_regress for use in extension tests (#274)

Previously, it was impossible to run isolation tests without directly building
pg_isolation2_regress from source. This complicates testing infrastructure in
extensions, requiring to specify ISOLATION2_ROOT to run isolation tests. This
patch instead builds and installs pg_isolation2_regress during the compilation
step.

Regular pg_regress was already built and installed in the pgxs directory, but
for some reason it wasn't actually being used. This patch instead uses the
installed version of pg_regress, and adds pg_isolation2_regress to the same
place. Other necessary files are added as symlinks to regress installation.

test_python step is moved from `all` target to `installcheck` target, since it
requires installed pygresql to work.

Ticket: GG-206
(cherry picked from commit https://github.com/GreengageDB/greengage/commit/44e96ec948f9caa7c8c667716a6d6c2d71e29716)

Changes compared to the original commit:
- Update the gg_tables_tracking extension to use the new pg_isolation2_regress
  path
- Make the installcheck target depend on the extended_protocol_test
  execulable, since it is built in the source directory and therefore
  not included in the docker image

---
Restore backwards compatibility for isolation2 tests (#302)

After commit https://github.com/GreengageDB/greengage/commit/44e96ec948f9caa7c8c667716a6d6c2d71e29716, even after make install
in isolation2 directory there were missing symlinks in the source directory.
These symlinks were moved to installation directory, but to preserve backwards
compatibility we should leave them in old place as well, so that isolation2
tests can still be run the old way, from source directory.

Ticket: ADBDEV-9345
(cherry picked from commit https://github.com/GreengageDB/greengage/commit/8b18119c950f18f6f96edea19101e6e214c83ea3)

---

Note: merge with rebase.
