### PR TITLE
ADBDEV-7532: Track PQresult allocations in server code [7X]

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -687,6 +687,8 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 
 	pfree(revents);
 	pfree(added);
+
+	SIMPLE_FAULT_INJECTOR("check_dispatch_result_end");
 }
 
 /*

--- a/src/backend/libpq/.gitignore
+++ b/src/backend/libpq/.gitignore
@@ -12,3 +12,4 @@ fe-secure-openssl.c
 fe-secure.c
 getpeereid.c
 pqexpbuffer.c
+libpq-events.c

--- a/src/backend/libpq/Makefile
+++ b/src/backend/libpq/Makefile
@@ -29,7 +29,7 @@ endif
 # Greengage objects follow
 OBJS += fe-protocol3.o fe-connect.o \
         fe-exec.o pqexpbuffer.o fe-auth.o fe-misc.o fe-protocol2.o fe-secure.o \
-	fe-auth-scram.o \
+	fe-auth-scram.o libpq-events.o \
         $(filter getpeereid.o, $(LIBOBJS))
 
 # Greengage OpenSSL objects follow
@@ -42,7 +42,7 @@ ifeq ($(with_gssapi),yes)
 OBJS += fe-gssapi-common.o fe-secure-gssapi.o
 endif
 
-fe-protocol3.c fe-connect.c fe-exec.c pqexpbuffer.c fe-auth.c fe-auth-scram.c fe-misc.c fe-protocol2.c fe-secure.c fe-secure-openssl.c fe-secure-common.c fe-secure-gssapi.c fe-gssapi-common.c: % : $(top_srcdir)/src/interfaces/libpq/%
+fe-protocol3.c fe-connect.c fe-exec.c pqexpbuffer.c fe-auth.c fe-auth-scram.c fe-misc.c fe-protocol2.c fe-secure.c fe-secure-openssl.c fe-secure-common.c fe-secure-gssapi.c fe-gssapi-common.c libpq-events.c: % : $(top_srcdir)/src/interfaces/libpq/%
 	rm -f $@ && $(LN_S) $< .
 
 getpeereid.c: % : $(top_srcdir)/src/port/%

--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -102,13 +102,31 @@ static int	ldapServiceLookup(const char *purl, PQconninfoOption *options,
  * than looking into errcodes.h since it reflects historical behavior
  * rather than that of the current code.
  */
+#ifdef ERRCODE_APPNAME_UNKNOWN
+#undef ERRCODE_APPNAME_UNKNOWN
+#endif
+
 #define ERRCODE_APPNAME_UNKNOWN "42704"
 
 /* This is part of the protocol so just define it */
+#ifdef ERRCODE_INVALID_PASSWORD
+#undef ERRCODE_INVALID_PASSWORD
+#endif
+
 #define ERRCODE_INVALID_PASSWORD "28P01"
+
 /* This too */
+#ifdef ERRCODE_CANNOT_CONNECT_NOW
+#undef ERRCODE_CANNOT_CONNECT_NOW
+#endif
+
 #define ERRCODE_CANNOT_CONNECT_NOW "57P03"
+
 /* And this GPDB-specific one, too */
