### PR TITLE
Fix README.md for the temp_tables_stat extension

### DIFF
--- a/gpcontrib/temp_tables_stat/README.md
+++ b/gpcontrib/temp_tables_stat/README.md
@@ -38,7 +38,3 @@ Create the extension in your database.
 ```
 CREATE EXTENSION temp_tables_stat;
 ```
-
-## Test
-
-src/test/isolation2/sql/temp_tables_stat.sql


### PR DESCRIPTION
Fix README.md for the temp_tables_stat extension

The extension tests are placed in the extension directory. 
The src/test/isolation2/sql/temp_tables_stat.sql file does not exist.
