### PR TITLE
GG-326: Add separate queue support for the communication channel

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -36,7 +36,7 @@ static uint32 cdbconn_get_motion_listener_port(PGconn *conn);
 static void cdbconn_disconnect(SegmentDatabaseDescriptor *segdbDesc);
 
 static void MPPnoticeReceiver(void *arg, const PGresult *res);
-static void MPPmetadataReceiver(void *arg, ggMetadataChunk *, ggMetadataQueueId);
+static void MPPmetadataReceiver(void *arg, ggMetadataChunk *metadata_chunk, ggMetadataQueueId queue_id);
 
 static const char *
 transStatusToString(PGTransactionStatusType status)
@@ -873,7 +873,8 @@ forwardQENotices(void)
 		pq_flush();
 }
 
-typedef struct ggMetadataQueue {
+typedef struct ggMetadataQueue
+{
 	ggMetadataQueueId id;
 	int count;
 	ggMetadataChunk *chunks;

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -915,7 +915,7 @@ PQMetadataWalk(ggMetadataQueueId queue_id)
 {
 	ggMetadataQueue *queue = PQMetadataFindQueue(queue_id);
 	if (!queue)
-		elog(ERROR, "No metadata queue with id %d", queue_id);
+		elog(ERROR, "No metadata queue with id %u", queue_id);
 	return queue->chunks;
 }
 
@@ -947,7 +947,7 @@ PQgetMetadataCount(ggMetadataQueueId queue_id)
 {
 	ggMetadataQueue *queue = PQMetadataFindQueue(queue_id);
 	if (!queue)
-		elog(ERROR, "No metadata queue with id %d", queue_id);
+		elog(ERROR, "No metadata queue with id %u", queue_id);
 	return queue->count;
 }
 
@@ -1003,7 +1003,7 @@ PQDeleteMetadataQueue(ggMetadataQueueId queue_id)
 {
 	ggMetadataQueue *queue = PQMetadataFindQueue(queue_id);
 	if (!queue)
-		elog(ERROR, "No metadata queue with id %d", queue_id);
+		elog(ERROR, "No metadata queue with id %u", queue_id);
 
 	PQCleanMetadataInternal(queue);
 

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -36,7 +36,7 @@ static uint32 cdbconn_get_motion_listener_port(PGconn *conn);
 static void cdbconn_disconnect(SegmentDatabaseDescriptor *segdbDesc);
 
 static void MPPnoticeReceiver(void *arg, const PGresult *res);
-static void MPPmetadataReceiver(void *arg, ggMetadataChunk *);
+static void MPPmetadataReceiver(void *arg, ggMetadataChunk *, ggMetadataQueueId);
 
 static const char *
 transStatusToString(PGTransactionStatusType status)
@@ -873,24 +873,49 @@ forwardQENotices(void)
 		pq_flush();
 }
 
-static ggMetadataChunk *ggMetadataList = NULL;
-static int ggMetadataCount = 0;
+typedef struct ggMetadataQueue {
+	ggMetadataQueueId id;
+	int count;
+	ggMetadataChunk *chunks;
+} ggMetadataQueue;
+
+/* List of ggMetadataQueue */
+static List *ggMetadataQueues = NIL;
+
+static ggMetadataQueue *PQMetadataFindQueue(ggMetadataQueueId queue_id)
+{
+	ListCell *lc;
+	foreach(lc, ggMetadataQueues)
+	{
+		ggMetadataQueue *queue = (ggMetadataQueue *) lfirst(lc);
+		if (queue->id == queue_id)
+			return queue;
+	}
+	return NULL;
+}
 
 static void
-MPPmetadataReceiver(void *arg, ggMetadataChunk *metadata_chunk)
+MPPmetadataReceiver(void *arg, ggMetadataChunk *metadata_chunk, ggMetadataQueueId queue_id)
 {
 	SegmentDatabaseDescriptor *segdbDesc = (SegmentDatabaseDescriptor *)arg;
 
-	metadata_chunk->next = ggMetadataList;
-	metadata_chunk->segindex = segdbDesc->segindex;
-	ggMetadataList = metadata_chunk;
-	ggMetadataCount++;
+	ggMetadataQueue *queue = PQMetadataFindQueue(queue_id);
+	if (queue)
+	{
+		metadata_chunk->next = queue->chunks;
+		metadata_chunk->segindex = segdbDesc->segindex;
+		queue->chunks = metadata_chunk;
+		queue->count++;
+	}
 }
 
 ggMetadataChunkIterator
-PQMetadataWalk(void)
+PQMetadataWalk(ggMetadataQueueId queue_id)
 {
-	return ggMetadataList;
+	ggMetadataQueue *queue = PQMetadataFindQueue(queue_id);
+	if (!queue)
+		elog(ERROR, "No metadata queue with id %d", queue_id);
+	return queue->chunks;
 }
 
 ggMetadataChunkIterator
@@ -917,21 +942,70 @@ PQgetMetadata(ggMetadataChunkIterator it, ggMetadataDescriptor *out_desc)
 }
 
 int 
-PQgetMetadataCount(void)
+PQgetMetadataCount(ggMetadataQueueId queue_id)
 {
-	return ggMetadataCount;
+	ggMetadataQueue *queue = PQMetadataFindQueue(queue_id);
+	if (!queue)
+		elog(ERROR, "No metadata queue with id %d", queue_id);
+	return queue->count;
 }
 
-void
-PQCleanMetadata(void)
+static void
+PQCleanMetadataInternal(ggMetadataQueue *queue)
 {
-	ggMetadataChunk *chunk = ggMetadataList;
+	ggMetadataChunk *chunk = queue->chunks;
 	while (chunk)
 	{
 		ggMetadataChunkIterator next = chunk->next;
 		free(chunk);
 		chunk = next;
 	}
-	ggMetadataList = NULL;
-	ggMetadataCount = 0;
+	queue->chunks = NULL;
+	queue->count = 0;
+}
+
+void
+PQCleanMetadata(ggMetadataQueueId queue_id)
+{
+	ggMetadataQueue *queue = PQMetadataFindQueue(queue_id);
+	if (!queue)
+		elog(ERROR, "No metadata queue with id %d", queue_id);
+
+	PQCleanMetadataInternal(queue);
+}
+
+
+ggMetadataQueueId
+PQMetadataNextQueueId()
+{
+	static ggMetadataQueueId queueId = 0;
+	return queueId++;
+}
+
+void
+PQCreateMetadataQueue(ggMetadataQueueId queue_id)
+{
+	MemoryContext oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+
+	ggMetadataQueue *queue = palloc0(sizeof(ggMetadataQueue));
+	queue->id = queue_id;
+	queue->chunks = NULL;
+	queue->count = 0;
+
+	ggMetadataQueues = lappend(ggMetadataQueues, queue);
+
+	MemoryContextSwitchTo(oldcontext);
+}
+
+void
+PQDeleteMetadataQueue(ggMetadataQueueId queue_id)
+{
+	ggMetadataQueue *queue = PQMetadataFindQueue(queue_id);
+	if (!queue)
+		elog(ERROR, "No metadata queue with id %d", queue_id);
+
+	PQCleanMetadataInternal(queue);
+
+	ggMetadataQueues = list_delete(ggMetadataQueues, queue);
+	pfree(queue);
 }

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -970,7 +970,7 @@ PQCleanMetadata(ggMetadataQueueId queue_id)
 {
 	ggMetadataQueue *queue = PQMetadataFindQueue(queue_id);
 	if (!queue)
-		elog(ERROR, "No metadata queue with id %d", queue_id);
+		elog(ERROR, "No metadata queue with id %u", queue_id);
 
 	PQCleanMetadataInternal(queue);
 }

--- a/src/backend/libpq/pqformat.c
+++ b/src/backend/libpq/pqformat.c
@@ -692,7 +692,7 @@ pq_getmsgend(StringInfo msg)
  * conflict with the official Frontend/Backend protocol.
  */
 void
-pq_metadatasend(const void *data, size_t len)
+pq_metadatasend(const void *data, size_t len, int32 queue_id)
 {
 	StringInfoData buf;
 
@@ -711,6 +711,7 @@ pq_metadatasend(const void *data, size_t len)
 	 */
 	pq_beginmessage(&buf, 'M');
 
+	pq_sendint(&buf, queue_id, 4);
 	/* Append the opaque data */
 	pq_sendbytes(&buf, (const char *) data, (int) len);
 

--- a/src/include/libpq/libpq.h
+++ b/src/include/libpq/libpq.h
@@ -78,7 +78,7 @@ extern ssize_t secure_write(Port *port, void *ptr, size_t len);
 /*
  * Send custom metadata to frontend
  */
-extern void pq_metadatasend(const void *data, size_t len);
+extern void pq_metadatasend(const void *data, size_t len, int32 queue_id);
 
 typedef void *ggMetadataChunkIterator;
 
@@ -89,11 +89,17 @@ typedef struct ggMetadataDescriptor
 	void *data;
 } ggMetadataDescriptor;
 
-extern ggMetadataChunkIterator PQMetadataWalk(void);
+typedef uint32 ggMetadataQueueId;
+
+extern ggMetadataChunkIterator PQMetadataWalk(ggMetadataQueueId queue_id);
 extern ggMetadataChunkIterator PQgetNextMetadata(ggMetadataChunkIterator it);
 extern void PQgetMetadata(ggMetadataChunkIterator it, ggMetadataDescriptor *out_desc);
-extern int PQgetMetadataCount(void);
-extern void PQCleanMetadata(void);
+extern int PQgetMetadataCount(ggMetadataQueueId queue_id);
+extern void PQCleanMetadata(ggMetadataQueueId queue_id);
+
+extern ggMetadataQueueId PQMetadataNextQueueId(void);
+extern void PQCreateMetadataQueue(ggMetadataQueueId queue_id);
+extern void PQDeleteMetadataQueue(ggMetadataQueueId queue_id);
 
 
 #endif   /* LIBPQ_H */

--- a/src/include/libpq/libpq.h
+++ b/src/include/libpq/libpq.h
@@ -89,7 +89,7 @@ typedef struct ggMetadataDescriptor
 	void *data;
 } ggMetadataDescriptor;
 
