### PR TITLE
GG-299: Run behave tests in Ubuntu 22.04 and 24.04 for 6.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -1,4 +1,4 @@
-# Main CI pipeline orchestrating build, test, and upload stages
+# .github/workflows/greengage-ci.yml
 name: Greengage CI
 
 on:
@@ -40,15 +40,19 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        target_os: [ubuntu]
+        include:
+          - target_os: ubuntu
+          - target_os: ubuntu
+            target_os_version: "24.04"
     permissions:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v24
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v25
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
+      target_os_version: ${{ matrix.target_os_version }}
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Run behave tests in Ubuntu 22.04 and 24.04 for 6.x (#325)

- Update lead comment of `Greengage CI` workflow from the obvious to own file name for clarity
- Update behave tests matrix for additional use `ubuntu 24.04` with `ubuntu` (default `22.04`)
- Target behave tests reusable workflow to `v25` tag

### Note:
CI tag `v25` was made to run behave tests on different OS versions using a single default DB SQL Dump for all OS versions (`22.04`) while regression tests cannot create SQL Dump for `24.04`

Task: [GG-299](https://tracker.yandex.ru/GG-299)