### PR TITLE
Implement interactive mode for ggrebalance

### DIFF
--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -47,7 +47,7 @@ def parseargs():
                       help='performs rebalance rollback if possible.')
     parser.add_option('-h', '-?', '--help', '--usage', action='help',
                       help='show this help message and exit.')
-    parser.add_option('-y', '--non-interactive-mode', dest="interactive", action='store_false', default=True,
+    parser.add_option('--non-interactive-mode', dest="interactive", action='store_false', default=True,
                          help="non-interactive mode, do not require user input for confirmations, use defaults.")
     parser.add_option('-H', '--target-hosts', dest='target_hosts', metavar='<target_hosts>',
                       help='Set of hostnames where rebalance will distribute segments to')

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
@@ -188,10 +188,14 @@ class GGRebalanceMainSM:
             self.logger.info(f"Rebalance schema doesn't exist. Cleanup is not required.")
         else:
             self.plan = self.rebalance_schema.retrieveSavedPlan()
+            perform_schema_cleanup = True
             if isinstance(self.plan, ShrinkPlan):
-                self.gg_shrink.cleanup(self.prev_shrink_run_was_complete)
-            self.rebalance_schema.dropSchema()
-            self.logger.info('Cleanup is complete')
+                perform_schema_cleanup = self.gg_shrink.cleanup(self.prev_shrink_run_was_complete)
+            if perform_schema_cleanup:
+                self.rebalance_schema.dropSchema()
+                self.logger.info('Cleanup is complete')
+            else:
+                self.logger.info("Cleanup wasn't successfull due to unfinished shrink")
         self.trigger('move_to_STATE_END')
 
     @wrap_func_with_faults

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_sm.py
@@ -615,6 +615,9 @@ class RebalanceSM:
                 self.logger.error("Can't determine next state. Try to execute cleanup.")
                 self.trigger('move_to_STATE_ERROR')
                 return
+
+            if not interactive_check_yesno(self.options.interactive, None, 'Proceed with continue?', default = 'Y'):
+                raise Exception('Continue was not approved, interrupting execution')
             # use auto to_«state» method to recover
             self.trigger(f'to_{next_state}')
 

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_sm.py
@@ -721,12 +721,20 @@ class RebalanceSM:
 
         assert len(steps) > 0
 
+        steps_to_approve = []
         for step in steps:
             if step.getStatus() != RebalanceStep.Status.APPROVE_REQUIRED:
                 break
-            # TODO: we'll need to add logic here to get approval from the user in the interactive mode,
-            # once we start implementing the interactive mode.
-            # In non-interactive mode we assume that the switchover is always approved.
+            steps_to_approve.append(step)
+
+        msg = 'Following switchovers require approval:\n'
+        for step in steps_to_approve:
+            msg += str(step)
+            msg += '\n'
+        if not interactive_check_yesno(self.options.interactive, msg, 'Approve switchovers?', default = 'Y'):
+            raise Exception('Switchovers were not approved, interrupting execution')
+
+        for step in steps_to_approve:
             step.setStatus(RebalanceStep.Status.PLANNED, step.isRollback())
             self.rebalance_schema.updateExecutionStep(step)
 

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_sm.py
@@ -12,6 +12,7 @@ try:
     from ggrebalance_modules.planner import *
     from ggrebalance_modules.rebalance_schema import RebalanceSchema, STATE_NOT_DEFINED
     from ggrebalance_modules.rebalance_step import *
+    from ggrebalance_modules.rebalance_commons import interactive_check_yesno
     from gppylib.fault_injection import *
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
@@ -421,7 +422,8 @@ class RebalanceSM:
 
                     time.sleep(SLEEP_PERIOD_SEC)
                     time_waited = time_waited + SLEEP_PERIOD_SEC
-                    if time_waited >= TIMEOUT_SEC and self.interactive_check('Timeout waiting for segment start, wait again?', default = False):
+                    if time_waited >= TIMEOUT_SEC and interactive_check_yesno(self.options.interactive, None,
+                                                                              'Timeout waiting for segment start, wait again?', default = 'N'):
                         time_waited = 0
 
             # Continue with the next step, if we already marked this one
@@ -432,7 +434,7 @@ class RebalanceSM:
             if not allow_retry:
                 self.logger.warning("We've run out of retry attempts")
 
-            if allow_retry and self.interactive_check('Retry step?', default = True):
+            if allow_retry and interactive_check_yesno(self.options.interactive, None, 'Retry step?', default = 'Y'):
                 if step.isRollback():
                     self.logger.info('Plan to retry rollback step')
                     step.setStatus(RebalanceStep.Status.PLANNED, True)
@@ -442,7 +444,7 @@ class RebalanceSM:
                 self.rebalance_schema.updateExecutionStep(step)
                 continue
 
-            if not step.isRollback() and self.interactive_check('Rollback step?', default = True):
+            if not step.isRollback() and interactive_check_yesno(self.options.interactive, None, 'Rollback step?', default = 'Y'):
                 self.logger.info('Plan to rollback step')
                 step.setStatus(RebalanceStep.Status.PLANNED, True)
             else:
@@ -458,7 +460,7 @@ class RebalanceSM:
         steps_left_todo = self.rebalance_schema.getExecutionSteps([RebalanceStep.Status.PLANNED, RebalanceStep.Status.APPROVE_REQUIRED])
         for step in error_steps:
             self.logger.info(f'Processing error status for switchover step: {str(step)}')
-            if self.interactive_check(f'Retry step?', default = True):
+            if interactive_check_yesno(self.options.interactive, None, 'Retry step?', default = 'Y'):
                 if step.isRollback():
                     self.logger.info('Plan to retry rollback step')
                     step.setStatus(RebalanceStep.Status.PLANNED, True)
@@ -468,7 +470,7 @@ class RebalanceSM:
                 self.rebalance_schema.updateExecutionStep(step)
                 continue
 
-            if not step.isRollback() and self.interactive_check('Rollback step?', default = True):
+            if not step.isRollback() and interactive_check_yesno(self.options.interactive, None, 'Rollback step?', default = 'Y'):
                 self.logger.info('Plan to rollback step')
                 step.setStatus(RebalanceStep.Status.PLANNED, True)
 
@@ -540,27 +542,6 @@ class RebalanceSM:
             return -1
 
         return int(output)
-
-    # Decorator to overwrite the logic of interactive_check()
-    # during tests execution.
-    def wrap_interactive_check_with_faults(fun):
-        def func_with_faults(self, msg: str, default: bool):
-            try:
-                inject_value = inject_fault_get_value()
-                injected_answers = json.loads(inject_value)
-                if injected_answers.get(msg, '') == 'yes':
-                    return True
-                if injected_answers.get(msg, '') == 'no':
-                    return False
-            except:
-                pass
-            return fun(self, msg, default)
-        return func_with_faults
-
-    @wrap_interactive_check_with_faults
-    def interactive_check(self, msg: str, default: bool) -> bool:
-        # TODO: add logic here when implementing interactive mode
-        return default
 
     @staticmethod
     def convert_moves_to_rebalance_steps(moves: List[LogicalMove]) -> List[RebalanceStep]:

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_commons.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_commons.py
@@ -13,6 +13,8 @@ from gppylib.gparray import Segment, GpArray
 from gppylib.commands.base import REMOTE, WorkerPool
 from gppylib.commands.unix import Hostname, DiskFree, DiskUsage
 from gppylib.operations.validate_disk_space import FileSystem
+from gppylib import userinput
+from gppylib.fault_injection import *
 
 class ValidationError(Exception):
     pass
@@ -740,3 +742,25 @@ class DiskSpaceChecker:
                 raise
         
         return results
+
+# Decorator to overwrite the logic of interactive_check()
+# during tests execution.
+def wrap_interactive_check_with_faults(fun):
+    def func_with_faults(interactive: bool, bg_info: str, msg: str, default: str):
+        try:
+            inject_value = inject_fault_get_value()
+            injected_answers = json.loads(inject_value)
+            if injected_answers.get(msg, '') == 'yes':
+                return True
+            if injected_answers.get(msg, '') == 'no':
+                return False
+        except:
+            pass
+        return fun(interactive, bg_info, msg, default)
+    return func_with_faults
+
+@wrap_interactive_check_with_faults
+def interactive_check_yesno(interactive: bool, bg_info: str, msg: str, default: str) -> bool:
+    if not interactive:
+        return userinput.validate_yesno('', default)
+    return userinput.ask_yesno(bg_info, msg, default)

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_commons.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_commons.py
@@ -744,10 +744,10 @@ class DiskSpaceChecker:
         
         return results
 
-# Decorator to overwrite the logic of interactive_check()
+# Decorator to overwrite the logic of interactive_check_yesno()
 # during tests execution.
 def wrap_interactive_check_with_faults(fun):
-    def func_with_faults(interactive: bool, bg_info: str, msg: str, default: str):
+    def func_with_faults(interactive_mode: bool, bg_info: str, msg: str, default: str):
         try:
             inject_value = inject_fault_get_value()
             injected_answers = json.loads(inject_value)
@@ -757,11 +757,11 @@ def wrap_interactive_check_with_faults(fun):
                 return False
         except:
             pass
-        return fun(interactive, bg_info, msg, default)
+        return fun(interactive_mode, bg_info, msg, default)
     return func_with_faults
 
 @wrap_interactive_check_with_faults
-def interactive_check_yesno(interactive: bool, bg_info: str, msg: str, default: str) -> bool:
-    if not interactive:
+def interactive_check_yesno(interactive_mode: bool, bg_info: str, msg: str, default: str) -> bool:
+    if not interactive_mode:
         return userinput.validate_yesno('', default)
     return userinput.ask_yesno(bg_info, msg, default)

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_commons.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_commons.py
@@ -7,6 +7,7 @@ import os
 import pickle
 import re
 import socket
+import json
 from typing import Any, Dict, List, Set, Optional, Tuple
 from enum import IntEnum
 from gppylib.gparray import Segment, GpArray

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_step.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_step.py
@@ -28,7 +28,7 @@ class RebalanceStep:
         if self.isRollback():
             rollback_label = '[ROLLBACK] '
         return (
-            f"{rollback_label}Rebalance step with move_order: {self.getMoveOrder()}, status: {self.getStatus()}"
+            f"{rollback_label}Rebalance step with move_order: {self.getMoveOrder()}, status: {self.getStatus().name}"
         )
 
     def getMoveOrder(self) -> int:
@@ -66,7 +66,7 @@ class RebalanceStepMoveMirror(RebalanceStep):
 
     def __str__(self):
         return (
-            f"{super().__str__()}, type: RebalanceStepMoveMirror:\n"
+            f"{super().__str__()}, type: mirror move:\n"
             f"{str(self.move)}"
         )
 
@@ -77,7 +77,7 @@ class RebalanceStepSwitchoverToMirror(RebalanceStep):
 
     def __str__(self) -> str:
         return (
-            f"{super().__str__()}, type: RebalanceStepSwitchoverToMirror, DBID {str(self.move.seg.getSegmentDbId())}"
+            f"{super().__str__()}, type: switchover from Primary to Mirror, DBID {str(self.move.seg.getSegmentDbId())}"
         )
 
 class RebalanceStepSwitchoverToPrimary(RebalanceStep):
@@ -87,7 +87,7 @@ class RebalanceStepSwitchoverToPrimary(RebalanceStep):
 
     def __str__(self) -> str:
         return (
-            f"{super().__str__()}, type: RebalanceStepSwitchoverToPrimary, DBID {str(self.move.seg.getSegmentDbId())}"
+            f"{super().__str__()}, type: switchover from Mirror to Primary, DBID {str(self.move.seg.getSegmentDbId())}"
         )
 
 def deserializeStep(input: bytes) -> RebalanceStep:

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -9,7 +9,6 @@ try:
     from gppylib.commands.gp import *
     from gppylib.gplog import *
     from gppylib.db import dbconn
-    from gppylib import userinput
     from gppylib.gparray import GpArray, Segment
     from gppylib.fault_injection import *
     from gppylib.userinput import *
@@ -19,6 +18,7 @@ try:
     from gppylib.utils import escape_string, escapeDoubleQuoteInSQLString
     from ggrebalance_modules.planner import *
     from ggrebalance_modules.rebalance_schema import RebalanceSchema, STATE_NOT_DEFINED
+    from ggrebalance_modules.rebalance_commons import interactive_check_yesno
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
@@ -290,7 +290,7 @@ class GGShrink:
         if self.state in self.states_main_shrink_flow + self.states_rollback_flow:
             self.rebalance_schema.storeShrinkState(self.state)
 
-    def cleanup(self, prev_run_was_complete: bool) -> None:
+    def cleanup(self, prev_run_was_complete: bool) -> bool:
         if not prev_run_was_complete:
             self.logger.warning("ggrebalance hasn't finished shrink process properly. Previous run was interrupted. "
                                 "Some unbalanced tables can still exist.")
@@ -306,13 +306,12 @@ class GGShrink:
                 self.logger.warning('Current numsegments is not equal to default value.')
                 self.logger.info('Suggestion: explicitly reset the value before cleanup. Note: cluster restart will implicitly reset the value.')
 
-            if (self.options.interactive and
-                not userinput.ask_yesno(None, "\nContinue with cleanup?", 'Y')):
+            if not interactive_check_yesno(self.options.interactive, None, '\nContinue with cleanup?', default = 'Y'):
                 self.logger.info('Cleanup was interrupted...')
-                return
+                return False
 
             if (numsegments_is_set and
-                (not self.options.interactive or userinput.ask_yesno(None, "\nReset numsegments to default?", 'Y'))):
+                interactive_check_yesno(self.options.interactive, None, '\nReset numsegments to default?', default = 'Y')):
                 dbconn.execSQL(self.conn, 'BEGIN')
                 dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
                 dbconn.execSQL(self.conn, 'SELECT gp_toolkit.gp_reset_rebalance_numsegments()')
