### PR TITLE
Fix database, schema, and table name escaping in ggrebalance

### DIFF
--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -2,6 +2,7 @@
 
 from psycopg2.extensions import cursor
 from gppylib.db import dbconn
+from gppylib.utils import escape_string
 from typing import List
 from ggrebalance_modules.planner import Plan, deserializePlan
 from ggrebalance_modules.rebalance_step import *
@@ -13,7 +14,7 @@ def get_table_distr_segment_count(conn: dbconn.Connection, schema_name: str, tab
                           f'''SELECT p.numsegments
                           FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid
                           JOIN gp_distribution_policy p ON c.oid = p.localoid
-                          WHERE n.nspname='{schema_name}' AND c.relname='{table_name}';''')
+                          WHERE n.nspname='{escape_string(schema_name)}' AND c.relname='{escape_string(table_name)}';''')
     return int(row[0])
 
 class RebalanceSchema:
@@ -136,12 +137,12 @@ class RebalanceSchema:
     def addTableToRebalance(self, db: str, schema_name: str, rel_name: str, status: str) -> None:
         dbconn.execSQL(self.conn,
                        f'''INSERT INTO {self.schema_name}.{self.table_rebalance_status_detail}
-                       VALUES ('{db}', '{schema_name}', '{rel_name}', '{status}')''')
+                       VALUES ('{escape_string(db)}', '{escape_string(schema_name)}', '{escape_string(rel_name)}', '{status}')''')
 
     def setStatusForTableToRebalance(self, db: str, schema_name: str, rel_name: str, status: str) -> None:
         dbconn.execSQL(self.conn,
                        f'''UPDATE {self.schema_name}.{self.table_rebalance_status_detail} SET status = '{status}'
-                       WHERE db_name = '{db}' AND schema_name = '{schema_name}' AND rel_name = '{rel_name}';''')
+                       WHERE db_name = '{escape_string(db)}' AND schema_name = '{escape_string(schema_name)}' AND rel_name = '{escape_string(rel_name)}';''')
 
     def getTablesToRebalanceWithStatus(self, status: str) -> cursor:
         return dbconn.query(self.conn, f"""SELECT db_name, schema_name, rel_name FROM

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -16,6 +16,7 @@ try:
     from gppylib.commands import base
     from gppylib.commands.gp import SEGMENT_STOP_TIMEOUT_DEFAULT, SegmentStop
     from gppylib.system.environment import *
+    from gppylib.utils import escape_string, escapeDoubleQuoteInSQLString
     from ggrebalance_modules.planner import *
     from ggrebalance_modules.rebalance_schema import RebalanceSchema, STATE_NOT_DEFINED
 except ImportError as e:
@@ -613,13 +614,13 @@ class GGShrink:
             if dbconn.querySingleton(conn, f"""
                 SELECT count(1)
                 FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid
-                WHERE c.relname = '{rel_name}' AND n.nspname = '{schema_name}' AND c.relnamespace = n.oid
+                WHERE c.relname = '{escape_string(rel_name)}' AND n.nspname = '{escape_string(schema_name)}' AND c.relnamespace = n.oid
                 """) == 0:
                 return False
             return True
 
         def db_exists(self, conn: dbconn.Connection, db_name: str) -> bool:
-            if dbconn.querySingleton(conn, f"""SELECT count(*) FROM pg_database WHERE datname = '{db_name}'""") == 0:
+            if dbconn.querySingleton(conn, f"""SELECT count(*) FROM pg_database WHERE datname = '{escape_string(db_name)}'""") == 0:
                 return False
             return True
 
@@ -634,11 +635,11 @@ class GGShrink:
                     table_exists = self.table_exists(conn, self.schema_name, self.rel_name)
                     if table_exists:
                         dbconn.execSQL(conn,
-                                    f'''ALTER TABLE "{self.schema_name}"."{self.rel_name}"
+                                    f'''ALTER TABLE {escapeDoubleQuoteInSQLString(self.schema_name, True)}.{escapeDoubleQuoteInSQLString(self.rel_name, True)}
                                     REBALANCE {self.target_segment_count}''')
                         if self.shrink.options.analyze:
                             dbconn.execSQL(conn,
-                                           f'''ANALYZE "{self.schema_name}"."{self.rel_name}"''')
+                                           f'''ANALYZE {escapeDoubleQuoteInSQLString(self.schema_name, True)}.{escapeDoubleQuoteInSQLString(self.rel_name, True)}''')
                     else:
                         self.shrink.logger.info(f'''Table "{self.db_name}"."{self.schema_name}"."{self.rel_name}" doesn't exist, skipping actual rebalance''')
 

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
@@ -802,3 +802,15 @@ Feature: ggrebalance behave tests
          And distribution information from table "test_schema_1.mv_test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 1, row count = 100
          And the numsegments of table "ext_test" is 1