-typedef uint32 ggMetadataQueueId;
+typedef unsigned int ggMetadataQueueId;
 
 extern ggMetadataChunkIterator PQMetadataWalk(ggMetadataQueueId queue_id);
 extern ggMetadataChunkIterator PQgetNextMetadata(ggMetadataChunkIterator it);

--- a/src/interfaces/libpq/fe-protocol3.c
+++ b/src/interfaces/libpq/fe-protocol3.c
@@ -2381,6 +2381,8 @@ pgGetMetadataMessage(PGconn *conn, int length)
 		return pqSkipnchar(length, conn);
 	}
 
+	int payload_len = length - 4;
+
 	/*
 	 * Since the metadata might be pretty long, we create an own buffer
 	 * rather than using conn->workBuffer.  workBuffer is intended
@@ -2389,21 +2391,29 @@ pgGetMetadataMessage(PGconn *conn, int length)
 	 * we can not use palloc/pqAlloc here as this is a handler.
 	 */
 
-	ggMetadataChunk *chunk = malloc(sizeof(ggMetadataChunk) + length);
+	ggMetadataChunk *chunk = malloc(sizeof(ggMetadataChunk) + payload_len);
 	if (chunk == NULL)
 		return 1;
 
 	chunk->next = NULL;
-	chunk->metadataLen = length;
+	chunk->metadataLen = payload_len;
 
