### PR TITLE
GG-285: Fix SIGSEGV due to subqueries flow temporary nullification

### DIFF
--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -2953,5 +2953,7 @@ cdb_insert_result_node(PlannerInfo *root, Plan *plan, int rtoffset)
 		plan->flow = flow;
 	}
 
+	AssertImply(flow && resultplan->lefttree, resultplan->lefttree->flow);
+
     return resultplan;
 }                               /* cdb_insert_result_node */

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -2938,9 +2938,20 @@ cdb_insert_result_node(PlannerInfo *root, Plan *plan, int rtoffset)
     /* Fix up the Result node and the Plan tree below it. */
     resultplan = set_plan_refs(root, resultplan, rtoffset);
 
-    /* Reattach the Flow node. */
     resultplan->flow = flow;
-	plan->flow = flow;
+	/* In case we ommited SubqueryScan node in set_subqueryscan_references()
+	 * we need to reatach flow to new outerplan node, because previously we
+	 * copied null into it. Otherwise reatach flow to previous node.
+	 */
+	if (resultplan->lefttree && IsA(plan, SubqueryScan) &&
+		nodeTag(resultplan->lefttree) != nodeTag(plan))
+	{
+		resultplan->lefttree->flow = flow;
+	}
+	else
+	{
+		plan->flow = flow;
+	}
 
     return resultplan;
 }                               /* cdb_insert_result_node */

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -2944,7 +2944,7 @@ cdb_insert_result_node(PlannerInfo *root, Plan *plan, int rtoffset)
 	 * copied null into it. Otherwise reatach flow to previous node.
 	 */
 	if (resultplan->lefttree && IsA(plan, SubqueryScan) &&
-		nodeTag(resultplan->lefttree) != nodeTag(plan))
+		resultplan->lefttree != plan)
 	{
 		resultplan->lefttree->flow = flow;
 	}

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -2939,7 +2939,8 @@ cdb_insert_result_node(PlannerInfo *root, Plan *plan, int rtoffset)
     resultplan = set_plan_refs(root, resultplan, rtoffset);
 
     resultplan->flow = flow;
-	/* In case we ommited SubqueryScan node in set_subqueryscan_references()
+	/*
+	 * In case we ommited SubqueryScan node in set_subqueryscan_references()
 	 * we need to reatach flow to new outerplan node, because previously we
 	 * copied null into it. Otherwise reatach flow to previous node.
 	 */

--- a/src/test/regress/expected/bfv_subquery.out
+++ b/src/test/regress/expected/bfv_subquery.out
@@ -500,6 +500,21 @@ EXPLAIN SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
 
 DROP TABLE A;
 --
+-- Test if we reattach flow of omitted SubqueryScan to outerplan.
+--
+WITH A AS (
+    SELECT I FROM T
+), B AS (
+    SELECT I, UNNEST(ARRAY[0]) FROM A
+), C AS (
+    SELECT I FROM B
+) SELECT I FROM C JOIN T USING (I) WHERE T.I IN (SELECT T.I FROM C);
+ i 
+---
+(0 rows)
+
+DROP TABLE
+--
 -- Test the ctid in Function and Values Scans
 --
 create table t1(a int) ;