+
+    Scenario: test 7. shrink - check database, schema, table with special character
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1"
+         And all files in gpAdminLogs directory are deleted
+         And create database schema table with special character
+        When the user runs "ggrebalance --analyze -x 1 --skip-rebalance"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And ggrebalance should not print "doesn't exist, skipping actual rebalance" to logfile with latest timestamp
+

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2863,8 +2863,14 @@ def impl(context, command, target):
     if target not in contents:
         raise Exception("cannot find %s in %s" % (target, filename))
 
-@then('{command} should print "{target}" to logfile with latest timestamp')
-def impl(context, command, target):
+@then('{command} should {print} "{target}" to logfile with latest timestamp')
+def impl(context, command, print, target):
+    if print == 'print':
+        valuesShouldExist = True
+    elif print == 'not print':
+        valuesShouldExist = False
+    else:
+        raise Exception("only 'print' and 'not print' are valid inputs")
     log_dir = _get_gpAdminLogs_directory()
     filenames = glob.glob('%s/%s_*.log' % (log_dir, command))
     filename = max(filenames, key=os.path.getctime)
@@ -2872,8 +2878,10 @@ def impl(context, command, target):
     with open(filename) as fr:
         for line in fr:
             contents += line
-    if target not in contents:
+    if valuesShouldExist and target not in contents:
         raise Exception("cannot find %s in %s" % (target, filename))
+    if not valuesShouldExist and target in contents:
+        raise Exception("found %s in %s" % (target, filename))
 
 
 @then('{command} should print "{target}" regex to logfile')

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17740,20 +17740,28 @@ ATExecShrinkTable(Relation rel, GpPolicy *policy)
 		volatile bool connected = false;
 		StringInfoData sqlstmtInsert;
 		initStringInfo(&sqlstmtInsert);
-		char *nsp = get_namespace_name(RelationGetNamespace(rel));
-		char *relname = RelationGetRelationName(rel);
+		const char *nsp = quote_identifier(
+			get_namespace_name(RelationGetNamespace(rel)));
+		const char *relname = quote_identifier(
+			RelationGetRelationName(rel));
+
+		StringInfoData qualified_table_name;
+		initStringInfo(&qualified_table_name);
+		appendStringInfo(&qualified_table_name, "%s.%s", nsp, relname);
 
 		/*
 		 * 'gp_dist_random' will cause fallback to Postgres planner,
 		 * so no need to tweak 'optimizer' value.
 		 */
 		appendStringInfo(&sqlstmtInsert,
-						 "insert into %s.%s select * "
-						 "from gp_dist_random('%s.%s') "
+						 "insert into %s select * "
+						 "from gp_dist_random(%s) "
 						 "where gp_segment_id >= %d",
-						 nsp, relname,
-						 nsp, relname,
+						 qualified_table_name.data,
+						 quote_literal_cstr(qualified_table_name.data),
 						 policy->numsegments);
+
+		pfree(qualified_table_name.data);
 
 		gp_segment_number_for_table_shrink = policy->numsegments;
 


### PR DESCRIPTION
Fix database, schema, and table name escaping in ggrebalance

Problem description:
Database, schema, and table names that contain special chars like `'` caused
ggrebalance to fail during cluster shrink.

Root cause:
The names were not escaped properly.

Fix:
 - add name escaping into ggrebalance;
 - add schema and table name escaping in the auxiliary query in
ATExecShrinkTable(), which is used at 'ALTER TABLE ... REBALANCE' operation.