-	if (pqGetnchar(chunk->payload, length, conn))
+	int32 queue_id;
+
+	if (pqGetInt(&queue_id, 4, conn))
+	{
+		free(chunk);
+		return 1;
+	}
+
+	if (pqGetnchar(chunk->payload, payload_len, conn))
 	{
 		free(chunk);
 		return 1;
 	}		
 
 	/* pass ownership of the link too the handler */
-	conn->metadataHooks.metadataRec(conn->metadataHooks.metadataRecArg, chunk);
+	conn->metadataHooks.metadataRec(conn->metadataHooks.metadataRecArg, chunk, queue_id);
 
 	return 0;
 }

--- a/src/interfaces/libpq/fe-protocol3.c
+++ b/src/interfaces/libpq/fe-protocol3.c
@@ -2381,7 +2381,7 @@ pgGetMetadataMessage(PGconn *conn, int length)
 		return pqSkipnchar(length, conn);
 	}
 
-	int payload_len = length - 4;
+	int payload_len = length - sizeof(ggMetadataQueueId);
 
 	/*
 	 * Since the metadata might be pretty long, we create an own buffer
@@ -2400,7 +2400,7 @@ pgGetMetadataMessage(PGconn *conn, int length)
 
 	int32 queue_id;
 
-	if (pqGetInt(&queue_id, 4, conn))
+	if (pqGetInt(&queue_id, sizeof(ggMetadataQueueId), conn))
 	{
 		free(chunk);
 		return 1;

--- a/src/interfaces/libpq/libpq-fe.h
+++ b/src/interfaces/libpq/libpq-fe.h
@@ -626,7 +626,7 @@ typedef struct ggMetadataChunk
 	char   payload[];
 } ggMetadataChunk;
 
-typedef void (*PQmetadataReceiver) (void *arg, ggMetadataChunk *);
+typedef void (*PQmetadataReceiver) (void *arg, ggMetadataChunk *, uint32);
 typedef void (*PQmetadataProcessor) (void *arg, ggMetadataChunk *);
 
 extern PQmetadataReceiver PQsetMetadataReceiver(PGconn *conn,

--- a/src/interfaces/libpq/libpq-fe.h
+++ b/src/interfaces/libpq/libpq-fe.h
@@ -626,7 +626,8 @@ typedef struct ggMetadataChunk
 	char   payload[];
 } ggMetadataChunk;
 
-typedef void (*PQmetadataReceiver) (void *arg, ggMetadataChunk *, uint32);
+typedef unsigned int ggMetadataQueueId;
+typedef void (*PQmetadataReceiver) (void *arg, ggMetadataChunk *, ggMetadataQueueId);
 typedef void (*PQmetadataProcessor) (void *arg, ggMetadataChunk *);
 
 extern PQmetadataReceiver PQsetMetadataReceiver(PGconn *conn,

--- a/src/test/modules/test_metadata/expected/test_metadata.out
+++ b/src/test/modules/test_metadata/expected/test_metadata.out
@@ -1,6 +1,11 @@
 create extension if not exists test_metadata;
+-- Create two queues
+SELECT test_create_metadata_queue() as queue1
+\gset
+SELECT test_create_metadata_queue() as queue2
+\gset
 -- Test on all segments
-SELECT gp_segment_id, test_send_metadata(150, gp_segment_id)
+SELECT gp_segment_id, test_send_metadata(150, gp_segment_id, :queue1)
     FROM gp_dist_random('gp_id');
 WARNING:  Sending custom metadata...
 WARNING:  Custom metadata sent!
@@ -12,7 +17,7 @@ WARNING:  Custom metadata sent!
 (3 rows)
 
 -- Read metadata collected on coordinator
-SELECT test_check_metadata();
+SELECT test_check_metadata(:queue1);
 WARNING:  Custom metadata received, len=150, id=0
 WARNING:  Custom metadata received, len=150, id=1
 WARNING:  Custom metadata received, len=150, id=2
@@ -21,22 +26,28 @@ WARNING:  Custom metadata received, len=150, id=2
                    3
 (1 row)
 
+SELECT test_check_metadata(:queue2);
+ test_check_metadata 
+---------------------
+                   0
+(1 row)
+
 -- Clean metadata on coordinator
-SELECT test_clean_metadata();
+SELECT test_clean_metadata(:queue1);
  test_clean_metadata 
 ---------------------
                    0
 (1 row)
 
 -- Check that metadata has been cleaned on coordinator
-SELECT test_check_metadata();
+SELECT test_check_metadata(:queue1);
  test_check_metadata 
 ---------------------
                    0
 (1 row)
 
 -- Test longer metadata
-SELECT gp_segment_id, test_send_metadata(150000, gp_segment_id)
+SELECT gp_segment_id, test_send_metadata(150000, gp_segment_id, :queue1)
     FROM gp_dist_random('gp_id');
 WARNING:  Sending custom metadata...
 WARNING:  Custom metadata sent!
@@ -47,7 +58,7 @@ WARNING:  Custom metadata sent!
              2 |             150000
 (3 rows)
 
-SELECT gp_segment_id, test_send_metadata(1500000, gp_segment_id)
+SELECT gp_segment_id, test_send_metadata(1500000, gp_segment_id, :queue2)
     FROM gp_dist_random('gp_id');
 WARNING:  Sending custom metadata...
 WARNING:  Custom metadata sent!
@@ -58,7 +69,7 @@ WARNING:  Custom metadata sent!
              2 |            1500000
 (3 rows)
 
-SELECT gp_segment_id, test_send_metadata(15000000, gp_segment_id)
+SELECT gp_segment_id, test_send_metadata(15000000, gp_segment_id, :queue1)
     FROM gp_dist_random('gp_id');
 WARNING:  Sending custom metadata...
 WARNING:  Custom metadata sent!
@@ -69,7 +80,7 @@ WARNING:  Custom metadata sent!
              2 |           15000000
 (3 rows)
 
-SELECT gp_segment_id, test_send_metadata(150000000, gp_segment_id)
+SELECT gp_segment_id, test_send_metadata(150000000, gp_segment_id, :queue2)
     FROM gp_dist_random('gp_id');
 WARNING:  Sending custom metadata...
 WARNING:  Custom metadata sent!
@@ -80,7 +91,7 @@ WARNING:  Custom metadata sent!
              2 |          150000000
 (3 rows)
 
-SELECT gp_segment_id, test_send_empty_metadata()
+SELECT gp_segment_id, test_send_empty_metadata(:queue1)
     FROM gp_dist_random('gp_id');
 WARNING:  Sending empty metadata...
 WARNING:  Empty metadata sent!
@@ -92,48 +103,91 @@ WARNING:  Empty metadata sent!
 (3 rows)
 
 -- Read metadata collected on coordinator
-SELECT test_check_metadata();
+SELECT test_check_metadata(:queue1);
 WARNING:  Custom metadata received, len=0, id=-1
 WARNING:  Custom metadata received, len=0, id=-1
 WARNING:  Custom metadata received, len=0, id=-1
-WARNING:  Custom metadata received, len=150000000, id=0
 WARNING:  Custom metadata received, len=15000000, id=0
-WARNING:  Custom metadata received, len=1500000, id=0
 WARNING:  Custom metadata received, len=150000, id=0
-WARNING:  Custom metadata received, len=150000000, id=1
 WARNING:  Custom metadata received, len=15000000, id=1
-WARNING:  Custom metadata received, len=1500000, id=1
 WARNING:  Custom metadata received, len=150000, id=1
-WARNING:  Custom metadata received, len=150000000, id=2
 WARNING:  Custom metadata received, len=15000000, id=2
-WARNING:  Custom metadata received, len=1500000, id=2
 WARNING:  Custom metadata received, len=150000, id=2
  test_check_metadata 
 ---------------------
-                  15
+                   9
 (1 row)
 
-SELECT test_count_metadata();
+SELECT test_check_metadata(:queue2);
+WARNING:  Custom metadata received, len=150000000, id=0
+WARNING:  Custom metadata received, len=1500000, id=0
+WARNING:  Custom metadata received, len=150000000, id=1
+WARNING:  Custom metadata received, len=1500000, id=1
+WARNING:  Custom metadata received, len=150000000, id=2
+WARNING:  Custom metadata received, len=1500000, id=2
+ test_check_metadata 
+---------------------
+                   6
+(1 row)
+
+SELECT test_count_metadata(:queue1);
  test_count_metadata 
 ---------------------
-                  15
+                   9
 (1 row)
 
-SELECT test_clean_metadata();
+SELECT test_count_metadata(:queue2);
+ test_count_metadata 
+---------------------
+                   6
+(1 row)
+
+SELECT test_clean_metadata(:queue1);
  test_clean_metadata 
 ---------------------
                    0
 (1 row)
 
-SELECT test_check_metadata();
+SELECT test_clean_metadata(:queue2);
+ test_clean_metadata 
+---------------------
+                   0
+(1 row)
+
+SELECT test_check_metadata(:queue1);
  test_check_metadata 
 ---------------------
                    0
 (1 row)
 
-SELECT test_count_metadata();
+SELECT test_check_metadata(:queue2);
+ test_check_metadata 
+---------------------
+                   0
+(1 row)
+
+SELECT test_count_metadata(:queue1);
  test_count_metadata 
 ---------------------
                    0
+(1 row)
+
+SELECT test_count_metadata(:queue2);
+ test_count_metadata 
+---------------------
+                   0
+(1 row)
+
+-- Delete two queues
+SELECT test_delete_metadata_queue(:queue1);
+ test_delete_metadata_queue 
+----------------------------
+                          0
+(1 row)
+
+SELECT test_delete_metadata_queue(:queue2);
+ test_delete_metadata_queue 
+----------------------------
+                          0
 (1 row)
 

--- a/src/test/modules/test_metadata/sql/test_metadata.sql
+++ b/src/test/modules/test_metadata/sql/test_metadata.sql
@@ -1,42 +1,58 @@
 
 create extension if not exists test_metadata;
 
+-- Create two queues
+SELECT test_create_metadata_queue() as queue1
+\gset
+SELECT test_create_metadata_queue() as queue2
+\gset
+
 -- Test on all segments
-SELECT gp_segment_id, test_send_metadata(150, gp_segment_id)
+SELECT gp_segment_id, test_send_metadata(150, gp_segment_id, :queue1)
     FROM gp_dist_random('gp_id');
 
 -- Read metadata collected on coordinator
-SELECT test_check_metadata();
+SELECT test_check_metadata(:queue1);
+SELECT test_check_metadata(:queue2);
 
 -- Clean metadata on coordinator
-SELECT test_clean_metadata();
+SELECT test_clean_metadata(:queue1);
 
 -- Check that metadata has been cleaned on coordinator
-SELECT test_check_metadata();
+SELECT test_check_metadata(:queue1);
 
 -- Test longer metadata
-SELECT gp_segment_id, test_send_metadata(150000, gp_segment_id)
+SELECT gp_segment_id, test_send_metadata(150000, gp_segment_id, :queue1)
     FROM gp_dist_random('gp_id');
 
-SELECT gp_segment_id, test_send_metadata(1500000, gp_segment_id)
+SELECT gp_segment_id, test_send_metadata(1500000, gp_segment_id, :queue2)
     FROM gp_dist_random('gp_id');
 
-SELECT gp_segment_id, test_send_metadata(15000000, gp_segment_id)
+SELECT gp_segment_id, test_send_metadata(15000000, gp_segment_id, :queue1)
     FROM gp_dist_random('gp_id');
 
-SELECT gp_segment_id, test_send_metadata(150000000, gp_segment_id)
+SELECT gp_segment_id, test_send_metadata(150000000, gp_segment_id, :queue2)
     FROM gp_dist_random('gp_id');
 
-SELECT gp_segment_id, test_send_empty_metadata()
+SELECT gp_segment_id, test_send_empty_metadata(:queue1)
     FROM gp_dist_random('gp_id');
 
 -- Read metadata collected on coordinator
-SELECT test_check_metadata();
+SELECT test_check_metadata(:queue1);
+SELECT test_check_metadata(:queue2);
 
-SELECT test_count_metadata();
+SELECT test_count_metadata(:queue1);
+SELECT test_count_metadata(:queue2);
 
-SELECT test_clean_metadata();
+SELECT test_clean_metadata(:queue1);
+SELECT test_clean_metadata(:queue2);
 
-SELECT test_check_metadata();
+SELECT test_check_metadata(:queue1);
+SELECT test_check_metadata(:queue2);
 
-SELECT test_count_metadata();
+SELECT test_count_metadata(:queue1);
+SELECT test_count_metadata(:queue2);
+
+-- Delete two queues
+SELECT test_delete_metadata_queue(:queue1);
+SELECT test_delete_metadata_queue(:queue2);

--- a/src/test/modules/test_metadata/test_metadata--1.0.sql
+++ b/src/test/modules/test_metadata/test_metadata--1.0.sql
@@ -1,25 +1,35 @@
 -- test_metadata--1.0.sql
-CREATE FUNCTION test_send_metadata(IN len int4, IN gp_id int4)
+CREATE FUNCTION test_create_metadata_queue()
 RETURNS integer
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-CREATE FUNCTION test_send_empty_metadata()
+CREATE FUNCTION test_delete_metadata_queue(IN queue_id int4)
 RETURNS integer
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-CREATE FUNCTION test_check_metadata()
+CREATE FUNCTION test_send_metadata(IN len int4, IN gp_id int4, IN queue_id int4)
 RETURNS integer
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-CREATE FUNCTION test_count_metadata()
+CREATE FUNCTION test_send_empty_metadata(IN queue_id int4)
 RETURNS integer
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-CREATE FUNCTION test_clean_metadata()
+CREATE FUNCTION test_check_metadata(IN queue_id int4)
+RETURNS integer
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION test_count_metadata(IN queue_id int4)
+RETURNS integer
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION test_clean_metadata(IN queue_id int4)
 RETURNS integer
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;

--- a/src/test/modules/test_metadata/test_metadata.c
+++ b/src/test/modules/test_metadata/test_metadata.c
@@ -8,18 +8,41 @@
 
 PG_MODULE_MAGIC;
 
+PG_FUNCTION_INFO_V1(test_create_metadata_queue);
+PG_FUNCTION_INFO_V1(test_delete_metadata_queue);
 PG_FUNCTION_INFO_V1(test_send_empty_metadata);
 PG_FUNCTION_INFO_V1(test_send_metadata);
 PG_FUNCTION_INFO_V1(test_check_metadata);
 PG_FUNCTION_INFO_V1(test_count_metadata);
 PG_FUNCTION_INFO_V1(test_clean_metadata);
 
+Datum
+test_create_metadata_queue(PG_FUNCTION_ARGS)
+{
+	ggMetadataQueueId queue_id = PQMetadataNextQueueId();
+
+	PQCreateMetadataQueue(queue_id);
+
+	PG_RETURN_INT32(queue_id);
+}
+
+Datum
+test_delete_metadata_queue(PG_FUNCTION_ARGS)
+{
+	ggMetadataQueueId queue_id = PG_GETARG_INT32(0);
+
+	PQDeleteMetadataQueue(queue_id);
+
+	PG_RETURN_INT32(0);
+}
 
 Datum
 test_send_empty_metadata(PG_FUNCTION_ARGS)
 {
+	ggMetadataQueueId queue_id = PG_GETARG_INT32(0);
+
 	elog(WARNING, "Sending empty metadata...");
-	pq_metadatasend("", 0);
+	pq_metadatasend("", 0, queue_id);
 	elog(WARNING, "Empty metadata sent!");
 	PG_RETURN_INT32(0);
 }
@@ -27,8 +50,9 @@ test_send_empty_metadata(PG_FUNCTION_ARGS)
 Datum
 test_send_metadata(PG_FUNCTION_ARGS)
 {
-	uint32		len = PG_GETARG_UINT32(0);
-	uint32		id = PG_GETARG_UINT32(1);
+	uint32				len = PG_GETARG_UINT32(0);
+	uint32				id = PG_GETARG_UINT32(1);
+	ggMetadataQueueId 	queue_id = PG_GETARG_INT32(2);
 
 	char	   *metadata = palloc(len);
 
@@ -44,7 +68,7 @@ test_send_metadata(PG_FUNCTION_ARGS)
 
 	/* Send custom metadata */
 	elog(WARNING, "Sending custom metadata...");