+#ifdef ERRCODE_MIRROR_READY
+#undef ERRCODE_MIRROR_READY
+#endif
+
 #define ERRCODE_MIRROR_READY "57M02"
 
 /*

--- a/src/interfaces/libpq/fe-exec.c
+++ b/src/interfaces/libpq/fe-exec.c
@@ -145,13 +145,18 @@ static int	check_field_number(const PGresult *res, int field_num);
  *	 returns a newly allocated, initialized PGresult with given status.
  *	 If conn is not NULL and status indicates an error, the conn's
  *	 errorMessage is copied.  Also, any PGEvents are copied from the conn.
+ *
+ * GPDB: most of the libpq's memory allocations happen here--PQresults store
+ *       all retrieved rows. Thus we use a palloc() wrapper instead of bare
+ *       malloc() for vmtracker to see the allocations, in case we're the
+ *       backend.
  */
 PGresult *
 PQmakeEmptyPGresult(PGconn *conn, ExecStatusType status)
 {
 	PGresult   *result;
 
-	result = (PGresult *) malloc(sizeof(PGresult));
+	result = (PGresult *) pqPalloc(sizeof(PGresult));
 	if (!result)
 		return NULL;
 
@@ -402,6 +407,9 @@ PQcopyResult(const PGresult *src, int flags)
  * Does not duplicate the event instance data, sets this to NULL.
  * Also, the resultInitialized flags are all cleared.
  * The total space allocated is added to *memSize.
+ *
+ * GPDB: backends use palloc() for allocations here. Make sure this function
+ *       is only used for PGresult->events!
  */
 static PGEvent *
 dupEvents(PGEvent *events, int count, size_t *memSize)
@@ -414,7 +422,7 @@ dupEvents(PGEvent *events, int count, size_t *memSize)
 		return NULL;
 
 	msize = count * sizeof(PGEvent);
-	newEvents = (PGEvent *) malloc(msize);
+	newEvents = (PGEvent *) pqPalloc(msize);
 	if (!newEvents)
 		return NULL;
 
@@ -424,12 +432,12 @@ dupEvents(PGEvent *events, int count, size_t *memSize)
 		newEvents[i].passThrough = events[i].passThrough;
 		newEvents[i].data = NULL;
 		newEvents[i].resultInitialized = false;
-		newEvents[i].name = strdup(events[i].name);
+		newEvents[i].name = pqPstrdup(events[i].name);
 		if (!newEvents[i].name)
 		{
 			while (--i >= 0)
-				free(newEvents[i].name);
-			free(newEvents);
+				pqPfree(newEvents[i].name);
+			pqPfree(newEvents);
 			return NULL;
 		}
 		msize += strlen(events[i].name) + 1;
@@ -596,7 +604,7 @@ pqResultAlloc(PGresult *res, size_t nBytes, bool isBinary)
 	{
 		size_t		alloc_size = nBytes + PGRESULT_BLOCK_OVERHEAD;
 
-		block = (PGresult_data *) malloc(alloc_size);
+		block = (PGresult_data *) pqPalloc(alloc_size);
 		if (!block)
 			return NULL;
 		res->memorySize += alloc_size;
@@ -621,7 +629,7 @@ pqResultAlloc(PGresult *res, size_t nBytes, bool isBinary)
 	}
 
 	/* Otherwise, start a new block. */
-	block = (PGresult_data *) malloc(PGRESULT_DATA_BLOCKSIZE);
+	block = (PGresult_data *) pqPalloc(PGRESULT_DATA_BLOCKSIZE);
 	if (!block)
 		return NULL;
 	res->memorySize += PGRESULT_DATA_BLOCKSIZE;
@@ -730,22 +738,22 @@ PQclear(PGresult *res)
 			(void) res->events[i].proc(PGEVT_RESULTDESTROY, &evt,
 									   res->events[i].passThrough);
 		}
-		free(res->events[i].name);
+		pqPfree(res->events[i].name);
 	}
 
 	if (res->events)
-		free(res->events);
+		pqPfree(res->events);
 
 	/* Free all the subsidiary blocks */
 	while ((block = res->curBlock) != NULL)
 	{
 		res->curBlock = block->next;
-		free(block);
+		pqPfree(block);
 	}
 
 	/* Free the top-level tuple pointer array */
 	if (res->tuples)
-		free(res->tuples);
+		pqPfree(res->tuples);
 
 	/* zero out the pointer fields to catch programming errors */
 	res->attDescs = NULL;
@@ -757,18 +765,18 @@ PQclear(PGresult *res)
 	/* res->curBlock was zeroed out earlier */
 
 	if (res->extras)
-		free(res->extras);
+		pqPfree(res->extras);
 	res->extraslen = 0;
 	res->extras = NULL;
 	res->extraType = PGExtraTypeNone;
 
 	if (res->waitGxids)
-		free(res->waitGxids);
+		pqPfree(res->waitGxids);
 	res->waitGxids = NULL;
 	res->nWaits = 0;
 
 	/* Free the PGresult structure itself */
-	free(res);
+	pqPfree(res);
 }
 
 /*
@@ -1001,10 +1009,10 @@ pqAddTuple(PGresult *res, PGresAttValue *tup, const char **errmsgp)
 
 		if (res->tuples == NULL)
 			newTuples = (PGresAttValue **)
-				malloc(newSize * sizeof(PGresAttValue *));
+				pqPalloc(newSize * sizeof(PGresAttValue *));
 		else
 			newTuples = (PGresAttValue **)
-				realloc(res->tuples, newSize * sizeof(PGresAttValue *));
+				pqRepalloc(res->tuples, newSize * sizeof(PGresAttValue *));
 		if (!newTuples)
 			return false;		/* malloc or realloc failed */
 		res->memorySize +=