--- a/src/test/regress/expected/bfv_subquery.out
+++ b/src/test/regress/expected/bfv_subquery.out
@@ -504,50 +504,30 @@ DROP TABLE A;
 --
 EXPLAIN (VERBOSE, COSTS OFF)
 WITH A AS (
-    SELECT I FROM T
+    SELECT * FROM UNNEST(ARRAY[0]) I
 ), B AS (
-    SELECT I, UNNEST(ARRAY[0]) FROM A
-), C AS (
-    SELECT I FROM B
-) SELECT I FROM C JOIN T USING (I) WHERE T.I IN (SELECT T.I FROM C);
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
-   Output: b.i
-   ->  Hash Join
-         Output: b.i
-         Hash Cond: (t.i = b.i)
-         ->  Seq Scan on public.t
-               Output: t.i
-               Filter: (SubPlan 1)
-               SubPlan 1  (slice2; segments: 3)
-                 ->  Subquery Scan on c
-                       Output: t.i
-                       ->  Subquery Scan on b_1
-                             Output: b_1.i
-                             ->  Result
-                                   Output: t_2.i, unnest('{0}'::integer[])
-                                   ->  Result
-                                         Output: t_2.i
-                                         ->  Materialize
-                                               Output: t_2.i
-                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                                                     Output: t_2.i
-                                                     ->  Seq Scan on public.t t_2
-                                                           Output: t_2.i
-         ->  Hash
-               Output: b.i
-               ->  Subquery Scan on b
-                     Output: b.i
-                     ->  Result
-                           Output: t_1.i, unnest('{0}'::integer[])
-                           ->  Seq Scan on public.t t_1
-                                 Output: t_1.i
+    SELECT *, UNNEST(ARRAY[1]) FROM A
+) SELECT * FROM A WHERE I IN (SELECT A.I FROM B);
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Subquery Scan on a
+   Output: a.i
+   Filter: (SubPlan 1)
+   ->  Function Scan on pg_catalog.unnest i
+         Output: i.i
+         Function Call: unnest('{0}'::integer[])
+   SubPlan 1
+     ->  Subquery Scan on b
+           Output: a.i
+           ->  Result
+                 Output: i_1.i, unnest('{1}'::integer[])
+                 ->  Function Scan on pg_catalog.unnest i_1
+                       Output: i_1.i
+                       Function Call: unnest('{0}'::integer[])
  Optimizer: Postgres query optimizer
  Settings: optimizer=off
-(33 rows)
+(16 rows)
 
-DROP TABLE T;
 --
 -- Test the ctid in Function and Values Scans
 --

--- a/src/test/regress/expected/bfv_subquery.out
+++ b/src/test/regress/expected/bfv_subquery.out
@@ -502,6 +502,7 @@ DROP TABLE A;
 --
 -- Test if we reattach flow of omitted SubqueryScan to outerplan.
 --
