### PR TITLE
GG-281: Build in Ubuntu 22.04 and 24.04 for 6.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -16,17 +16,21 @@ concurrency:
 jobs:
   build:
     strategy:
-      fail-fast: true  # Stop on any failure in the matrix
+      fail-fast: false
       matrix:
-        target_os: [ubuntu]
+        include:
+          - target_os: ubuntu
+          - target_os: ubuntu
+            target_os_version: "24.04"
     permissions:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v19
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v25
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
+      target_os_version: ${{ matrix.target_os_version }}
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Build in Ubuntu 22.04 and 24.04 for 6.x (#312)

Update reusable build workflow to `v25` and enable `Ubuntu 24.04` matrix

- Upgrade `greengage-reusable-build` workflow from v19 to v25
- Add Ubuntu 24.04 to the build matrix alongside default 22.04
- Set `fail-fast: false` to allow all matrix jobs to complete
- Pass `target_os_version` parameter to the reusable workflow

Task: [GG-281](https://tracker.yandex.ru/GG-281)

---

## CI v25 changes

Prepare greengage-reusable-build workflow for parallel build (https://github.com/GreengageDB/greengage-ci/pull/38)

- Remove unused `python3` input parameter
- Use `OS_VERSION` build argument to support multiple Ubuntu
  versions (22.04, 24.04) with single `Dockerfile`
- Add default value for `OS_VERSION` (22.04)
- Move environment variables to job level to reduce code duplication
- Replace manual "git fetch --tags" with native `fetch-tags: true`
- Simplify `Dockerfile` path construction
- Standardize image name usage via global environment variables
- Update `README/REUSABLE-BUILD.md`

Task: [CI-5269](https://tracker.yandex.ru/CI-5269)

