### PR TITLE
ADBDEV-9468: Add BREAK_SYSTEM_PACKAGES=1 to instruction for Ubuntu 24

### DIFF
--- a/README.linux.md
+++ b/README.linux.md
@@ -31,9 +31,16 @@
 
 ## For Ubuntu (versions 22.04 or 24.04):
 
-- Install dependencies using README.ubuntu.bash script:
+- Install dependencies using README.ubuntu.bash script.
+
+  For Ubuntu 22.04:
   ```bash
   sudo ./README.ubuntu.bash
+  ```
+
+  Ubuntu 24.04 restricts system pip installs. Allow it explicitly:
+  ```bash
+  sudo -E PIP_BREAK_SYSTEM_PACKAGES=1 ./README.ubuntu.bash
   ```
 
 - For Ubuntu 22.04, create symbolic link to Python 2 in `/usr/bin`:

--- a/README.linux.md
+++ b/README.linux.md
@@ -31,18 +31,13 @@
 
 ## For Ubuntu (versions 22.04 or 24.04):
 
-- Install dependencies using README.ubuntu.bash script.
-
-  For Ubuntu 22.04:
-  ```bash
-  sudo ./README.ubuntu.bash
-  ```
-
-  Ubuntu 24.04 restricts system pip installs. Allow it explicitly:
+- Install dependencies using README.ubuntu.bash script:
   ```bash
   sudo -E PIP_BREAK_SYSTEM_PACKAGES=1 ./README.ubuntu.bash
   ```
-
+  Note: Ubuntu 24.04 restricts system pip installs. Use 
+  PIP_BREAK_SYSTEM_PACKAGES to allow this.
+  
 - For Ubuntu 22.04, create symbolic link to Python 2 in `/usr/bin`:
 
   ```bash


### PR DESCRIPTION
Ubuntu 24.04 enforces PEP 668, which blocks pip from installing packages into 
the system Python. The README.ubuntu.bash script installs the future module for
Python 3.12, causing a failure.

Update instruction to use env PIP_BREAK_SYSTEM_PACKAGES=1 to allow
the installation.

Ticket: ADBDEV-9468