-	pq_metadatasend(metadata, len);
+	pq_metadatasend(metadata, len, queue_id);
 	elog(WARNING, "Custom metadata sent!");
 
 	pfree(metadata);
@@ -57,6 +81,7 @@ Datum
 test_check_metadata(PG_FUNCTION_ARGS)
 {
 	Assert(Gp_role == GP_ROLE_DISPATCH);
+	ggMetadataQueueId queue_id = PG_GETARG_INT32(0);
 
 	/*
 	 * Metadata records are unordered for the each query, so to make
@@ -69,7 +94,7 @@ test_check_metadata(PG_FUNCTION_ARGS)
 
 	for (int seg_id = -1; seg_id < numsegments; seg_id++)
 	{
-		ggMetadataChunkIterator it = PQMetadataWalk();
+		ggMetadataChunkIterator it = PQMetadataWalk(queue_id);
 
 		for (; it; it = PQgetNextMetadata(it))
 		{
@@ -107,7 +132,8 @@ test_check_metadata(PG_FUNCTION_ARGS)
 Datum
 test_count_metadata(PG_FUNCTION_ARGS)
 {
-	int			count = PQgetMetadataCount();
+	ggMetadataQueueId	queue_id = PG_GETARG_INT32(0);
+	int					count = PQgetMetadataCount(queue_id);
 
 	PG_RETURN_INT32(count);
 }
@@ -115,6 +141,7 @@ test_count_metadata(PG_FUNCTION_ARGS)
 Datum
 test_clean_metadata(PG_FUNCTION_ARGS)
 {
-	PQCleanMetadata();
+	ggMetadataQueueId queue_id = PG_GETARG_INT32(0);
+	PQCleanMetadata(queue_id);
 	PG_RETURN_INT32(0);
 }


### PR DESCRIPTION
Add separate queue support for the communication channel

Multiple extensions might use the metadata communication channel, possibly in
the same session and at the same time. To avoid metadata messages mixing
between extensions, we should add an API to create/delete separate message
queues for extensions. Existing APIs should also be adjusted to work with
separate queues instead of a global one.

Each queue is identified with its own queue_id. Since extensions might want to
preallocate this id in advance (for example, to pass it from master to
segments during planning stage), allocating a queue_id is separate from
actually creating a queue. All actions with metadata queue now require a
queue_id.