--- a/src/interfaces/libpq/fe-protocol3.c
+++ b/src/interfaces/libpq/fe-protocol3.c
@@ -499,7 +499,7 @@ pqParseInput3(PGconn *conn)
 							return;
 						if (pqGetInt(&conn->result->extraslen, 4, conn))
 							return;
-						conn->result->extras = malloc(conn->result->extraslen);
+						conn->result->extras = pqPalloc(conn->result->extraslen);
 						if (pqGetnchar((char *)conn->result->extras, conn->result->extraslen, conn))
 							return;
 						if (ready)
@@ -526,7 +526,7 @@ pqParseInput3(PGconn *conn)
 					{
 						if (conn->result->waitGxids == NULL)
 							conn->result->waitGxids =
-								malloc(sizeof(int) * conn->result->nWaits);
+								pqPalloc(sizeof(int) * conn->result->nWaits);
 						for (i = 0; i < conn->result->nWaits; i++)
 						{
 							int gxid;

--- a/src/interfaces/libpq/libpq-events.c
+++ b/src/interfaces/libpq/libpq-events.c
@@ -12,7 +12,7 @@
  *
  *-------------------------------------------------------------------------
  */
-#include "postgres_fe.h"
+#include "c.h"
 
 #include "libpq-fe.h"
 #include "libpq-int.h"

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -82,6 +82,34 @@ typedef struct
 #endif							/* USE_OPENSSL */
 
 /*
+ * Definitions meant to lessen the malloc() usage for CDB routines in
+ * server-sided code for struct PGresult allocations.
+ */
+#ifndef FRONTEND
+#include "postgres.h"
+#include "utils/memutils.h"
+
+/*
+ * TopTransactionContext's lifetime lasts until the end of the current query,
+ * which does the job well for backends. Auxiliary processes do not set
+ * transaction contexts, so we have to use TopMemoryContext to achieve a
+ * lifetime equivalent to malloc().
+ */
+#define PQ_PALLOC_CONTEXT \
+	((TopTransactionContext != NULL) ? TopTransactionContext : TopMemoryContext)
+
+#define pqPalloc(sz) MemoryContextAlloc(PQ_PALLOC_CONTEXT, sz)
+#define pqPstrdup(x) MemoryContextStrdup(PQ_PALLOC_CONTEXT, x)
+#define pqRepalloc(x, sz) repalloc(x, sz)
+#define pqPfree(x) pfree(x)
+#else
+#define pqPalloc(sz) malloc(sz)
+#define pqPstrdup(x) strdup(x)
+#define pqRepalloc(x, sz) realloc(x, sz)
+#define pqPfree(x) free(x)
+#endif
+
+/*
  * POSTGRES backend dependent Constants.
  */
 

--- a/src/test/isolation2/input/resgroup/resgroup_oom.source
+++ b/src/test/isolation2/input/resgroup/resgroup_oom.source
@@ -1,0 +1,42 @@
+-- start_ignore
+CREATE EXTENSION gp_inject_fault;
+DROP FUNCTION gp_mock_cdbdispatchcommand(amount int);
+DROP ROLE role_oom_test;
+DROP RESOURCE GROUP rg_oom_test;
+-- end_ignore
+CREATE RESOURCE GROUP rg_oom_test
+WITH (cpu_max_percent=20, memory_limit=20);
+CREATE ROLE role_oom_test RESOURCE GROUP rg_oom_test;
+CREATE OR REPLACE FUNCTION gp_mock_cdbdispatchcommand(amount int)
+RETURNS SETOF text AS '@abs_srcdir@/../regress/regress.so',
+'gp_mock_cdbdispatchcommand' LANGUAGE C;
+
+1: SET ROLE TO role_oom_test;
+
+-- Freeze coordinator's session after it reads results from segments.
+SELECT gp_inject_fault('check_dispatch_result_end', 'suspend', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- Send the heavy query.
+1&: SELECT count(*) FROM gp_mock_cdbdispatchcommand(1000000);
+
+-- Wait until we receive everything.
+SELECT gp_wait_until_triggered_fault('check_dispatch_result_end', 1, dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- The query should've used ~110 MB of memory. Allow some error.
+WITH r AS (
+  SELECT memory_usage AS mb
+  FROM gp_toolkit.gp_resgroup_status_per_host WHERE groupname = 'rg_oom_test'
+)
+SELECT r.mb < 150 AS "under 150 MB", r.mb > 90 AS "above 90 MB"
+FROM r;
+
+SELECT gp_inject_fault('check_dispatch_result_end', 'reset', dbid) FROM
+gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+1<:
+
+DROP FUNCTION gp_mock_cdbdispatchcommand(amount int);
+DROP ROLE role_oom_test;
+DROP RESOURCE GROUP rg_oom_test;

--- a/src/test/isolation2/isolation2_resgroup_v1_schedule
+++ b/src/test/isolation2/isolation2_resgroup_v1_schedule
@@ -44,4 +44,6 @@ test: resgroup/resgroup_large_group_id
 # parallel retrieve cursor integration
 test: resgroup/resgroup_parallel_retrieve
 
+test: resgroup/resgroup_oom
+
 test: resgroup/resgroup_disable_resgroup

--- a/src/test/isolation2/isolation2_resgroup_v2_schedule
+++ b/src/test/isolation2/isolation2_resgroup_v2_schedule
@@ -49,4 +49,6 @@ test: resgroup/resgroup_large_group_id
 # parallel retrieve cursor integration
 test: resgroup/resgroup_parallel_retrieve
 
+test: resgroup/resgroup_oom
+
 test: resgroup/resgroup_disable_resgroup

--- a/src/test/isolation2/output/resgroup/resgroup_oom.source
+++ b/src/test/isolation2/output/resgroup/resgroup_oom.source
@@ -1,0 +1,52 @@
+CREATE RESOURCE GROUP rg_oom_test WITH (cpu_max_percent=20, memory_limit=20);
+CREATE RESOURCE GROUP
+CREATE ROLE role_oom_test RESOURCE GROUP rg_oom_test;
+CREATE ROLE
+CREATE OR REPLACE FUNCTION gp_mock_cdbdispatchcommand(amount int) RETURNS SETOF text AS '@abs_srcdir@/../regress/regress.so', 'gp_mock_cdbdispatchcommand' LANGUAGE C;
+CREATE FUNCTION
+
+1: SET ROLE TO role_oom_test;
+SET
+
+-- Freeze coordinator's session after it reads results from segments.
+SELECT gp_inject_fault('check_dispatch_result_end', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Send the heavy query.
+1&: SELECT count(*) FROM gp_mock_cdbdispatchcommand(1000000);  <waiting ...>
+
+-- Wait until we receive everything.
+SELECT gp_wait_until_triggered_fault('check_dispatch_result_end', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- The query should've used ~110 MB of memory. Allow some error.
+WITH r AS ( SELECT memory_usage AS mb FROM gp_toolkit.gp_resgroup_status_per_host WHERE groupname = 'rg_oom_test' ) SELECT r.mb < 150 AS "under 150 MB", r.mb > 90 AS "above 90 MB" FROM r;
+ under 150 MB | above 90 MB 
+--------------+-------------
+ t            | t           
+(1 row)
+
+SELECT gp_inject_fault('check_dispatch_result_end', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ count   
+---------
+ 4000000 
+(1 row)
+
+DROP FUNCTION gp_mock_cdbdispatchcommand(amount int);
+DROP FUNCTION
+DROP ROLE role_oom_test;
+DROP ROLE
+DROP RESOURCE GROUP rg_oom_test;
+DROP RESOURCE GROUP

--- a/src/test/regress/.gitignore
+++ b/src/test/regress/.gitignore
@@ -38,6 +38,7 @@ fe-protocol2.c
 fe-secure.c
 fe-auth-scram.c
 pqexpbuffer.c
+libpq-events.c
 
 # Note: regreesion.* are only left behind on a failure; that's why they're not ignored
 #/regression.diffs

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -101,7 +101,7 @@ OBJS += regress_gp.o
 # We need the objects only for the missing symbols. Non-hidden symbols will be
 # pulled from the postgres binary, just to save you some hair on your head.
 LIBPQ_BE_SRCS = fe-protocol3.c fe-connect.c fe-exec.c pqexpbuffer.c fe-auth.c \
-	fe-misc.c fe-protocol2.c fe-secure.c fe-auth-scram.c
+	fe-misc.c fe-protocol2.c fe-secure.c fe-auth-scram.c libpq-events.c
 LIBPQ_BE_OBJS = $(LIBPQ_BE_SRCS:%.c=%.o)
 
 OBJS += $(LIBPQ_BE_OBJS)

--- a/src/test/regress/input/libpq.source
+++ b/src/test/regress/input/libpq.source
@@ -1,5 +1,5 @@
 --
--- Test that linked libpq library is compiled for backends.
+-- Test that linked libpq library is properly compiled.
 --
 
 CREATE OR REPLACE FUNCTION is_backend()
@@ -9,3 +9,15 @@ CREATE OR REPLACE FUNCTION is_backend()
   LANGUAGE C STRICT;
 
 SELECT is_backend();
+
+DROP FUNCTION is_backend();
+
+CREATE OR REPLACE FUNCTION check_events()
+  RETURNS bool
+  AS '@abs_builddir@/regress@DLSUFFIX@',
+     'gp_check_libpq_events'
+  LANGUAGE C STRICT;
+
+SELECT check_events();
+
+DROP FUNCTION check_events();

--- a/src/test/regress/output/libpq.source
+++ b/src/test/regress/output/libpq.source
@@ -1,5 +1,5 @@
 --
--- Test that linked libpq library is compiled for backends.
+-- Test that linked libpq library is properly compiled.
 --
 CREATE OR REPLACE FUNCTION is_backend()
   RETURNS BOOL
@@ -12,3 +12,16 @@ SELECT is_backend();
  t
 (1 row)
 
+DROP FUNCTION is_backend();
+CREATE OR REPLACE FUNCTION check_events()
+  RETURNS bool
+  AS '@abs_builddir@/regress@DLSUFFIX@',
+     'gp_check_libpq_events'
+  LANGUAGE C STRICT;
+SELECT check_events();
+ check_events 
+--------------
+ t
+(1 row)
+
+DROP FUNCTION check_events();

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -24,6 +24,7 @@
 
 #include "libpq-fe.h"
 #include "libpq-int.h"
+#include "libpq-events.h"
 #include "pgstat.h"
 #include "access/transam.h"
 #include "access/xact.h"
@@ -115,6 +116,9 @@ extern Datum broken_int4out(PG_FUNCTION_ARGS);
 
 /* fts tests */
 extern Datum gp_fts_probe_stats(PG_FUNCTION_ARGS);
+
+/* libpq events test */
+extern Datum gp_check_libpq_events(PG_FUNCTION_ARGS);
 
 /* Triggers */
 
@@ -2338,4 +2342,171 @@ gp_raise_sigint(PG_FUNCTION_ARGS)
 	CHECK_FOR_INTERRUPTS();
 
 	pg_unreachable();
+}
+
+typedef struct
+{
+	int cur_tuple_idx;
+	int cur_segment_idx;
+	int cur_segment_tuple_idx;
+
+	int n_segments;
+	int n_tuples;
+
+	Datum some_text;
+	struct pg_result **pg_results;
+} gp_mock_cdbdispatchcommand_status;
+
+/*
+ * This test function mocks CdbDispatchCommand() with a customizable amount of
+ * tuples.
+ */
+PG_FUNCTION_INFO_V1(gp_mock_cdbdispatchcommand);
+Datum
+gp_mock_cdbdispatchcommand(PG_FUNCTION_ARGS)
+{
+	FuncCallContext *func_ctx;
+	gp_mock_cdbdispatchcommand_status *my_status;
+
+	int arg_tuple_amount = PG_GETARG_INT32(0);
+
+	if (arg_tuple_amount <= 0)
+	{
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						errmsg("gp_mock_cdbdispatchcommand() should only be "
+							   "called with it's parameter greater than 0")));
+	}
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		func_ctx = SRF_FIRSTCALL_INIT();
+
+		MemoryContext oldcontext =
+			MemoryContextSwitchTo(func_ctx->multi_call_memory_ctx);
+
+		my_status = palloc0(sizeof(gp_mock_cdbdispatchcommand_status));
+
+		/* Cache the return result. */
+		my_status->some_text = CStringGetTextDatum("sometext");
+
+		/* Send the command to segments from QD. */
+		if (Gp_role == GP_ROLE_DISPATCH)
+		{
+			char *query =
+				psprintf("SELECT * FROM gp_mock_cdbdispatchcommand(%d)",
+						 arg_tuple_amount);
+
+			CdbPgResults cdb_pgresults = {0};
+			CdbDispatchCommand(query, DF_WITH_SNAPSHOT, &cdb_pgresults);
+
+			pfree(query);
+
+			Assert(cdb_pgresults.numResults > 0);
+
+			for (int i = 0; i < cdb_pgresults.numResults; i++)
+			{
+				Assert(PQresultStatus(cdb_pgresults.pg_results[i]) ==
+					   PGRES_TUPLES_OK);
+				my_status->n_tuples += PQntuples(cdb_pgresults.pg_results[i]);
+			}
+
+			my_status->n_segments = cdb_pgresults.numResults;
+			my_status->pg_results = cdb_pgresults.pg_results;
+		}
+
+		func_ctx->user_fctx = my_status;
+
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	func_ctx = SRF_PERCALL_SETUP();
+	my_status = func_ctx->user_fctx;
+
+	/* Generate fake tuples from every segment. */
+	if (my_status->cur_tuple_idx < arg_tuple_amount)
+	{
+		my_status->cur_tuple_idx++;
+		SRF_RETURN_NEXT(func_ctx, my_status->some_text);
+	}
+
+	/* Receive tuples from the loop above on master. */
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		while (my_status->cur_segment_idx < my_status->n_segments)
+		{
+			PGresult *res = my_status->pg_results[my_status->cur_segment_idx];
+
+			if (my_status->cur_segment_tuple_idx < PQntuples(res))
+			{
+				Datum ret = CStringGetTextDatum(
+					PQgetvalue(res, my_status->cur_segment_tuple_idx, 0));
+
+				my_status->cur_segment_tuple_idx++;
+				SRF_RETURN_NEXT(func_ctx, ret);
+			}
+
+			PQclear(res);
+
+			my_status->cur_segment_idx++;
+			my_status->cur_segment_tuple_idx = 0;
+		}
+
+		pfree(my_status->pg_results);
+	}
+
+	SRF_RETURN_DONE(func_ctx);
+}
+
+static int
+check_libpq_events_example_proc(PGEventId evtId, void *evtInfo,
+								void *passThrough)
+{
+	return 1;
+}
+
+PG_FUNCTION_INFO_V1(gp_check_libpq_events);
+Datum
+gp_check_libpq_events(PG_FUNCTION_ARGS)
+{
+	PGconn *conn;
+	PGresult *res;
+
+	conn = PQconnectdb("");
+	if (!conn)
+	{
+		ereport(ERROR, (errmsg("PQconnectdb returned NULL")));
+	}
+
+	/* PGEVT_REGISTER */
+	if (!PQregisterEventProc(conn, check_libpq_events_example_proc,
+							 "gp_check_libpq_events", NULL))
+	{
+		PQfinish(conn);
+		ereport(ERROR, (errmsg("PQregisterEventProc failed")));
+	}
+
+	/* calls dupEvents() */
+	res = PQmakeEmptyPGresult(conn, PGRES_COMMAND_OK);
+	if (!res)
+	{
+		PQfinish(conn);
+		ereport(ERROR, (errmsg("PQmakeEmptyPGresult failed")));
+	}
+
+	/* PGEVT_RESULTCREATE */
+	if (!PQfireResultCreateEvents(conn, res))
+	{
+		/* PGEVT_RESULTDESTROY */
+		PQclear(res);
+		PQfinish(conn);
+		ereport(ERROR, (errmsg("PQfireResultCreateEvents failed")));
+	}
+
+	/* PGEVT_RESULTDESTROY */
+	PQclear(res);
+
+	/* PGEVT_CONNDESTROY */
+	PQfinish(conn);
+
+	PG_RETURN_BOOL(true);
 }


### PR DESCRIPTION
Track PQresult allocations in server code

8a2a471 was adopted for 7X.

Fixed palloc() for events. Some palloc() wrappers were missing--this is a bug in the original commit, which will be addressed separately.

There is no 'ERROR' part of the test, and no parallel retrieve cursor tests, since 7X is not affected by the original problem and the it's impossible to set shared quota for a resource group.

Please note that this PR needs to be rebased.