@@ -321,6 +320,8 @@ class GGShrink:
 
         if os.path.exists(self.gparray_dump_file):
             os.remove(self.gparray_dump_file)
+
+        return True
 
     def state_is_final(self, state: str) -> bool:
         return state == self.states_main_shrink_flow[-1]

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -375,6 +375,8 @@ class GGShrink:
                     self.trigger('move_to_STATE_ERROR')
                     return
 
+            if not interactive_check_yesno(self.options.interactive, None, 'Proceed with continue?', default = 'Y'):
+                raise Exception('Continue was not approved, interrupting execution')
             # use auto to_«state» method to recover
             self.trigger(f'to_{next_state}')
 

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -49,7 +49,6 @@ def print_progress(pool: WorkerPool, interval: int = 10) -> None:
 
 class GGShrink:
     timeout = SEGMENT_STOP_TIMEOUT_DEFAULT
-    stop_mode = 'fast'
 
     states = [
         'STATE_START',
@@ -226,6 +225,11 @@ class GGShrink:
         self.rebalance_schema = schema
         self.shrink_plan = None
         self.dumped_gparray = gparray.GpArray.initFromFile(self.gparray_dump_file) if os.path.exists(self.gparray_dump_file) else None
+
+        if self.options.interactive:
+            self.stop_mode = 'smart'
+        else:
+            self.stop_mode = 'fast'
 
         self.machine = Machine(model = self,
                                queued=True,
@@ -449,26 +453,43 @@ class GGShrink:
         segments_to_stop = gp_array.get_segment_count() - self.shrink_plan.getTargetSegmentCount()
         self.workers_for_segment_stop = WorkerPool(numWorkers=min(segments_to_stop, self.options.batch_size))
 
+        segments_stop_successful = []
+        segments_stop_failed = []
+        segments_stop_skipped = []
+
         # Stop primaries first, and mirrors after primaries,
         # to avoid hanging replication processes
         seg_roles = [gparray.ROLE_PRIMARY, gparray.ROLE_MIRROR]
         for seg_role in seg_roles:
-            self.logger.info(f"Prepare to stop segments with role '{seg_role}'")
+            self.logger.debug(f"Prepare to stop (mode={self.stop_mode}) segments with role '{seg_role}'")
             for seg in gp_array.getSegDbList():
                 if (seg.getSegmentContentId() >= self.shrink_plan.getTargetSegmentCount() and
                     seg.getSegmentRole() == seg_role and seg.isSegmentUp()):
+                    if (seg_role == gparray.ROLE_MIRROR and
+                        any(seg.getSegmentContentId() == failed_seg.getSegmentContentId() for failed_seg in segments_stop_failed)):
+                        segments_stop_skipped.append(seg)
+                        continue
                     cmd = self.SegmentStopAfterShrink(self, seg)
                     self.workers_for_segment_stop.addCommand(cmd)
             if self.shutdown_requested:
                 break
             print_progress(self.workers_for_segment_stop, interval=1)
+            for task in self.workers_for_segment_stop.getCompletedItems():
+                if task.was_successful():
+                    segments_stop_successful.append(task.segment)
+                else:
+                    segments_stop_failed.append(task.segment)
 
         self.workers_for_segment_stop.haltWork()
         self.workers_for_segment_stop.joinWorkers()
 
-        for task in self.workers_for_segment_stop.getCompletedItems():
-            if not task.was_successful():
-                self.logger.warning('Failed to stop segments')
+        self.logger.info('Summary of shrinked segments:')
+        for seg in segments_stop_successful:
+            self.logger.info(f'segment stopped ok - {str(seg)}')
+        for seg in segments_stop_failed:
+            self.logger.info(f'segment failed to stop - {str(seg)}')
+        for seg in segments_stop_skipped:
+            self.logger.info(f'segment stop skipped - {str(seg)}')
 
         self.workers_for_segment_stop = None
 
@@ -476,7 +497,6 @@ class GGShrink:
 
     @wrap_func_with_faults
     def on_enter_STATE_SHRINK_SEGMENTS_STOP_DONE(self) -> None:
-        self.logger.info('Shrinked segments were stopped')
         self.trigger('move_to_STATE_SHRINK_DONE')
 
     @wrap_func_with_faults
@@ -578,18 +598,18 @@ class GGShrink:
 
         @wrap_segment_stop_with_faults
         def run(self) -> None:
-            self.shrink.logger.info(f'Stopping shrinked segment {str(self.segment)}')
+            self.shrink.logger.debug(f'Stopping shrinked segment {str(self.segment)}')
             self.checkRunningSegment.run()
             if self.checkRunningSegment.is_shutdown():
-                self.shrink.logger.info(f'Segment {str(self.segment)} is already down')
+                self.shrink.logger.debug(f'Segment {str(self.segment)} is already down')
                 self.set_results(CommandResult(0, b'', b'', True, False))
             else:
                 try:
                     SegmentStop.run(self, validateAfter = True)
                 except ExecutionError:
-                    self.shrink.logger.info(f'Failed to stop shrinked segment {str(self.segment)}')
+                    self.shrink.logger.debug(f'Failed to stop shrinked segment {str(self.segment)}')
                     return
-                self.shrink.logger.info(f'Stopped shrinked segment {str(self.segment)}')
+                self.shrink.logger.debug(f'Stopped shrinked segment {str(self.segment)}')
 
     class TableRebalanceTask(SQLCommand):
         def __init__(self,

--- a/gpMgmt/doc/ggrebalance_help
+++ b/gpMgmt/doc/ggrebalance_help
@@ -180,6 +180,9 @@ OPTIONS
 --non-interactive-mode
  If this option is set, the tool does not ask the user for input and applies
  default options when interaction with the user is required.
+ At the cluster shrink operation, in the interactive mode the shrunken segments
+ are stopped via 'smart' mode, and in non-interactive mode they are stopped via
+ 'fast' mode.
 
 --inplace-swap-roles
  If this option is set, it is permitted to temporarily place primary and

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
@@ -89,7 +89,7 @@ Feature: ggrebalance behave tests
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
-        When the user runs "ggrebalance -c -y"
+        When the user runs "ggrebalance -c --non-interactive-mode"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Reset numsegments to default is done." to logfile with latest timestamp
          And ggrebalance should print "Cleanup is complete" to logfile with latest timestamp

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -454,7 +454,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance --replay-lag 0 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode --replay-lag 0 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And gprecoverseg should print "0 bytes of wal is still to be replayed on mirror with dbid.*, let mirror catchup on replay then trigger rebalance" regex to logfile
          And all files in gpAdminLogs directory are deleted

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -35,7 +35,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -x 6 --mirror-mode grouped -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 6 --mirror-mode grouped -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And verify that mirror segments are in "group" configuration
@@ -57,7 +57,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -x 6 --mirror-mode spread -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 6 --mirror-mode spread -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And verify that mirror segments are in "spread" configuration
@@ -88,7 +88,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -x 4 --target-hosts 'sdw2, sdw3' -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 4 --target-hosts 'sdw2, sdw3' -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has 0 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
@@ -126,7 +126,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And ggrebalance should print "No such file or directory: '/tmp/ggrebalance_non_existing_file'" to logfile with latest timestamp
          And all files in gpAdminLogs directory are deleted
         When there is a file "/tmp/ggrebalance_target_hosts" with hosts "sdw2|sdw3"
-         And the user runs "ggrebalance -x 4 --target-hosts-file /tmp/ggrebalance_target_hosts -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+         And the user runs "ggrebalance --non-interactive-mode -x 4 --target-hosts-file /tmp/ggrebalance_target_hosts -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has 0 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
@@ -155,7 +155,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And there is a file "/tmp/ggrebalance_add_hosts" with hosts "sdw2|sdw3"
-        When the user runs "ggrebalance -x 3 --add-hosts-file /tmp/ggrebalance_add_hosts -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 3 --add-hosts-file /tmp/ggrebalance_add_hosts -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has 1 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
@@ -184,7 +184,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And there is a file "/tmp/ggrebalance_remove_hosts" with hosts "sdw3"
-        When the user runs "ggrebalance -x 4 --remove-hosts-file /tmp/ggrebalance_remove_hosts -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 4 --remove-hosts-file /tmp/ggrebalance_remove_hosts -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
@@ -212,7 +212,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -x 6 --remove-hosts sdw3 --target-datadirs '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_new/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_new/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 6 --remove-hosts sdw3 --target-datadirs '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_new/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_new/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has some segments where "datadir like '/home/gpadmin/gpdb\_src/gpAux/gpdemo/datadirs\_new/dbfast/gpseg_'"
@@ -235,7 +235,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -x 6 --remove-hosts sdw3 --target-datadirs '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_new/dbfast/new_seg{content}_on_host_{hostname}, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_new/dbfast_mirror/new_seg{content}_on_host_{hostname}'"
+        When the user runs "ggrebalance --non-interactive-mode -x 6 --remove-hosts sdw3 --target-datadirs '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_new/dbfast/new_seg{content}_on_host_{hostname}, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_new/dbfast_mirror/new_seg{content}_on_host_{hostname}'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has some segments where "datadir like '/home/gpadmin/gpdb\_src/gpAux/gpdemo/datadirs\_new/dbfast/new\_seg_\_on\_host\_sdw_'"
@@ -259,7 +259,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And there is a file "/tmp/ggrebalance_target_datadirs" with hosts "/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_{hostname}/dbfast/new_seg{content}|/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_{hostname}/dbfast_mirror/new_seg{content}"
-        When the user runs "ggrebalance -x 6 --remove-hosts sdw3 --target-datadirs-file /tmp/ggrebalance_target_datadirs"
+        When the user runs "ggrebalance --non-interactive-mode -x 6 --remove-hosts sdw3 --target-datadirs-file /tmp/ggrebalance_target_datadirs"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has some segments where "datadir like '/home/gpadmin/gpdb\_src/gpAux/gpdemo/datadirs\_sdw_/dbfast/new\_seg_'"
@@ -346,7 +346,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -l "/tmp/ggrebalance_logs" -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -l "/tmp/ggrebalance_logs" -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And gpAdminLogs directory has no "ggrebalance*" files
          And gpAdminLogs directory has no "gpmovemirrors*" files
@@ -357,7 +357,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And all files in "/tmp/ggrebalance_logs" directory are deleted
         When the user runs "ggrebalance -c"
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance --log-dir "/tmp/ggrebalance logs" -x 6 --add-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode --log-dir "/tmp/ggrebalance logs" -x 6 --add-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And gpAdminLogs directory has no "ggrebalance*" files
          And gpAdminLogs directory has no "gpmovemirrors*" files
@@ -390,7 +390,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
         Then validate that following rows are in the stored rows
           |  analyzed_tables_cnt  |
           |  0                    |
-        When the user runs "ggrebalance -x 3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
         When execute following sql in db "test_db_1" and store result in the context
@@ -431,7 +431,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
         Then validate that following rows are in the stored rows
           |  analyzed_tables_cnt  |
           |  0                    |
-        When the user runs "ggrebalance --analyze -x 3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode --analyze -x 3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
         When execute following sql in db "test_db_1" and store result in the context
@@ -464,7 +464,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance --hba-hostnames -x 2 --add-hosts sdw2 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode --hba-hostnames -x 2 --add-hosts sdw2 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And pg_hba file "/data/gpdata/ggrebalance/data/primary/gpseg0/pg_hba.conf" on host "sdw1" contains entries for "sdw2"
@@ -474,7 +474,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -x 2 --add-hosts sdw2 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 2 --add-hosts sdw2 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And pg_hba file "/data/gpdata/ggrebalance/data/primary/gpseg0/pg_hba.conf" on host "sdw1" contains only cidr addresses

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -394,6 +394,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And the gprecoverseg lock directory is removed
         When user will answer "yes" to the prompt "Retry step?"
          And user will answer "yes" to the prompt "Approve switchovers?"
+         And user will answer "yes" to the prompt "Proceed with continue?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -444,6 +445,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When user will answer "no" to the prompt "Retry step?"
          And user will answer "yes" to the prompt "Rollback step?"
          And user will answer "yes" to the prompt "Approve switchovers?"
+         And user will answer "yes" to the prompt "Proceed with continue?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -494,6 +496,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When user will answer "no" to the prompt "Retry step?"
          And user will answer "no" to the prompt "Rollback step?"
          And user will answer "yes" to the prompt "Approve switchovers?"
+         And user will answer "yes" to the prompt "Proceed with continue?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -543,6 +546,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And the gprecoverseg lock directory is removed
         When user will answer "yes" to the prompt "Retry step?"
          And user will answer "yes" to the prompt "Approve switchovers?"
+         And user will answer "yes" to the prompt "Proceed with continue?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Processing error status for switchover step" to logfile with latest timestamp
@@ -593,6 +597,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When user will answer "no" to the prompt "Retry step?"
          And user will answer "yes" to the prompt "Rollback step?"
          And user will answer "yes" to the prompt "Approve switchovers?"
+         And user will answer "yes" to the prompt "Proceed with continue?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Processing error status for switchover step" to logfile with latest timestamp
@@ -642,6 +647,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When user will answer "no" to the prompt "Retry step?"
          And user will answer "yes" to the prompt "Rollback step?"
          And user will answer "yes" to the prompt "Approve switchovers?"
+         And user will answer "yes" to the prompt "Proceed with continue?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Processing error status for switchover step" to logfile with latest timestamp
@@ -690,6 +696,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When user will answer "no" to the prompt "Retry step?"
          And user will answer "no" to the prompt "Rollback step?"
          And user will answer "yes" to the prompt "Approve switchovers?"
+         And user will answer "yes" to the prompt "Proceed with continue?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Processing error status for switchover step" to logfile with latest timestamp
@@ -738,6 +745,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When user will answer "no" to the prompt "Retry step?"
          And user will answer "no" to the prompt "Rollback step?"
          And user will answer "yes" to the prompt "Approve switchovers?"
+         And user will answer "yes" to the prompt "Proceed with continue?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -786,6 +794,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When user will answer "no" to the prompt "Retry step?"
          And user will answer "yes" to the prompt "Rollback step?"
          And user will answer "yes" to the prompt "Approve switchovers?"
+         And user will answer "yes" to the prompt "Proceed with continue?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -883,6 +892,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When user will answer "no" to the prompt "Timeout waiting for segment start, wait again?"
          And user will answer "yes" to the prompt "Retry step?"
          And user will answer "yes" to the prompt "Approve switchovers?"
+         And user will answer "yes" to the prompt "Proceed with continue?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -935,6 +945,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And user will answer "no" to the prompt "Retry step?"
          And user will answer "yes" to the prompt "Rollback step?"
          And user will answer "yes" to the prompt "Approve switchovers?"
+         And user will answer "yes" to the prompt "Proceed with continue?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -987,6 +998,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And user will answer "no" to the prompt "Retry step?"
          And user will answer "no" to the prompt "Rollback step?"
          And user will answer "yes" to the prompt "Approve switchovers?"
+         And user will answer "yes" to the prompt "Proceed with continue?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -1035,6 +1047,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When user will answer "no" to the prompt "Timeout waiting for segment start, wait again?"
          And user will answer "yes" to the prompt "Retry step?"
          And user will answer "yes" to the prompt "Approve switchovers?"
+         And user will answer "yes" to the prompt "Proceed with continue?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -1047,6 +1060,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And on host "sdw1" unset fault inject
          And user will answer "yes" to the prompt "Rollback step?"
          And user will answer "yes" to the prompt "Approve switchovers?"
+         And user will answer "yes" to the prompt "Proceed with continue?"
         When the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -1148,6 +1162,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And the gprecoverseg lock directory is removed
         When user will answer "yes" to the prompt "Retry step?"
          And user will answer "yes" to the prompt "Approve switchovers?"
+         And user will answer "yes" to the prompt "Proceed with continue?"
          And the user runs "ggrebalance"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance rollback is complete" to logfile with latest timestamp

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -14,7 +14,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance --parallel <parallel_size> -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode --parallel <parallel_size> -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
@@ -44,7 +44,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When the user runs "ggrebalance -c"
         Then ggrebalance should return a return code of 0
         And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance --parallel <parallel_size> -x 6 --add-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode --parallel <parallel_size> -x 6 --add-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
@@ -91,7 +91,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -x 3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has 1 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
@@ -128,13 +128,13 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
          And all files in gpAdminLogs directory are deleted
          And the gprecoverseg lock directory is removed
-        When the user runs "ggrebalance"
+        When the user runs "ggrebalance --non-interactive-mode"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
@@ -185,12 +185,12 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "fault_rebalance_table_test_db_2.test_schema_2.test_table_1"
-        When the user runs "ggrebalance -x 4 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 4 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance"
+        When the user runs "ggrebalance --non-interactive-mode"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Continue interrupted shrink operation..." to logfile with latest timestamp
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
@@ -221,12 +221,12 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "on_enter_STATE_REBALANCE_EXECUTION_STARTED_begin"
-        When the user runs "ggrebalance -x 4 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 4 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance"
+        When the user runs "ggrebalance --non-interactive-mode"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Continue interrupted rebalance operation..." to logfile with latest timestamp
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
@@ -305,8 +305,8 @@ Feature: ggrebalance behave tests (rebalance scenarios)
 
         Examples: inplace swap and using 3rd host
         | command    | restore_env|
-        |"ggrebalance -x 6 -d '/data/gpdata/ggrebalance/primary, /data/gpdata/ggrebalance/mirror'"|stub|
-        |"ggrebalance -x 6 -d '/data/gpdata/ggrebalance/primary, /data/gpdata/ggrebalance/mirror'  --inplace-swap-roles"|"COORDINATOR_DATA_DIRECTORY" environment variable should be restored|
+        |"ggrebalance --non-interactive-mode -x 6 -d '/data/gpdata/ggrebalance/primary, /data/gpdata/ggrebalance/mirror'"|stub|
+        |"ggrebalance --non-interactive-mode -x 6 -d '/data/gpdata/ggrebalance/primary, /data/gpdata/ggrebalance/mirror'  --inplace-swap-roles"|"COORDINATOR_DATA_DIRECTORY" environment variable should be restored|
     
     Scenario: 7. rebalance - case with multiple swaps.
         Given the database is not running
@@ -351,7 +351,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -x 6 -d '/data/gpdata/ggrebalance/primary, /data/gpdata/ggrebalance/mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 6 -d '/data/gpdata/ggrebalance/primary, /data/gpdata/ggrebalance/mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has 1 segments where "hostname='sdw1' and content = 2 and role = 'm' and status = 'u'"
@@ -386,13 +386,14 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
          And all files in gpAdminLogs directory are deleted
          And the gprecoverseg lock directory is removed
         When user will answer "yes" to the prompt "Retry step?"
+         And user will answer "yes" to the prompt "Approve switchovers?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -434,7 +435,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
@@ -442,6 +443,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And the gprecoverseg lock directory is removed
         When user will answer "no" to the prompt "Retry step?"
          And user will answer "yes" to the prompt "Rollback step?"
+         And user will answer "yes" to the prompt "Approve switchovers?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -483,7 +485,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
@@ -491,6 +493,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And the gprecoverseg lock directory is removed
         When user will answer "no" to the prompt "Retry step?"
          And user will answer "no" to the prompt "Rollback step?"
+         And user will answer "yes" to the prompt "Approve switchovers?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -532,13 +535,14 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
          And all files in gpAdminLogs directory are deleted
          And the gprecoverseg lock directory is removed
         When user will answer "yes" to the prompt "Retry step?"
+         And user will answer "yes" to the prompt "Approve switchovers?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Processing error status for switchover step" to logfile with latest timestamp
@@ -580,7 +584,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
@@ -588,6 +592,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And the gprecoverseg lock directory is removed
         When user will answer "no" to the prompt "Retry step?"
          And user will answer "yes" to the prompt "Rollback step?"
+         And user will answer "yes" to the prompt "Approve switchovers?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Processing error status for switchover step" to logfile with latest timestamp
@@ -628,7 +633,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
@@ -636,6 +641,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And the gprecoverseg lock directory is removed
         When user will answer "no" to the prompt "Retry step?"
          And user will answer "yes" to the prompt "Rollback step?"
+         And user will answer "yes" to the prompt "Approve switchovers?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Processing error status for switchover step" to logfile with latest timestamp
@@ -675,7 +681,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
@@ -683,6 +689,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And the gprecoverseg lock directory is removed
         When user will answer "no" to the prompt "Retry step?"
          And user will answer "no" to the prompt "Rollback step?"
+         And user will answer "yes" to the prompt "Approve switchovers?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Processing error status for switchover step" to logfile with latest timestamp
@@ -722,7 +729,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
@@ -730,6 +737,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And the gprecoverseg lock directory is removed
         When user will answer "no" to the prompt "Retry step?"
          And user will answer "no" to the prompt "Rollback step?"
+         And user will answer "yes" to the prompt "Approve switchovers?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -769,7 +777,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
@@ -777,6 +785,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And the gprecoverseg lock directory is removed
         When user will answer "no" to the prompt "Retry step?"
          And user will answer "yes" to the prompt "Rollback step?"
+         And user will answer "yes" to the prompt "Approve switchovers?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -818,13 +827,13 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
          And all files in gpAdminLogs directory are deleted
          And the gprecoverseg lock directory is removed
-        When the user runs "ggrebalance -n 1"
+        When the user runs "ggrebalance --non-interactive-mode -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
          And ggrebalance should print "Start checking if segment is up with timeout" to logfile with latest timestamp
@@ -865,7 +874,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And on host "sdw1" set fault inject "<fault_name>"
-        When the user runs "ggrebalance -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And on host "sdw1" unset fault inject
@@ -873,6 +882,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And the gprecoverseg lock directory is removed
         When user will answer "no" to the prompt "Timeout waiting for segment start, wait again?"
          And user will answer "yes" to the prompt "Retry step?"
+         And user will answer "yes" to the prompt "Approve switchovers?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -915,7 +925,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And on host "sdw1" set fault inject "<fault_name>"
-        When the user runs "ggrebalance -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And on host "sdw1" unset fault inject
@@ -924,6 +934,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When user will answer "no" to the prompt "Timeout waiting for segment start, wait again?"
          And user will answer "no" to the prompt "Retry step?"
          And user will answer "yes" to the prompt "Rollback step?"
+         And user will answer "yes" to the prompt "Approve switchovers?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -966,7 +977,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And on host "sdw1" set fault inject "<fault_name>"
-        When the user runs "ggrebalance -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And on host "sdw1" unset fault inject
@@ -975,6 +986,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When user will answer "no" to the prompt "Timeout waiting for segment start, wait again?"
          And user will answer "no" to the prompt "Retry step?"
          And user will answer "no" to the prompt "Rollback step?"
+         And user will answer "yes" to the prompt "Approve switchovers?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -1015,13 +1027,14 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And on host "sdw1" set fault inject "<fault_name>"
-        When the user runs "ggrebalance -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And all files in gpAdminLogs directory are deleted
          And the gprecoverseg lock directory is removed
         When user will answer "no" to the prompt "Timeout waiting for segment start, wait again?"
          And user will answer "yes" to the prompt "Retry step?"
+         And user will answer "yes" to the prompt "Approve switchovers?"
          And the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -1033,6 +1046,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And all files in gpAdminLogs directory are deleted
          And on host "sdw1" unset fault inject
          And user will answer "yes" to the prompt "Rollback step?"
+         And user will answer "yes" to the prompt "Approve switchovers?"
         When the user runs "ggrebalance -n 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Checking error status for step" to logfile with latest timestamp
@@ -1075,13 +1089,13 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
          And all files in gpAdminLogs directory are deleted
          And the gprecoverseg lock directory is removed
-        When the user runs "ggrebalance -r"
+        When the user runs "ggrebalance --non-interactive-mode -r"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance rollback is complete" to logfile with latest timestamp
          And verify the gp_segment_configuration has been restored
@@ -1119,20 +1133,21 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "on_enter_STATE_REBALANCE_DONE_begin"
-        When the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
          And all files in gpAdminLogs directory are deleted
          And the gprecoverseg lock directory is removed
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance -r"
+        When the user runs "ggrebalance --non-interactive-mode -r"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
          And all files in gpAdminLogs directory are deleted
          And the gprecoverseg lock directory is removed
         When user will answer "yes" to the prompt "Retry step?"
+         And user will answer "yes" to the prompt "Approve switchovers?"
          And the user runs "ggrebalance"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance rollback is complete" to logfile with latest timestamp
@@ -1180,11 +1195,11 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And schema "test_schema_2" exists in "test_db_2"
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
-        When the user runs "ggrebalance -x 4 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 4 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
-        When the user runs "ggrebalance -r"
+        When the user runs "ggrebalance --non-interactive-mode -r"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rollback is complete" to logfile with latest timestamp
          And verify the gp_segment_configuration has been restored
@@ -1210,22 +1225,22 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And schema "test_schema_2" exists in "test_db_2"
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
-        When the user runs "ggrebalance -x 4 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 4 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
          And all files in gpAdminLogs directory are deleted
          And set fault inject "on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_end"
-        When the user runs "ggrebalance -r"
+        When the user runs "ggrebalance --non-interactive-mode -r"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -r"
+        When the user runs "ggrebalance --non-interactive-mode -r"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rollback is already in progress, and was interrupted. Execute 'ggrebalance' without '-r' flag." to logfile with latest timestamp
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance"
+        When the user runs "ggrebalance --non-interactive-mode"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rollback is complete" to logfile with latest timestamp
          And verify the gp_segment_configuration has been restored
@@ -1250,11 +1265,11 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And schema "test_schema_2" exists in "test_db_2"
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
-        When the user runs "ggrebalance -x 4 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 4 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
-        When the user runs "ggrebalance -r"
+        When the user runs "ggrebalance --non-interactive-mode -r"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance rollback is complete" to logfile with latest timestamp
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
@@ -1284,11 +1299,11 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And schema "test_schema_2" exists in "test_db_2"
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
-        When the user runs "ggrebalance -x 4 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 4 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
-        When the user runs "ggrebalance -r"
+        When the user runs "ggrebalance --non-interactive-mode -r"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance rollback is complete" to logfile with latest timestamp
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
@@ -1318,11 +1333,11 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -r"
+        When the user runs "ggrebalance --non-interactive-mode -r"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance rollback is complete" to logfile with latest timestamp
          And verify the gp_segment_configuration has been restored

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
@@ -86,9 +86,11 @@ Feature: ggrebalance behave tests
         When the user runs "ggrebalance -x 1 --parallel 1 --batch-size 1 --skip-rebalance"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "Can't start a new operation, because the previous one was interrupted" to logfile with latest timestamp
-        When the user runs "ggrebalance --parallel 1 --batch-size 1"
+        When user will answer "yes" to the prompt "Proceed with continue?"
+         And the user runs "ggrebalance --parallel 1 --batch-size 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And clear user's answers
          And verify no segment running for saved segment information
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
@@ -156,9 +158,11 @@ Feature: ggrebalance behave tests
         When the user runs "gpstop -arf"
         Then gpstart should return a return code of 0
         When there is a "heap" table "test_schema_2.test_table_3" in "test_db_2" with data
+         And user will answer "yes" to the prompt "Proceed with continue?"
          And the user runs "ggrebalance"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And clear user's answers
          And verify no segment running for saved segment information
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
@@ -307,9 +311,11 @@ Feature: ggrebalance behave tests
         When the user runs "ggrebalance -r"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Can't perform rollback as the catalog is already updated" to logfile with latest timestamp
-        When the user runs "ggrebalance"
+        When user will answer "yes" to the prompt "Proceed with continue?"
+         And the user runs "ggrebalance"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And clear user's answers
          And verify no segment running for saved segment information
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
@@ -424,9 +430,11 @@ Feature: ggrebalance behave tests
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
-        When the user runs "ggrebalance"
+        When user will answer "yes" to the prompt "Proceed with continue?"
+         And the user runs "ggrebalance"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And clear user's answers
          And verify no segment running for saved segment information
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
@@ -474,9 +482,11 @@ Feature: ggrebalance behave tests
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
-        When the user runs "ggrebalance"
+        When user will answer "yes" to the prompt "Proceed with continue?"
+         And the user runs "ggrebalance"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rollback is complete" to logfile with latest timestamp
+         And clear user's answers
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 2, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 2, row count = 100
          And distribution information from table "test_schema_1.part_test_table_1" with data in "test_db_1" is equal to segment count = 2, row count = 100
@@ -603,9 +613,11 @@ Feature: ggrebalance behave tests
         When the user runs "gpstop -arf"
         Then gpstart should return a return code of 0
         When there is a "heap" table "test_schema_2.test_table_4" in "test_db_2" with "300" rows
-        When the user runs "ggrebalance"
+        When user will answer "yes" to the prompt "Proceed with continue?"
+         And the user runs "ggrebalance"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rollback is complete" to logfile with latest timestamp
+         And clear user's answers
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 2, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 2, row count = 100
          And distribution information from table "test_schema_1.part_test_table_1" with data in "test_db_1" is equal to segment count = 2, row count = 100
@@ -673,9 +685,11 @@ Feature: ggrebalance behave tests
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
          And table "test_schema_2.test_table_1" is dropped in "test_db_2"
-        When the user runs "ggrebalance"
+        When user will answer "yes" to the prompt "Proceed with continue?"
+         And the user runs "ggrebalance"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And clear user's answers
          And verify no segment running for saved segment information
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_1.part_test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
@@ -711,9 +725,11 @@ Feature: ggrebalance behave tests
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
          And materialized view "test_schema_1.mv_test_table_1" is dropped in "test_db_1"
-        When the user runs "ggrebalance"
+        When user will answer "yes" to the prompt "Proceed with continue?"
+         And the user runs "ggrebalance"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And clear user's answers
          And verify no segment running for saved segment information
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_1.part_test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
@@ -749,9 +765,11 @@ Feature: ggrebalance behave tests
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
          And the database "test_db_2" does not exist
-        When the user runs "ggrebalance"
+        When user will answer "yes" to the prompt "Proceed with continue?"
+         And the user runs "ggrebalance"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And clear user's answers
          And verify no segment running for saved segment information
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_1.part_test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100


### PR DESCRIPTION
Implement interactive mode for ggrebalance

This patch adds interactive mode of operation, which is the default mode.
Non-interactive mode of operation can be used if the key
'--non-interactive-mode' is specified at the tool start.

In the interactive mode, the user is asked to confirm the following decisions:
 - cleanup continue at shrink's cleanup if numsegments is not equal to default
value;
 - reset numsegments to the default value at shrink's cleanup;
 - proceed with operation continue on the tool's re-enter after interruption;
 - wait again on timeout expiration when checking for errored rebalance steps;
 - retry / rollback / cancel steps for errored rebalance steps;
 - approve segment switchovers.

Also this patch:
 - changes the segment stop mode to 'smart' when operating in the interactive
mode. 'fast' is still used for non-interactive mode. It is done to comply with
the requirements.
 - prints status of both stopped and failed to stop shrunken segments at the
end of the shrink process. It is done to comply with the requirements (notify
dba that some segments are still up).
 - fixes cleanup if the user didn't confirm the cleanup continue. Previously,
even if user didn't approve the cleanup to continue, the rebalance schema was
still dropped. Now it is fixed.
 - removes '-y' flag, as it doesn't comply with current requirements;
 - makes the rebalance step string representation more human-readable;
 - updates test (either by adding '--non-interactive-mode' where suitable, or
by adding required user answers).