### PR TITLE
GG-323: Fix potential catalog corruption with temporary identity columns

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1096,6 +1096,13 @@ standard_ProcessUtility(Node *parsetree,
 							   dest, completionTag);
 			break;
 	}
+
+	/*
+	 * Make effects of commands visible, for instance so that
+	 * PreCommit_on_commit_actions() can see them (see for example bug
+	 * #15631).
+	 */
+	CommandCounterIncrement();
 }
 
 /*

--- a/src/test/regress/expected/temp.out
+++ b/src/test/regress/expected/temp.out
@@ -113,6 +113,13 @@ SELECT * FROM temptest;
 ERROR:  relation "temptest" does not exist
 LINE 1: SELECT * FROM temptest;
                       ^
+-- Check that the sequence does not exist after auto-dropping the table.
+CREATE TEMP TABLE temptest(col serial) ON COMMIT DROP;
+SELECT relname, relkind, relpersistence FROM pg_class WHERE relname = 'temptest_col_seq';
+ relname | relkind | relpersistence 
+---------+---------+----------------
+(0 rows)
+
 -- ON COMMIT is only allowed for TEMP
 CREATE TABLE temptest(col int) ON COMMIT DELETE ROWS;
 ERROR:  ON COMMIT can only be used on temporary tables

--- a/src/test/regress/sql/temp.sql
+++ b/src/test/regress/sql/temp.sql
@@ -101,6 +101,10 @@ COMMIT;
 
 SELECT * FROM temptest;
 
+-- Check that the sequence does not exist after auto-dropping the table.
+CREATE TEMP TABLE temptest(col serial) ON COMMIT DROP;
+SELECT relname, relkind, relpersistence FROM pg_class WHERE relname = 'temptest_col_seq';
+
 -- ON COMMIT is only allowed for TEMP
 
 CREATE TABLE temptest(col int) ON COMMIT DELETE ROWS;


### PR DESCRIPTION
Fix potential catalog corruption with temporary identity columns

If a temporary table with an identity column and ON COMMIT DROP is
created in a single-statement transaction (not useful, but allowed),
it would leave the catalog corrupted.  We need to add a
CommandCounterIncrement() so that PreCommit_on_commit_actions() sees
the created dependency between table and sequence and can clean it
up.

The analogous and more useful case of doing this in a transaction
block already runs some CommandCounterIncrement() before it gets to
the on-commit cleanup, so it wasn't a problem in practical use.

Several locations for placing the new CommandCounterIncrement() call
were discussed.  This patch places it at the end of
standard_ProcessUtility().  That would also help if other commands
were to create catalog entries that some on-commit action would like
to see.

Bug: #15631
Reported-by: Serge Latyntsev <dnsl48@gmail.com>
Author: Peter Eisentraut <peter.eisentraut@2ndquadrant.com>
Reviewed-by: Michael Paquier <michael@paquier.xyz>
(cherry picked from commit cd3e27464cca40664c54fb8cd10454f979c1db4e)

changes from original commit
- Add a test to check that the sequence does not exist after the table
  auto-drop.

Ticket: GG-323
