### PR TITLE
GG-315: Disable cancellation of behave tests for 7.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -34,7 +34,7 @@ jobs:
     needs: build  # Wait for build to complete
     if: github.event_name == 'pull_request'  # Only for PR
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         target_os: [ubuntu]
     permissions:
@@ -52,7 +52,7 @@ jobs:
     needs: build
     if: github.event_name == 'pull_request'  # Only for PR
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         target_os: [ubuntu]
     permissions:
@@ -70,7 +70,7 @@ jobs:
     needs: build
     if: github.event_name == 'pull_request'  # Only for PR
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         target_os: [ubuntu]
     permissions:
@@ -88,7 +88,7 @@ jobs:
     needs: build
     if: github.event_name == 'pull_request'  # Only for PR
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         target_os: [ubuntu]
     permissions:
@@ -124,7 +124,7 @@ jobs:
     if: github.event_name == 'push'  # For push to main or tags
     needs: build  # For push (main or tags)
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         target_os: [ubuntu]
     permissions:

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     strategy:
-      fail-fast: true  # Stop on any failure in the matrix
+      fail-fast: false
       matrix:
         target_os: [ubuntu]
     permissions:
@@ -106,7 +106,7 @@ jobs:
     needs: build
     if: github.event_name == 'pull_request'  # Only for PR
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         target_os: [ubuntu]
     permissions:


### PR DESCRIPTION
## Disable cancellation of behave tests for 7.x (#341)

### Note
Not affected now but fix required for future.

### Cause
When running behave tests for two Ubuntu systems, we forgot to change the matrix [strategy](https://github.com/GreengageDB/greengage/blob/388bc6ebeb07ef899593c2b2b168df46c5163006/.github/workflows/greengage-ci.yml#L41). As a result, when the tests fail on one Ubuntu, they are canceled on the other. For [example](https://github.com/GreengageDB/greengage/actions/runs/23305279686/job/67781123133?pr=336), on Ubuntu 22, all behave tests completed, but some failed, causing the tests to be canceled on Ubuntu 24.

Additionally, this is true not only for behave tests.
Failure to execute a matrix step should not affect the execution of other steps for other OS versions in matrix.

### Solution
All `fail-fast: true` should be replaced with `fail-fast: false`

- cherry-pick from 6.x [ci (general): set matrix jobs strategy fail-fast to false](https://github.com/GreengageDB/greengage/commit/c35c3fb7aac40215983b4c66015361c3e2ebdb92)
- [ci (general): adjust matrix fail-fast 6.x to 7.x](https://github.com/GreengageDB/greengage/commit/a4c9642931737e2034fd5dd04e7faa203221b85f)

Task: [CI-5408](https://tracker.yandex.ru/CI-5408)