### PR TITLE
Fix calculating "total_queue_duration" in gp_toolkit.gp_resgroup_status

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -930,7 +930,7 @@ ResGroupGetStat(Oid groupId, ResGroupStatType type)
 			 * justify_interval() if she wants.
 			 */
 			interval = (Interval *) palloc(sizeof(Interval));
-			interval->time = group->totalQueuedTimeMs;
+			interval->time = group->totalQueuedTimeMs * 1000;
 			interval->day = 0;
 			interval->month = 0;
 			result = IntervalPGetDatum(interval);
@@ -1386,7 +1386,11 @@ addTotalQueueDuration(ResGroupData *group)
 	if (group == NULL)
 		return;
 
-	group->totalQueuedTimeMs += (groupWaitEnd - groupWaitStart);
+	/*
+	 * Note: groupWaitEnd and groupWaitStart are in microseconds, but
+	 * totalQueuedTimeMs is in milliseconds. We should convert it here.
+	 */
+	group->totalQueuedTimeMs += ((groupWaitEnd - groupWaitStart) / 1000);
 }
 
 /*

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -930,7 +930,7 @@ ResGroupGetStat(Oid groupId, ResGroupStatType type)
 			 * justify_interval() if she wants.
 			 */
 			interval = (Interval *) palloc(sizeof(Interval));
-			interval->time = group->totalQueuedTimeMs * 1000;
+			interval->time = group->totalQueuedTimeMs;
 			interval->day = 0;
 			interval->month = 0;
 			result = IntervalPGetDatum(interval);

--- a/src/test/isolation2/expected/resgroup/resgroup_wait_time.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_wait_time.out
@@ -102,3 +102,49 @@ drop role role_wait_time_test;
 DROP ROLE
 drop resource group rg_wait_time_test;
 DROP RESOURCE GROUP
+
+-- Test to check correctness of value at column "total_queue_duration"
+create resource group rg_wait_time_test with (CONCURRENCY=1, cpu_max_percent=100);
+CREATE RESOURCE GROUP
+create role role_wait_time_test resource group rg_wait_time_test;
+CREATE ROLE
+
+select total_queue_duration = '00:00:00' waited from gp_toolkit.gp_resgroup_status where groupname = 'rg_wait_time_test';
+ waited 
+--------
+ t      
+(1 row)
+
+1: set role role_wait_time_test;
+SET
+1: begin;
+BEGIN
+2: set role role_wait_time_test;
+SET
+2&: begin;  <waiting ...>
+1: select pg_sleep(10);
+ pg_sleep 
+----------
+          
+(1 row)
+1: rollback;
+ROLLBACK
+2<:  <... completed>
+BEGIN
+2: rollback;
+ROLLBACK
+
+select total_queue_duration > '00:00:00' AND total_queue_duration < '00:20:00' waited from gp_toolkit.gp_resgroup_status where groupname = 'rg_wait_time_test';
+ waited 
+--------
+ t      
+(1 row)
+
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- clean up
+drop role role_wait_time_test;
+DROP ROLE
+drop resource group rg_wait_time_test;
+DROP RESOURCE GROUP

--- a/src/test/isolation2/sql/resgroup/resgroup_wait_time.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_wait_time.sql
@@ -60,3 +60,29 @@ from gp_toolkit.gp_resgroup_status where groupname = 'rg_wait_time_test';
 -- clean up
 drop role role_wait_time_test;
 drop resource group rg_wait_time_test;
+
+-- Test to check correctness of value at column "total_queue_duration"
+create resource group rg_wait_time_test with (CONCURRENCY=1, cpu_max_percent=100);
+create role role_wait_time_test resource group rg_wait_time_test;
+
+select total_queue_duration = '00:00:00' waited
+from gp_toolkit.gp_resgroup_status where groupname = 'rg_wait_time_test';
+
+1: set role role_wait_time_test;
+1: begin;
+2: set role role_wait_time_test;
+2&: begin;
+1: select pg_sleep(10);
+1: rollback;
+2<:
+2: rollback;
+
+select total_queue_duration > '00:00:00' AND total_queue_duration < '00:20:00' waited
+from gp_toolkit.gp_resgroup_status where groupname = 'rg_wait_time_test';
+
+1q:
+2q:
+
+-- clean up
+drop role role_wait_time_test;
+drop resource group rg_wait_time_test;


### PR DESCRIPTION
Fix calculating "total_queue_duration" in gp_toolkit.gp_resgroup_status

View gp_toolkit.gp_resgroup_status uses "select" from the function
pg_resgroup_get_status. It gets statistics of resource groups by executing
function ResGroupGetStat. For the total_queue_duration column, value from field
totalQueuedTimeMs is used. But at the function addTotalQueueDuration value is
calculated incorrectly. Variables groupWaitStart and groupWaitEnd contain data
in microseconds and such value is written to totalQueuedTimeMs without
converting. As a result, we get total_queue_duration which is greater 1000
times, than correct value.

Patch adds converting microseconds to milliseconds to the function
addTotalQueueDuration, and View gp_toolkit.gp_resgroup_status returns correct
value in the "total_queue_duration" column.