### PR TITLE
GG-322: Rename deb package 'greengage' to 'greengage6'

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -34,81 +34,81 @@ jobs:
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
-  # behave-tests:
-  #   needs: build  # Wait for build to complete
-  #   if: github.event_name == 'pull_request'  # Only for PR
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       include:
-  #         - target_os: ubuntu
-  #         - target_os: ubuntu
-  #           target_os_version: "24.04"
-  #   permissions:
-  #     contents: read  # Explicit for default behavior
-  #     packages: read  # Explicit for GHCR access clarity
-  #     actions: write  # Required for artifact upload
-  #   uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v26
-  #   with:
-  #     version: 6
-  #     target_os: ${{ matrix.target_os }}
-  #     target_os_version: ${{ matrix.target_os_version }}
-  #   secrets:
-  #     ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+  behave-tests:
+    needs: build  # Wait for build to complete
+    if: github.event_name == 'pull_request'  # Only for PR
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - target_os: ubuntu
+          - target_os: ubuntu
+            target_os_version: "24.04"
+    permissions:
+      contents: read  # Explicit for default behavior
+      packages: read  # Explicit for GHCR access clarity
+      actions: write  # Required for artifact upload
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v26
+    with:
+      version: 6
+      target_os: ${{ matrix.target_os }}
+      target_os_version: ${{ matrix.target_os_version }}
+    secrets:
+      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
-  # regression-tests:
-  #   needs: build
-  #   if: github.event_name == 'pull_request'  # Only for PR
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       target_os: [ubuntu]
-  #   permissions:
-  #     contents: read  # Explicit for default behavior
-  #     packages: read  # Explicit for GHCR access clarity
-  #     actions: write  # Required for artifact upload
-  #   uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v26
-  #   with:
-  #     version: 6
-  #     target_os: ${{ matrix.target_os }}
-  #   secrets:
-  #     ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+  regression-tests:
+    needs: build
+    if: github.event_name == 'pull_request'  # Only for PR
+    strategy:
+      fail-fast: true
+      matrix:
+        target_os: [ubuntu]
+    permissions:
+      contents: read  # Explicit for default behavior
+      packages: read  # Explicit for GHCR access clarity
+      actions: write  # Required for artifact upload
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v26
+    with:
+      version: 6
+      target_os: ${{ matrix.target_os }}
+    secrets:
+      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
-  # orca-tests:
-  #   needs: build
-  #   if: github.event_name == 'pull_request'  # Only for PR
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       target_os: [ubuntu]
-  #   permissions:
-  #     contents: read  # Explicit for default behavior
-  #     packages: read  # Explicit for GHCR access clarity
-  #     actions: write  # Required for artifact upload
-  #   uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v19
-  #   with:
-  #     version: 6
-  #     target_os: ${{ matrix.target_os }}
-  #   secrets:
-  #     ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+  orca-tests:
+    needs: build
+    if: github.event_name == 'pull_request'  # Only for PR
+    strategy:
+      fail-fast: true
+      matrix:
+        target_os: [ubuntu]
+    permissions:
+      contents: read  # Explicit for default behavior
+      packages: read  # Explicit for GHCR access clarity
+      actions: write  # Required for artifact upload
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v19
+    with:
+      version: 6
+      target_os: ${{ matrix.target_os }}
+    secrets:
+      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
-  # resgroup-tests:
-  #   needs: build
-  #   if: github.event_name == 'pull_request'  # Only for PR
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       target_os: [ubuntu]
-  #   permissions:
-  #     contents: read  # Explicit for default behavior
-  #     packages: read  # Explicit for GHCR access clarity
-  #     actions: write  # Required for artifact upload
-  #   uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v23
-  #   with:
-  #     version: 6
-  #     target_os: ${{ matrix.target_os }}
-  #   secrets:
-  #     ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+  resgroup-tests:
+    needs: build
+    if: github.event_name == 'pull_request'  # Only for PR
+    strategy:
+      fail-fast: true
+      matrix:
+        target_os: [ubuntu]
+    permissions:
+      contents: read  # Explicit for default behavior
+      packages: read  # Explicit for GHCR access clarity
+      actions: write  # Required for artifact upload
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v23
+    with:
+      version: 6
+      target_os: ${{ matrix.target_os }}
+    secrets:
+      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
   upload:
     if: github.event_name == 'push'

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -34,81 +34,81 @@ jobs:
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
-  behave-tests:
-    needs: build  # Wait for build to complete
-    if: github.event_name == 'pull_request'  # Only for PR
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - target_os: ubuntu
-          - target_os: ubuntu
-            target_os_version: "24.04"
-    permissions:
-      contents: read  # Explicit for default behavior
-      packages: read  # Explicit for GHCR access clarity
-      actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v26
-    with:
-      version: 6
-      target_os: ${{ matrix.target_os }}
-      target_os_version: ${{ matrix.target_os_version }}
-    secrets:
-      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+  # behave-tests:
+  #   needs: build  # Wait for build to complete
+  #   if: github.event_name == 'pull_request'  # Only for PR
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       include:
+  #         - target_os: ubuntu
+  #         - target_os: ubuntu
+  #           target_os_version: "24.04"
+  #   permissions:
+  #     contents: read  # Explicit for default behavior
+  #     packages: read  # Explicit for GHCR access clarity
+  #     actions: write  # Required for artifact upload
+  #   uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v26
+  #   with:
+  #     version: 6
+  #     target_os: ${{ matrix.target_os }}
+  #     target_os_version: ${{ matrix.target_os_version }}
+  #   secrets:
+  #     ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
-  regression-tests:
-    needs: build
-    if: github.event_name == 'pull_request'  # Only for PR
-    strategy:
-      fail-fast: true
-      matrix:
-        target_os: [ubuntu]
-    permissions:
-      contents: read  # Explicit for default behavior
-      packages: read  # Explicit for GHCR access clarity
-      actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v26
-    with:
-      version: 6
-      target_os: ${{ matrix.target_os }}
-    secrets:
-      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+  # regression-tests:
+  #   needs: build
+  #   if: github.event_name == 'pull_request'  # Only for PR
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       target_os: [ubuntu]
+  #   permissions:
+  #     contents: read  # Explicit for default behavior
+  #     packages: read  # Explicit for GHCR access clarity
+  #     actions: write  # Required for artifact upload
+  #   uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v26
+  #   with:
+  #     version: 6
+  #     target_os: ${{ matrix.target_os }}
+  #   secrets:
+  #     ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
-  orca-tests:
-    needs: build
-    if: github.event_name == 'pull_request'  # Only for PR
-    strategy:
-      fail-fast: true
-      matrix:
-        target_os: [ubuntu]
-    permissions:
-      contents: read  # Explicit for default behavior
-      packages: read  # Explicit for GHCR access clarity
-      actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v19
-    with:
-      version: 6
-      target_os: ${{ matrix.target_os }}
-    secrets:
-      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+  # orca-tests:
+  #   needs: build
+  #   if: github.event_name == 'pull_request'  # Only for PR
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       target_os: [ubuntu]
+  #   permissions:
+  #     contents: read  # Explicit for default behavior
+  #     packages: read  # Explicit for GHCR access clarity
+  #     actions: write  # Required for artifact upload
+  #   uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v19
+  #   with:
+  #     version: 6
+  #     target_os: ${{ matrix.target_os }}
+  #   secrets:
+  #     ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
-  resgroup-tests:
-    needs: build
-    if: github.event_name == 'pull_request'  # Only for PR
-    strategy:
-      fail-fast: true
-      matrix:
-        target_os: [ubuntu]
-    permissions:
-      contents: read  # Explicit for default behavior
-      packages: read  # Explicit for GHCR access clarity
-      actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v23
-    with:
-      version: 6
-      target_os: ${{ matrix.target_os }}
-    secrets:
-      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+  # resgroup-tests:
+  #   needs: build
+  #   if: github.event_name == 'pull_request'  # Only for PR
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       target_os: [ubuntu]
+  #   permissions:
+  #     contents: read  # Explicit for default behavior
+  #     packages: read  # Explicit for GHCR access clarity
+  #     actions: write  # Required for artifact upload
+  #   uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v23
+  #   with:
+  #     version: 6
+  #     target_os: ${{ matrix.target_os }}
+  #   secrets:
+  #     ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
   upload:
     if: github.event_name == 'push'