+EXPLAIN (VERBOSE, COSTS OFF)
 WITH A AS (
     SELECT I FROM T
 ), B AS (
@@ -509,9 +510,42 @@ WITH A AS (
 ), C AS (
     SELECT I FROM B
 ) SELECT I FROM C JOIN T USING (I) WHERE T.I IN (SELECT T.I FROM C);
- i 
----
-(0 rows)
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: b.i
+   ->  Hash Join
+         Output: b.i
+         Hash Cond: (t.i = b.i)
+         ->  Seq Scan on public.t
+               Output: t.i
+               Filter: (SubPlan 1)
+               SubPlan 1  (slice2; segments: 3)
+                 ->  Subquery Scan on c
+                       Output: t.i
+                       ->  Subquery Scan on b_1
+                             Output: b_1.i
+                             ->  Result
+                                   Output: t_2.i, unnest('{0}'::integer[])
+                                   ->  Result
+                                         Output: t_2.i
+                                         ->  Materialize
+                                               Output: t_2.i
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                                     Output: t_2.i
+                                                     ->  Seq Scan on public.t t_2
+                                                           Output: t_2.i
+         ->  Hash
+               Output: b.i
+               ->  Subquery Scan on b
+                     Output: b.i
+                     ->  Result
+                           Output: t_1.i, unnest('{0}'::integer[])
+                           ->  Seq Scan on public.t t_1
+                                 Output: t_1.i
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(33 rows)
 
 DROP TABLE T;
 --

--- a/src/test/regress/expected/bfv_subquery.out
+++ b/src/test/regress/expected/bfv_subquery.out
@@ -513,7 +513,7 @@ WITH A AS (
 ---
 (0 rows)
 
-DROP TABLE
+DROP TABLE T;
 --
 -- Test the ctid in Function and Values Scans
 --

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -499,6 +499,7 @@ DROP TABLE A;
 --
 -- Test if we reattach flow of omitted SubqueryScan to outerplan.
 --
+EXPLAIN (VERBOSE, COSTS OFF)
 WITH A AS (
     SELECT I FROM T
 ), B AS (
@@ -506,9 +507,42 @@ WITH A AS (
 ), C AS (
     SELECT I FROM B
 ) SELECT I FROM C JOIN T USING (I) WHERE T.I IN (SELECT T.I FROM C);
- i 
----
-(0 rows)
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: b.i
+   ->  Hash Join
+         Output: b.i
+         Hash Cond: (t.i = b.i)
+         ->  Seq Scan on public.t
+               Output: t.i
+               Filter: (SubPlan 1)
+               SubPlan 1  (slice2; segments: 3)
+                 ->  Subquery Scan on c
+                       Output: t.i
+                       ->  Subquery Scan on b_1
+                             Output: b_1.i
+                             ->  Result
+                                   Output: t_2.i, unnest('{0}'::integer[])
+                                   ->  Result
+                                         Output: t_2.i
+                                         ->  Materialize
+                                               Output: t_2.i
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                                     Output: t_2.i
+                                                     ->  Seq Scan on public.t t_2
+                                                           Output: t_2.i
+         ->  Hash
+               Output: b.i
+               ->  Subquery Scan on b
+                     Output: b.i
+                     ->  Result
+                           Output: t_1.i, unnest('{0}'::integer[])
+                           ->  Seq Scan on public.t t_1
+                                 Output: t_1.i
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=on
+(33 rows)
 
 DROP TABLE T;
 --

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -510,7 +510,7 @@ WITH A AS (
 ---
 (0 rows)
 
-DROP TABLE
+DROP TABLE T;
 --
 -- Test the ctid in Function and Values Scans
 --

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -501,50 +501,41 @@ DROP TABLE A;
 --
 EXPLAIN (VERBOSE, COSTS OFF)
 WITH A AS (
-    SELECT I FROM T
+    SELECT * FROM UNNEST(ARRAY[0]) I
 ), B AS (
-    SELECT I, UNNEST(ARRAY[0]) FROM A
-), C AS (
-    SELECT I FROM B
-) SELECT I FROM C JOIN T USING (I) WHERE T.I IN (SELECT T.I FROM C);
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
-   Output: b.i
-   ->  Hash Join
-         Output: b.i
-         Hash Cond: (t.i = b.i)
-         ->  Seq Scan on public.t
-               Output: t.i
-               Filter: (SubPlan 1)
-               SubPlan 1  (slice2; segments: 3)
-                 ->  Subquery Scan on c
-                       Output: t.i
-                       ->  Subquery Scan on b_1
-                             Output: b_1.i
-                             ->  Result
-                                   Output: t_2.i, unnest('{0}'::integer[])
-                                   ->  Result
-                                         Output: t_2.i
-                                         ->  Materialize
-                                               Output: t_2.i
-                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                                                     Output: t_2.i
-                                                     ->  Seq Scan on public.t t_2
-                                                           Output: t_2.i
-         ->  Hash
-               Output: b.i
-               ->  Subquery Scan on b
-                     Output: b.i
+    SELECT *, UNNEST(ARRAY[1]) FROM A
+) SELECT * FROM A WHERE I IN (SELECT A.I FROM B);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Sequence
+   Output: share0_ref3.unnest
+   ->  Shared Scan (share slice:id -1:0)
+         Output: share0_ref1.unnest
+         ->  Materialize
+               Output: unnest.unnest
+               ->  Function Scan on pg_catalog.unnest
+                     Output: unnest.unnest
+                     Function Call: unnest('{0}'::integer[])
+   ->  Nested Loop Semi Join
+         Output: share0_ref3.unnest
+         Join Filter: true
+         ->  Result
+               Output: share0_ref3.unnest
+               Filter: (share0_ref3.unnest = share0_ref3.unnest)
+               ->  Shared Scan (share slice:id -1:0)
+                     Output: share0_ref3.unnest
+         ->  Materialize
+               Output: (unnest('{1}'::integer[]))
+               ->  Limit
+                     Output: (unnest('{1}'::integer[]))
                      ->  Result
-                           Output: t_1.i, unnest('{0}'::integer[])
-                           ->  Seq Scan on public.t t_1
-                                 Output: t_1.i
- Optimizer: Postgres query optimizer
+                           Output: unnest('{1}'::integer[])
+                           ->  Shared Scan (share slice:id -1:0)
+                                 Output: share0_ref2.unnest
+ Optimizer: Pivotal Optimizer (GPORCA)
  Settings: optimizer=on
-(33 rows)
+(27 rows)
 
-DROP TABLE T;
 --
 -- Test the ctid in Function and Values Scans
 --

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -497,6 +497,21 @@ EXPLAIN SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
 
 DROP TABLE A;
 --
+-- Test if we reattach flow of omitted SubqueryScan to outerplan.
+--
+WITH A AS (
+    SELECT I FROM T
+), B AS (
+    SELECT I, UNNEST(ARRAY[0]) FROM A
+), C AS (
+    SELECT I FROM B
+) SELECT I FROM C JOIN T USING (I) WHERE T.I IN (SELECT T.I FROM C);
+ i 
+---
+(0 rows)
+
+DROP TABLE
+--
 -- Test the ctid in Function and Values Scans
 --
 create table t1(a int) ;

--- a/src/test/regress/sql/bfv_subquery.sql
+++ b/src/test/regress/sql/bfv_subquery.sql
@@ -295,20 +295,13 @@ DROP TABLE A;
 --
 -- Test if we reattach flow of omitted SubqueryScan to outerplan.
 --
--- start_ignore
-DROP TABLE IF EXISTS T;
-CREATE TABLE T (I INT) DISTRIBUTED BY (I);
--- end_ignore
 
+EXPLAIN (VERBOSE, COSTS OFF)
 WITH A AS (
-    SELECT I FROM T
+    SELECT * FROM UNNEST(ARRAY[0]) I
 ), B AS (
-    SELECT I, UNNEST(ARRAY[0]) FROM A
-), C AS (
-    SELECT I FROM B
-) SELECT I FROM C JOIN T USING (I) WHERE T.I IN (SELECT T.I FROM C);
-
-DROP TABLE T;
+    SELECT *, UNNEST(ARRAY[1]) FROM A
+) SELECT * FROM A WHERE I IN (SELECT A.I FROM B);
 
 --
 -- Test the ctid in Function and Values Scans

--- a/src/test/regress/sql/bfv_subquery.sql
+++ b/src/test/regress/sql/bfv_subquery.sql
@@ -293,6 +293,24 @@ EXPLAIN SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
 DROP TABLE A;
 
 --
+-- Test if we reattach flow of omitted SubqueryScan to outerplan.
+--
+-- start_ignore
+DROP TABLE IF EXISTS T;
+CREATE TABLE T (I INT) DISTRIBUTED BY (I);
+-- end_ignore
+
+WITH A AS (
+    SELECT I FROM T
+), B AS (
+    SELECT I, UNNEST(ARRAY[0]) FROM A
+), C AS (
+    SELECT I FROM B
+) SELECT I FROM C JOIN T USING (I) WHERE T.I IN (SELECT T.I FROM C);
+
+DROP TABLE T;
+
+--
 -- Test the ctid in Function and Values Scans
 --
 


### PR DESCRIPTION
Fix SIGSEGV due to subqueries flow temporary nullification

When subquery gets omitted in `set_subqueryscan_references()`, via
`trivial_subqueryscan()` there's a chance that previously we inserted `Result`
node via `cdb_insert_result_node()`, which may lead to nullification of flow in
firstly `SubqueryScan` node and secondly in node, which gets pulled up in place
of `SubqueryScan`. This happens because of next code part:
```c
/* Honor the flow of the SubqueryScan, by copying it to the subplan. */
		result->flow = plan->scan.plan.flow;
```
Here we assign previously nullified flow to pulled up node. 

So to fix this issue we should assign proper flow to the pulled up node in case
of `SubqueryScan` omition.

Co-authored-by: Georgy Shelkovy <g.shelkovy@arenadata.io>