--- a/.github/workflows/greengage-release.yml
+++ b/.github/workflows/greengage-release.yml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - extensions: deb ddeb
-          artifact_name: deb-packages
+        - artifact_name: deb-packages
+          extensions:    deb ddeb
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/greengage-release.yml
+++ b/.github/workflows/greengage-release.yml
@@ -20,8 +20,7 @@ jobs:
       actions: read
     steps:
       - name: Upload packages to release
-        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v10
+        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@CI-5427
         with:
-          version: ${{ matrix.version }}
           extensions: ${{ matrix.extensions }}
           artifact_name: ${{ matrix.artifact_name }}

--- a/.github/workflows/greengage-release.yml
+++ b/.github/workflows/greengage-release.yml
@@ -19,7 +19,7 @@ jobs:
       actions: read
     steps:
       - name: Upload packages to release
-        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@CI-5427
+        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v27
         with:
           extensions: ${{ matrix.extensions }}
           artifact_name: ${{ matrix.artifact_name }}

--- a/.github/workflows/greengage-release.yml
+++ b/.github/workflows/greengage-release.yml
@@ -11,8 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - version: 6
-          extensions: deb ddeb
+        - extensions: deb ddeb
           artifact_name: deb-packages
     runs-on: ubuntu-latest
     permissions:

--- a/gpAux/debian/control
+++ b/gpAux/debian/control
@@ -1,11 +1,11 @@
-Source: greengage
+Source: greengage6
 Maintainer: Greengage <greengage@greengagedb.org>
 Section: database
 Build-Depends: debhelper (>= 13),
 	 dh-python,
 	 lsb-release
 
-Package: greengage
+Package: greengage6
 Architecture: any
 Depends: ${shlibs:Depends},
 	 iproute2,

--- a/gpAux/debian/copyright
+++ b/gpAux/debian/copyright
@@ -1,5 +1,5 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: greengage
+Upstream-Name: greengage6
 Upstream-Contact: GreengageDB Team
 Source: https://github.com/GreengageDB/greengage
 

--- a/gpAux/debian/rules
+++ b/gpAux/debian/rules
@@ -43,4 +43,4 @@ override_dh_auto_install:
 
 override_dh_gencontrol:
 	@echo "=== GENCONTROL GPROOT=$(GPROOT), GPDIR=$(GPDIR), PACKAGE_NAME=$(PACKAGE_NAME) ==="
-	dh_gencontrol -p$(PACKAGE_NAME) -- -VpythonRequires="$(DEPS)" -VpythonConflicts="$(CONFLICTS)"
+	dh_gencontrol -- -VpythonRequires="$(DEPS)" -VpythonConflicts="$(CONFLICTS)"


### PR DESCRIPTION
## Rename deb package `greengage` to `greengage6` (#344)

- Update the following files to rename the package from `greengage` to `greengage6` for the `6.x` release line
  - `debian/control`
  - `debian/copyright`
- Fix `override_dh_gencontrol` in  `debian/rules` file to use correct `dh_gencontrol` syntax (remove redundant -p flag).
  This fix deb-package file name for [conventional syntax](https://www.debian.org/doc/manuals/debian-reference/ch02.en.html#_debian_package_file_names).
- Update Release workflow for upload deb package file with proper [conventional](https://www.debian.org/doc/manuals/debian-reference/ch02.en.html#_debian_package_file_names) filename.
  - Remove deprecated `version` from `upload-pkgs-to-release` action parameters
  - Resort `upload-pkgs-to-release` options for:
    -  alphabet 
    - pretty look for future
    - priority: `artifact_name` - primary key; `extensions` - secondary
  - Retarget upload-pkgs-to-release to new CI tag [v27](https://github.com/GreengageDB/greengage-ci/releases/tag/v27)
    * refactor(upload-pkgs-to-release): preserve original filenames on upload:
      - Remove package renaming step, upload files with original names
      - Remove unused `package_name` and `version` inputs
      - Update README to reflect original filename preservation
      - Update usage example with RPM packages in matrix

Tasks: [GG-322](https://tracker.yandex.ru/GG-322), [CI-5427](https://tracker.yandex.ru/CI-5427)