### PR TITLE
GG-259: Orca always scans replicated tables on the 0 segment for singleton slices

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -1100,17 +1100,6 @@ gpdb::GetGPSegmentCount(void)
 	return 0;
 }
 
-int
-gpdb::GetGPSessionId(void)
-{
-	GP_WRAP_START;
-	{
-		return gp_session_id;
-	}
-	GP_WRAP_END;
-	return 0;
-}
-
 bool
 gpdb::HeapAttIsNull(HeapTuple tup, int attno)
 {

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -1100,6 +1100,17 @@ gpdb::GetGPSegmentCount(void)
 	return 0;
 }
 
+int
+gpdb::GetGPSessionId(void)
+{
+	GP_WRAP_START;
+	{
+		return gp_session_id;
+	}
+	GP_WRAP_END;
+	return 0;
+}
+
 bool
 gpdb::HeapAttIsNull(HeapTuple tup, int attno)
 {

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -798,12 +798,16 @@ COptTasks::OptimizeTask(void *ptr)
 			CMDAccessor mda(mp, CMDCache::Pcache(), default_sysid,
 							relcache_provider);
 
+			// For some unknown reason the code below assumes that the following values are
+			// unsigned ints, when in reality they are signed.
+			// It easier to do calculation this way, though, so let it be.
 			ULONG num_segments = gpdb::GetGPSegmentCount();
 			ULONG num_segments_for_costing = optimizer_segments;
 			if (0 == num_segments_for_costing)
 			{
 				num_segments_for_costing = num_segments;
 			}
+			ULONG session_id = gpdb::GetGPSessionId();
 
 			CAutoP<CTranslatorQueryToDXL> query_to_dxl_translator;
 			query_to_dxl_translator = CTranslatorQueryToDXL::QueryToDXLInstance(
@@ -839,7 +843,7 @@ COptTasks::OptimizeTask(void *ptr)
 
 			plan_dxl = COptimizer::PdxlnOptimize(
 				mp, &mda, query_dxl, query_output_dxlnode_array,
-				cte_dxlnode_array, expr_evaluator, num_segments, gp_session_id,
+				cte_dxlnode_array, expr_evaluator, num_segments, session_id,
 				MyProc->queryCommandId, search_strategy_arr, optimizer_config);
 
 			if (opt_ctxt->m_should_serialize_plan_dxl)

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -807,7 +807,6 @@ COptTasks::OptimizeTask(void *ptr)
 			{
 				num_segments_for_costing = num_segments;
 			}
-			ULONG session_id = (ULONG) gpdb::GetGPSessionId();
 
 			CAutoP<CTranslatorQueryToDXL> query_to_dxl_translator;
 			query_to_dxl_translator = CTranslatorQueryToDXL::QueryToDXLInstance(
@@ -843,7 +842,7 @@ COptTasks::OptimizeTask(void *ptr)
 
 			plan_dxl = COptimizer::PdxlnOptimize(
 				mp, &mda, query_dxl, query_output_dxlnode_array,
-				cte_dxlnode_array, expr_evaluator, num_segments, session_id,
+				cte_dxlnode_array, expr_evaluator, num_segments, (ULONG) gp_session_id,
 				MyProc->queryCommandId, search_strategy_arr, optimizer_config);
 
 			if (opt_ctxt->m_should_serialize_plan_dxl)

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -807,7 +807,7 @@ COptTasks::OptimizeTask(void *ptr)
 			{
 				num_segments_for_costing = num_segments;
 			}
-			ULONG session_id = gpdb::GetGPSessionId();
+			ULONG session_id = (ULONG) gpdb::GetGPSessionId();
 
 			CAutoP<CTranslatorQueryToDXL> query_to_dxl_translator;
 			query_to_dxl_translator = CTranslatorQueryToDXL::QueryToDXLInstance(

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -842,8 +842,9 @@ COptTasks::OptimizeTask(void *ptr)
 
 			plan_dxl = COptimizer::PdxlnOptimize(
 				mp, &mda, query_dxl, query_output_dxlnode_array,
-				cte_dxlnode_array, expr_evaluator, num_segments, (ULONG) gp_session_id,
-				MyProc->queryCommandId, search_strategy_arr, optimizer_config);
+				cte_dxlnode_array, expr_evaluator, num_segments,
+				(ULONG) gp_session_id, MyProc->queryCommandId,
+				search_strategy_arr, optimizer_config);
 
 			if (opt_ctxt->m_should_serialize_plan_dxl)
 			{

--- a/src/backend/gporca/data/dxl/minidump/ArrayCoerceCast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ArrayCoerceCast.mdp
@@ -311,7 +311,7 @@
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
-              <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+              <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelAppend-ConstTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelAppend-ConstTable.mdp
@@ -250,7 +250,7 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+          <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="0.000015" Rows="1.000000" Width="4"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelAppend-Insert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelAppend-Insert.mdp
@@ -229,7 +229,7 @@ INSERT INTO t VALUES (11),(12),(13);
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="0.000014" Rows="1.000000" Width="4"/>
               </dxl:Properties>
@@ -258,7 +258,7 @@ INSERT INTO t VALUES (11),(12),(13);
                 <dxl:OneTimeFilter/>
               </dxl:Result>
             </dxl:RedistributeMotion>
-            <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="0.000014" Rows="1.000000" Width="4"/>
               </dxl:Properties>
@@ -287,7 +287,7 @@ INSERT INTO t VALUES (11),(12),(13);
                 <dxl:OneTimeFilter/>
               </dxl:Result>
             </dxl:RedistributeMotion>
-            <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="0.000014" Rows="1.000000" Width="4"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
@@ -758,7 +758,7 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="438.412150" Rows="1.000000" Width="8"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
@@ -729,7 +729,7 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2">
+          <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="438.412171" Rows="1.000000" Width="8"/>
             </dxl:Properties>
@@ -827,7 +827,7 @@
                         </dxl:Columns>
                       </dxl:TableDescriptor>
                     </dxl:TableScan>
-                    <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+                    <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                       <dxl:Properties>
                         <dxl:Cost StartupCost="0" TotalCost="0.014387" Rows="1000.000000" Width="4"/>
                       </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-random-distr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-random-distr.mdp
@@ -248,7 +248,7 @@
               <dxl:JoinFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:JoinFilter>
-              <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+              <dxl:BroadcastMotion InputSegments="1" OutputSegments="0,1,2">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="0.437600" Rows="3000.000000" Width="8"/>
                 </dxl:Properties>
@@ -283,7 +283,7 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+                <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="0.014387" Rows="1000.000000" Width="4"/>
                   </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-random-distributed-from-replicated-distributed-table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-random-distributed-from-replicated-distributed-table.mdp
@@ -278,7 +278,7 @@
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="1.000000" Width="12"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-with-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-with-Limit.mdp
@@ -700,7 +700,7 @@
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="848.400000" Rows="10000000.000000" Width="8"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-with-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-with-Limit.mdp
@@ -674,7 +674,7 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2">
+          <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="1136.133333" Rows="10000000.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CTAS_OrderedAgg_multiple_cols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS_OrderedAgg_multiple_cols.mdp
@@ -2229,7 +2229,7 @@ EXPLAIN CREATE TABLE test AS
                       </dxl:Sort>
                     </dxl:Aggregate>
                   </dxl:CTEProducer>
-                  <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2">
+                  <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2">
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="2778516239352.373535" Rows="1.000000" Width="72"/>
                     </dxl:Properties>
@@ -2471,7 +2471,7 @@ EXPLAIN CREATE TABLE test AS
                                     </dxl:ProjList>
                                     <dxl:Filter/>
                                     <dxl:OneTimeFilter/>
-                                    <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+                                    <dxl:BroadcastMotion InputSegments="1" OutputSegments="0,1,2">
                                       <dxl:Properties>
                                         <dxl:Cost StartupCost="0" TotalCost="431.001133" Rows="3.000000" Width="8"/>
                                       </dxl:Properties>
@@ -2716,7 +2716,7 @@ EXPLAIN CREATE TABLE test AS
                                       </dxl:ProjList>
                                       <dxl:Filter/>
                                       <dxl:OneTimeFilter/>
-                                      <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+                                      <dxl:BroadcastMotion InputSegments="1" OutputSegments="0,1,2">
                                         <dxl:Properties>
                                           <dxl:Cost StartupCost="0" TotalCost="431.001133" Rows="3.000000" Width="8"/>
                                         </dxl:Properties>
@@ -2963,7 +2963,7 @@ EXPLAIN CREATE TABLE test AS
                                     </dxl:ProjList>
                                     <dxl:Filter/>
                                     <dxl:OneTimeFilter/>
-                                    <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+                                    <dxl:BroadcastMotion InputSegments="1" OutputSegments="0,1,2">
                                       <dxl:Properties>
                                         <dxl:Cost StartupCost="0" TotalCost="431.001133" Rows="3.000000" Width="8"/>
                                       </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CTAS_OrderedAgg_multiple_cols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS_OrderedAgg_multiple_cols.mdp
@@ -2397,7 +2397,7 @@ EXPLAIN CREATE TABLE test AS
                                 <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
-                            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="1324037.570275" Rows="99.999999" Width="20"/>
                               </dxl:Properties>
@@ -2500,7 +2500,7 @@ EXPLAIN CREATE TABLE test AS
                                           </dxl:ProjElem>
                                         </dxl:ProjList>
                                         <dxl:Filter/>
-                                        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                                        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                                           <dxl:Properties>
                                             <dxl:Cost StartupCost="0" TotalCost="431.000702" Rows="1.000000" Width="8"/>
                                           </dxl:Properties>
@@ -2642,7 +2642,7 @@ EXPLAIN CREATE TABLE test AS
                                   <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
-                              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                                 <dxl:Properties>
                                   <dxl:Cost StartupCost="0" TotalCost="1324037.570275" Rows="99.999999" Width="20"/>
                                 </dxl:Properties>
@@ -2745,7 +2745,7 @@ EXPLAIN CREATE TABLE test AS
                                             </dxl:ProjElem>
                                           </dxl:ProjList>
                                           <dxl:Filter/>
-                                          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                                          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                                             <dxl:Properties>
                                               <dxl:Cost StartupCost="0" TotalCost="431.000702" Rows="1.000000" Width="8"/>
                                             </dxl:Properties>
@@ -2889,7 +2889,7 @@ EXPLAIN CREATE TABLE test AS
                                 <dxl:Ident ColId="89" ColName="ColRef_0089" TypeMdid="0.20.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
-                            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="1324037.570275" Rows="99.999999" Width="20"/>
                               </dxl:Properties>
@@ -2992,7 +2992,7 @@ EXPLAIN CREATE TABLE test AS
                                           </dxl:ProjElem>
                                         </dxl:ProjList>
                                         <dxl:Filter/>
-                                        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                                        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                                           <dxl:Properties>
                                             <dxl:Cost StartupCost="0" TotalCost="431.000702" Rows="1.000000" Width="8"/>
                                           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CTE15HAReplicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE15HAReplicated.mdp
@@ -471,7 +471,7 @@
                 <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
-            <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.001474" Rows="1.000000" Width="263"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CTE15Replicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE15Replicated.mdp
@@ -501,7 +501,7 @@
                 <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
-            <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.001474" Rows="1.000000" Width="263"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CTE2HAReplicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE2HAReplicated.mdp
@@ -630,7 +630,7 @@
                   <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:Comparison>
               </dxl:HashCondList>
-              <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+              <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.001474" Rows="1.000000" Width="263"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CTE2Replicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE2Replicated.mdp
@@ -660,7 +660,7 @@
                   <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:Comparison>
               </dxl:HashCondList>
-              <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+              <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.001474" Rows="1.000000" Width="263"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-ComputeScalar-With-Outerref.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-ComputeScalar-With-Outerref.mdp
@@ -440,7 +440,7 @@
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
-                                <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                                <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
                                   </dxl:Properties>
@@ -481,7 +481,7 @@
                         </dxl:Comparison>
                       </dxl:Filter>
                       <dxl:OneTimeFilter/>
-                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
                         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-ComputeScalar-With-Outerref.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-ComputeScalar-With-Outerref.mdp
@@ -380,7 +380,7 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
-              <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+              <dxl:BroadcastMotion InputSegments="1" OutputSegments="0,1,2">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="1324032.414668" Rows="3.000000" Width="1"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-Filter-With-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-Filter-With-OuterRef.mdp
@@ -401,7 +401,7 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
-              <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+              <dxl:BroadcastMotion InputSegments="1" OutputSegments="0,1,2">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="1324032.232601" Rows="3.000000" Width="1"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-Filter-With-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-Filter-With-OuterRef.mdp
@@ -464,7 +464,7 @@
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                                 <dxl:Properties>
                                   <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
                                 </dxl:Properties>
@@ -504,7 +504,7 @@
                         </dxl:SubPlan>
                       </dxl:Filter>
                       <dxl:OneTimeFilter/>
-                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
                         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-Replicated-Input.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-Replicated-Input.mdp
@@ -416,7 +416,7 @@ WHERE  sach_vsnr = 465132477;
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53" OutputSegments="0">
+              <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53" OutputSegments="1">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000067" Rows="1.000000" Width="6"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-Replicated-Input.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-Replicated-Input.mdp
@@ -353,7 +353,7 @@ WHERE  sach_vsnr = 465132477;
             <dxl:Column ColId="21" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53">
+        <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000213" Rows="1.000000" Width="14"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-UnionAll-With-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-UnionAll-With-OuterRef.mdp
@@ -508,7 +508,7 @@
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
-                                <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                                <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="431.000073" Rows="2.000000" Width="4"/>
                                   </dxl:Properties>
@@ -555,7 +555,7 @@
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                                 <dxl:Properties>
                                   <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="1.000000" Width="4"/>
                                 </dxl:Properties>
@@ -595,7 +595,7 @@
                         </dxl:SubPlan>
                       </dxl:Filter>
                       <dxl:OneTimeFilter/>
-                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
                         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-UnionAll-With-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-UnionAll-With-OuterRef.mdp
@@ -438,7 +438,7 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
-              <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+              <dxl:BroadcastMotion InputSegments="1" OutputSegments="0,1,2">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="1765376.338708" Rows="3.000000" Width="1"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-UnionAll-With-Universal-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-UnionAll-With-Universal-Child.mdp
@@ -686,7 +686,7 @@
             <dxl:Column ColId="18" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
+        <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.001501" Rows="10.000000" Width="8"/>
           </dxl:Properties>
@@ -769,7 +769,7 @@
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:OneTimeFilter/>
-                      <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+                      <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-UnionAll-With-Universal-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-UnionAll-With-Universal-Child.mdp
@@ -728,7 +728,7 @@
                   <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.001173" Rows="10.000000" Width="4"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-CorrelatedNLJ-With-Universal-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-CorrelatedNLJ-With-Universal-Child.mdp
@@ -353,7 +353,7 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="1.000000" Width="4"/>
                         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-CorrelatedNLJ-With-Universal-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-CorrelatedNLJ-With-Universal-Child.mdp
@@ -292,7 +292,7 @@
             <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
+        <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="882688.047511" Rows="1.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-HJ-And-UniversalChild.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-HJ-And-UniversalChild.mdp
@@ -802,7 +802,7 @@
                     <dxl:Cost StartupCost="0" TotalCost="431.000414" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList/>
-                  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="431.000413" Rows="1.000000" Width="1"/>
                     </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-HJ-And-UniversalChild.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-HJ-And-UniversalChild.mdp
@@ -790,7 +790,7 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
-              <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+              <dxl:BroadcastMotion InputSegments="1" OutputSegments="0,1,2">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000467" Rows="3.000000" Width="1"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-Join-With-Universal-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-Join-With-Universal-Child.mdp
@@ -310,7 +310,7 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="1.000000" Width="4"/>
                   </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-Join-With-Universal-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-Join-With-Universal-Child.mdp
@@ -242,7 +242,7 @@
             <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
+        <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="882688.076901" Rows="2.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-WindowFunc-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-WindowFunc-OuterRef.mdp
@@ -455,7 +455,7 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="431.000011" Rows="1.000000" Width="1"/>
                         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-WindowFunc-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-WindowFunc-OuterRef.mdp
@@ -401,7 +401,7 @@
                   </dxl:Cast>
                 </dxl:Comparison>
               </dxl:HashCondList>
-              <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
+              <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000139" Rows="1.000000" Width="8"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DMLCollapseProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DMLCollapseProject.mdp
@@ -377,7 +377,7 @@
             <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1">
+        <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="862.000327" Rows="1.000000" Width="32"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DMLCollapseProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DMLCollapseProject.mdp
@@ -493,7 +493,7 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:GatherMotion InputSegments="0,1" OutputSegments="0">
+                    <dxl:GatherMotion InputSegments="0,1" OutputSegments="1">
                       <dxl:Properties>
                         <dxl:Cost StartupCost="0" TotalCost="431.000100" Rows="1.000000" Width="8"/>
                       </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
@@ -861,7 +861,7 @@
                               <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
-                          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                             <dxl:Properties>
                               <dxl:Cost StartupCost="0" TotalCost="431.940767" Rows="10.000000" Width="4"/>
                             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
@@ -841,7 +841,7 @@
                       </dxl:SortingColumnList>
                       <dxl:LimitCount/>
                       <dxl:LimitOffset/>
-                      <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2">
+                      <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="431.940911" Rows="10.000000" Width="4"/>
                         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ForeignPartOneTimeFilterDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ForeignPartOneTimeFilterDPE.mdp
@@ -419,7 +419,7 @@
               <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+          <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000566" Rows="10.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ForeignScanExecLocAnyJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ForeignScanExecLocAnyJoin.mdp
@@ -318,7 +318,7 @@
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+          <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-Replicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-Replicated.mdp
@@ -302,7 +302,7 @@
             </dxl:SortingColumnList>
             <dxl:LimitCount/>
             <dxl:LimitOffset/>
-            <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="8"/>
               </dxl:Properties>
@@ -368,7 +368,7 @@
             </dxl:SortingColumnList>
             <dxl:LimitCount/>
             <dxl:LimitOffset/>
-            <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="8"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
@@ -404,7 +404,7 @@ Table X (int i, int j) is distributed by i, column i has index
           <dxl:JoinFilter>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
           </dxl:JoinFilter>
-          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+          <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1" DuplicateSensitive="true">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="0.000018" Rows="1.000000" Width="4"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/InsertCheckConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertCheckConstraint.mdp
@@ -294,7 +294,7 @@
             <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+        <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1" DuplicateSensitive="true">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="0.000116" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/InsertConstTuple.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertConstTuple.mdp
@@ -230,7 +230,7 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+          <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1" DuplicateSensitive="true">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="0.000031" Rows="1.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/InsertConstTupleRandomDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertConstTupleRandomDistribution.mdp
@@ -260,7 +260,7 @@
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/InsertDirectedDispatchNullValue.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertDirectedDispatchNullValue.mdp
@@ -233,7 +233,7 @@
             <dxl:Column ColId="14" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+        <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1" DuplicateSensitive="true">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="0.000096" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/InsertIntoNonNullAfterDroppingColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertIntoNonNullAfterDroppingColumn.mdp
@@ -200,7 +200,7 @@ EXPLAIN INSERT INTO ColumnMapping VALUES (NULL);
           <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
       </dxl:TableDescriptor>
-      <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+      <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="8"/>
         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/InsertNULLNotNULLConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertNULLNotNULLConstraint.mdp
@@ -185,7 +185,7 @@
             <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+        <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1" DuplicateSensitive="true">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="0.000039" Rows="1.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/InsertNoEnforceConstraints.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertNoEnforceConstraints.mdp
@@ -241,7 +241,7 @@ insert into constraints_tab values (NULL, -1);
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+          <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="0.000044" Rows="1.000000" Width="12"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/InsertNonSingleton.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertNonSingleton.mdp
@@ -321,7 +321,7 @@ EXPLAIN INSERT INTO snackbox SELECT a FROM (SELECT c FROM hottoast LIMIT 3) hott
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+          <dxl:BroadcastMotion InputSegments="1" OutputSegments="0,1,2">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="862.000752" Rows="3.000000" Width="4"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/InsertReplicatedIntoSerialHashDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertReplicatedIntoSerialHashDistributedTable.mdp
@@ -346,7 +346,7 @@ EXPLAIN (COSTS OFF) INSERT INTO distributed_table (val1, val2) SELECT val1, val2
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
+          <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.029440" Rows="100.000000" Width="24"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/InsertWithDroppedCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertWithDroppedCol.mdp
@@ -250,7 +250,7 @@
             <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+        <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1" DuplicateSensitive="true">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="0.000058" Rows="1.000000" Width="12"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/JoinOnReplicatedUniversal.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOnReplicatedUniversal.mdp
@@ -194,7 +194,7 @@
       </dxl:LogicalProject>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="6">
-      <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
+      <dxl:GatherMotion InputSegments="1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="882724.329545" Rows="1.000000" Width="8"/>
         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/LeftSemiJoinWithRepOuterTab.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftSemiJoinWithRepOuterTab.mdp
@@ -442,7 +442,7 @@
           </dxl:SubPlan>
         </dxl:Filter>
         <dxl:OneTimeFilter/>
-        <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
+        <dxl:GatherMotion InputSegments="1" OutputSegments="-1">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
@@ -708,7 +708,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
@@ -748,7 +748,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
@@ -788,7 +788,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
@@ -828,7 +828,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
@@ -868,7 +868,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
@@ -908,7 +908,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
@@ -948,7 +948,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
@@ -988,7 +988,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
@@ -1028,7 +1028,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
@@ -1068,7 +1068,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
@@ -1108,7 +1108,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/NLJ-Rewindability-CTAS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NLJ-Rewindability-CTAS.mdp
@@ -487,7 +487,7 @@
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="1324033.465142" Rows="1.000000" Width="8"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/NoPushdownPredicateWithCTEAnchor.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoPushdownPredicateWithCTEAnchor.mdp
@@ -1101,7 +1101,7 @@
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:OneTimeFilter/>
-                      <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+                      <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/NonSingleton.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NonSingleton.mdp
@@ -314,7 +314,7 @@ EXPLAIN SELECT a FROM snackbox JOIN (SELECT c FROM hottoast LIMIT 3) hottoast ON
                   <dxl:Ident ColId="8" ColName="c" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
+              <dxl:GatherMotion InputSegments="1" OutputSegments="-1">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ProjectSetFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ProjectSetFunction.mdp
@@ -281,7 +281,7 @@
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="0.000130" Rows="1.000000" Width="8"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ProjectWithConstant.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ProjectWithConstant.mdp
@@ -460,7 +460,7 @@
               </dxl:TableScan>
             </dxl:Result>
           </dxl:Result>
-          <dxl:RandomMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+          <dxl:RandomMotion InputSegments="1" OutputSegments="0,1" DuplicateSensitive="true">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PushSelectDownUnionAllOfCTG.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushSelectDownUnionAllOfCTG.mdp
@@ -365,7 +365,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
@@ -405,7 +405,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
@@ -445,7 +445,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
@@ -615,7 +615,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
@@ -655,7 +655,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
@@ -695,7 +695,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:OneTimeFilter/>
-                            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+                            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1" DuplicateSensitive="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedHashJoinReplicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedHashJoinReplicated.mdp
@@ -1025,7 +1025,7 @@
       </dxl:LogicalJoin>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="8">
-      <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
+      <dxl:GatherMotion InputSegments="1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.279678" Rows="100.000000" Width="16"/>
         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedJoinHashDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedJoinHashDistributedTable.mdp
@@ -1465,7 +1465,7 @@
               <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+          <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.005655" Rows="100.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedJoinRandomDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedJoinRandomDistributedTable.mdp
@@ -1067,7 +1067,7 @@
               <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+          <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.005655" Rows="100.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedLOJHashDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedLOJHashDistributedTable.mdp
@@ -1465,7 +1465,7 @@
               <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+          <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.005655" Rows="100.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedLOJRandomDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedLOJRandomDistributedTable.mdp
@@ -1067,7 +1067,7 @@
               <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+          <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.005655" Rows="100.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedLOJReplicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedLOJReplicated.mdp
@@ -1025,7 +1025,7 @@
       </dxl:LogicalJoin>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="7">
-      <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
+      <dxl:GatherMotion InputSegments="1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.302929" Rows="198.989800" Width="16"/>
         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedNLJReplicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedNLJReplicated.mdp
@@ -1023,7 +1023,7 @@
       </dxl:LogicalJoin>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="4">
-      <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
+      <dxl:GatherMotion InputSegments="1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1333704.411938" Rows="33333.333333" Width="16"/>
         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedTableAggregate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedTableAggregate.mdp
@@ -210,7 +210,7 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
+        <dxl:GatherMotion InputSegments="1" OutputSegments="-1">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.002365" Rows="1.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedTableCTE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedTableCTE.mdp
@@ -1471,7 +1471,7 @@
               <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+          <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.005655" Rows="100.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedTableGroupBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedTableGroupBy.mdp
@@ -993,7 +993,7 @@
       </dxl:LogicalGroupBy>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="12">
-      <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
+      <dxl:GatherMotion InputSegments="1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.029802" Rows="99.999999" Width="12"/>
         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedTableSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedTableSelect.mdp
@@ -577,7 +577,7 @@
       </dxl:LogicalSelect>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
+      <dxl:GatherMotion InputSegments="1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.008436" Rows="29.292900" Width="8"/>
         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/RightJoinBothReplicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RightJoinBothReplicated.mdp
@@ -694,7 +694,7 @@
       </dxl:LogicalJoin>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="7">
-      <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
+      <dxl:GatherMotion InputSegments="1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.223062" Rows="18.888880" Width="16"/>
         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/RightJoinReplicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RightJoinReplicated.mdp
@@ -1123,7 +1123,7 @@
             </dxl:TableDescriptor>
           </dxl:TableScan>
         </dxl:GatherMotion>
-        <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
+        <dxl:GatherMotion InputSegments="1" OutputSegments="-1">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.012522" Rows="100.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/SqlFuncDmlScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SqlFuncDmlScalar.mdp
@@ -342,7 +342,7 @@ LIMIT 999
                   <dxl:Ident ColId="8" ColName="yolo" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000076" Rows="1.000000" Width="4"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/SqlFuncDmlScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SqlFuncDmlScalar.mdp
@@ -300,7 +300,7 @@ LIMIT 999
             <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
+        <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/SqlFuncDmlTvf.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SqlFuncDmlTvf.mdp
@@ -365,7 +365,7 @@ LIMIT 999
                   <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="882704.983354" Rows="1000.000000" Width="8"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/SqlFuncDmlTvf.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SqlFuncDmlTvf.mdp
@@ -314,7 +314,7 @@ LIMIT 999
             <dxl:Column ColId="18" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
+        <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="882705.034463" Rows="999.000000" Width="12"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/TaintedReplicatedAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TaintedReplicatedAgg.mdp
@@ -287,7 +287,7 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+          <dxl:BroadcastMotion InputSegments="1" OutputSegments="0,1,2">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000241" Rows="3.000000" Width="4"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/TaintedReplicatedFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TaintedReplicatedFilter.mdp
@@ -285,7 +285,7 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+          <dxl:BroadcastMotion InputSegments="1" OutputSegments="0,1,2">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000498" Rows="3.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/TaintedReplicatedLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TaintedReplicatedLimit.mdp
@@ -275,7 +275,7 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+          <dxl:BroadcastMotion InputSegments="1" OutputSegments="0,1,2">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000245" Rows="3.000000" Width="4"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/TaintedReplicatedTablesCTE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TaintedReplicatedTablesCTE.mdp
@@ -379,7 +379,7 @@
               <dxl:Ident ColId="8" ColName="rank_desc" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
+          <dxl:GatherMotion InputSegments="1" OutputSegments="-1">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000333" Rows="1.000000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/TaintedReplicatedWindowAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TaintedReplicatedWindowAgg.mdp
@@ -290,7 +290,7 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+          <dxl:BroadcastMotion InputSegments="1" OutputSegments="0,1,2">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000241" Rows="3.000000" Width="4"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/Union-Distributed-Table-With-Const-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-Distributed-Table-With-Const-Table.mdp
@@ -394,7 +394,7 @@ Table X (int i, int j) is distributed by i
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+            <dxl:RandomMotion InputSegments="1" OutputSegments="0,1" DuplicateSensitive="true">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/Union-NOT-Plus-OR-Constraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-NOT-Plus-OR-Constraint.mdp
@@ -504,7 +504,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:OneTimeFilter/>
-                      <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+                      <dxl:RandomMotion InputSegments="1" OutputSegments="0,1,2" DuplicateSensitive="true">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/UnionWithOuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionWithOuterRefs.mdp
@@ -818,7 +818,7 @@
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:TableScan>
-              <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+              <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1" DuplicateSensitive="true">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="0.000018" Rows="1.000000" Width="4"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/UpdateCardinalityAssert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateCardinalityAssert.mdp
@@ -282,7 +282,7 @@
             <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1">
+        <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="862.001023" Rows="2.000000" Width="22"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/UpdateCardinalityAssert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateCardinalityAssert.mdp
@@ -360,7 +360,7 @@
                   <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:Comparison>
               </dxl:HashCondList>
-              <dxl:GatherMotion InputSegments="0,1" OutputSegments="0">
+              <dxl:GatherMotion InputSegments="0,1" OutputSegments="1">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="18"/>
                 </dxl:Properties>
@@ -414,7 +414,7 @@
                   </dxl:TableDescriptor>
                 </dxl:TableScan>
               </dxl:GatherMotion>
-              <dxl:GatherMotion InputSegments="0,1" OutputSegments="0">
+              <dxl:GatherMotion InputSegments="0,1" OutputSegments="1">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="8"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/UpdateWindowGatherMerge.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateWindowGatherMerge.mdp
@@ -772,7 +772,7 @@
                 <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
-            <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
+            <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1,2">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.014700" Rows="100.000000" Width="8"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/UpdateWindowGatherMerge.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateWindowGatherMerge.mdp
@@ -820,7 +820,7 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="1">
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="431.011823" Rows="100.000000" Width="8"/>
                     </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/UpdateZeroRows.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateZeroRows.mdp
@@ -379,7 +379,7 @@
             <dxl:Column ColId="21" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+        <dxl:RedistributeMotion InputSegments="1" OutputSegments="0,1" DuplicateSensitive="true">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="26"/>
           </dxl:Properties>

--- a/src/backend/gporca/libgpopt/include/gpopt/optimizer/COptimizer.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/optimizer/COptimizer.h
@@ -61,7 +61,8 @@ private:
 	static CDXLNode *CreateDXLNode(CMemoryPool *mp, CMDAccessor *md_accessor,
 								   CExpression *pexpr,
 								   CColRefArray *colref_array,
-								   CMDNameArray *pdrgpmdname, ULONG ulHosts);
+								   CMDNameArray *pdrgpmdname, ULONG ulHosts,
+								   ULONG ulSessionId);
 
 	// helper function to print query expression
 	static void PrintQuery(CMemoryPool *mp, CExpression *pexprTranslated,

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -98,6 +98,9 @@ private:
 	// segment ids on target system
 	IntPtrArray *m_pdrgpiSegments;
 
+	// id of the current session
+	ULONG m_ulSessionId;
+
 	// id of coordinator node
 	INT m_iCoordinatorId;
 
@@ -714,7 +717,7 @@ private:
 public:
 	// ctor
 	CTranslatorExprToDXL(CMemoryPool *mp, CMDAccessor *md_accessor,
-						 IntPtrArray *pdrgpiSegments,
+						 IntPtrArray *pdrgpiSegments, ULONG ulSessionId,
 						 BOOL fInitColumnFactory = true);
 
 	// dtor

--- a/src/backend/gporca/libgpopt/src/eval/CConstExprEvaluatorDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/eval/CConstExprEvaluatorDXL.cpp
@@ -43,6 +43,7 @@ CConstExprEvaluatorDXL::CConstExprEvaluatorDXL(
 	IConstDXLNodeEvaluator *pconstdxleval)
 	: m_pconstdxleval(pconstdxleval),
 	  m_trexpr2dxl(mp, md_accessor, nullptr /*pdrgpiSegments*/,
+				   0, /* ulSegmentId*/
 				   false /*fInitColumnFactory*/),
 	  m_trdxl2expr(mp, md_accessor, false /*fInitColumnFactory*/)
 {

--- a/src/backend/gporca/libgpopt/src/eval/CConstExprEvaluatorDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/eval/CConstExprEvaluatorDXL.cpp
@@ -43,7 +43,7 @@ CConstExprEvaluatorDXL::CConstExprEvaluatorDXL(
 	IConstDXLNodeEvaluator *pconstdxleval)
 	: m_pconstdxleval(pconstdxleval),
 	  m_trexpr2dxl(mp, md_accessor, nullptr /*pdrgpiSegments*/,
-				   0, /* ulSegmentId*/
+				   0, /* ulSessionId*/
 				   false /*fInitColumnFactory*/),
 	  m_trdxl2expr(mp, md_accessor, false /*fInitColumnFactory*/)
 {

--- a/src/backend/gporca/libgpopt/src/optimizer/COptimizer.cpp
+++ b/src/backend/gporca/libgpopt/src/optimizer/COptimizer.cpp
@@ -319,8 +319,9 @@ COptimizer::PdxlnOptimize(
 			GPOS_CHECK_ABORT;
 
 			// translate plan into DXL
-			pdxlnPlan = CreateDXLNode(mp, md_accessor, pexprPlan,
-									  pqc->PdrgPcr(), pdrgpmdname, ulHosts);
+			pdxlnPlan =
+				CreateDXLNode(mp, md_accessor, pexprPlan, pqc->PdrgPcr(),
+							  pdrgpmdname, ulHosts, ulSessionId);
 			GPOS_CHECK_ABORT;
 
 			if (fMinidump)
@@ -450,7 +451,8 @@ COptimizer::PexprOptimize(CMemoryPool *mp, CQueryContext *pqc,
 CDXLNode *
 COptimizer::CreateDXLNode(CMemoryPool *mp, CMDAccessor *md_accessor,
 						  CExpression *pexpr, CColRefArray *colref_array,
-						  CMDNameArray *pdrgpmdname, ULONG ulHosts)
+						  CMDNameArray *pdrgpmdname, ULONG ulHosts,
+						  ULONG ulSessionId)
 {
 	GPOS_ASSERT(0 < ulHosts);
 	IntPtrArray *pdrgpiHosts = GPOS_NEW(mp) IntPtrArray(mp);
@@ -460,7 +462,8 @@ COptimizer::CreateDXLNode(CMemoryPool *mp, CMDAccessor *md_accessor,
 		pdrgpiHosts->Append(GPOS_NEW(mp) INT(ul));
 	}
 
-	CTranslatorExprToDXL ptrexprtodxl(mp, md_accessor, pdrgpiHosts);
+	CTranslatorExprToDXL ptrexprtodxl(mp, md_accessor, pdrgpiHosts,
+									  ulSessionId);
 	CDXLNode *pdxlnPlan =
 		ptrexprtodxl.PdxlnTranslate(pexpr, colref_array, pdrgpmdname);
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -205,12 +205,14 @@ using namespace gpnaucrates;
 CTranslatorExprToDXL::CTranslatorExprToDXL(CMemoryPool *mp,
 										   CMDAccessor *md_accessor,
 										   IntPtrArray *pdrgpiSegments,
+										   ULONG ulSessionId,
 										   BOOL fInitColumnFactory)
 	: m_mp(mp),
 	  m_pmda(md_accessor),
 	  m_pdpplan(nullptr),
 	  m_pcf(nullptr),
 	  m_pdrgpiSegments(pdrgpiSegments),
+	  m_ulSessionId(ulSessionId),
 	  m_iCoordinatorId(GPOPT_COORDINATOR_SEGMENT_ID)
 {
 	GPOS_ASSERT(nullptr != mp);
@@ -7667,8 +7669,8 @@ CTranslatorExprToDXL::GetInputSegIdsArray(CExpression *pexprMotion)
 			CDistributionSpecSingleton::PdssConvert(pds);
 		if (!pdss->FOnCoordinator())
 		{
-			// non-coordinator singleton is currently fixed to the first segment
-			iSegmentId = *((*m_pdrgpiSegments)[0]);
+			ULONG ulSegmentCount = m_pdrgpiSegments->Size();
+			iSegmentId = (INT)(m_ulSessionId % ulSegmentCount);
 		}
 		pdrgpi->Append(GPOS_NEW(m_mp) INT(iSegmentId));
 		return pdrgpi;
@@ -7685,7 +7687,10 @@ CTranslatorExprToDXL::GetInputSegIdsArray(CExpression *pexprMotion)
 		// input from one segment in order to ensure that data is consistent
 		// after bring read from operator delivering tainted replication.
 		IntPtrArray *pdrgpi = GPOS_NEW(m_mp) IntPtrArray(m_mp);
-		INT iSegmentId = *((*m_pdrgpiSegments)[0]);
+
+		ULONG ulSegmentCount = m_pdrgpiSegments->Size();
+		INT iSegmentId = (INT)(m_ulSessionId % ulSegmentCount);
+
 		pdrgpi->Append(GPOS_NEW(m_mp) INT(iSegmentId));
 		return pdrgpi;
 	}

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -7617,8 +7617,12 @@ CTranslatorExprToDXL::GetOutputSegIdsArray(CExpression *pexprMotion)
 
 			if (CDistributionSpecSingleton::EstSegment == popGather->Est())
 			{
-				// gather to first segment
-				iSegmentId = *((*m_pdrgpiSegments)[0]);
+				// keep this value in sync with GetInputSegIdsArray
+				// (though it is not really necessary as of right now,
+				// as CTranslatorDXLToPlStmt::TranslateDXLMotion is not
+				// using it to determine outputs of the slices)
+				ULONG ulSegmentCount = m_pdrgpiSegments->Size();
+				iSegmentId = (INT)(m_ulSessionId % ulSegmentCount);
 			}
 			pdrgpi->Append(GPOS_NEW(m_mp) INT(iSegmentId));
 			break;

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -2889,7 +2889,8 @@ CTestUtils::EresTranslate(CMemoryPool *mp, const CHAR *szQueryFileName,
 	pexprPlan->OsPrint(oss);
 
 	// translate plan back to DXL
-	CTranslatorExprToDXL ptrexpr2dxl(mp, md_accessor, PdrgpiSegments(mp));
+	CTranslatorExprToDXL ptrexpr2dxl(mp, md_accessor, PdrgpiSegments(mp),
+									 1 /* ulSessionId */);
 	CDXLNode *pdxlnPlan = ptrexpr2dxl.PdxlnTranslate(pexprPlan, pqc->PdrgPcr(),
 													 pqc->Pdrgpmdname());
 	GPOS_UNITTEST_ASSERT(nullptr != pdxlnPlan);

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CMiniDumperDXLTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CMiniDumperDXLTest.cpp
@@ -169,7 +169,8 @@ CMiniDumperDXLTest::EresUnittest_Basic()
 			pdrgpiSegments->Append(GPOS_NEW(mp) INT(ul));
 		}
 
-		CTranslatorExprToDXL ptrexprtodxl(mp, &mda, pdrgpiSegments);
+		CTranslatorExprToDXL ptrexprtodxl(mp, &mda, pdrgpiSegments,
+										  1 /* ulSessionId */);
 		CDXLNode *pdxlnPlan = ptrexprtodxl.PdxlnTranslate(
 			pexprPlan, pqc->PdrgPcr(), pqc->Pdrgpmdname());
 		GPOS_UNITTEST_ASSERT(nullptr != pdxlnPlan);

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -295,6 +295,9 @@ char *GetTypeName(Oid typid);
 // number of GP segments
 int GetGPSegmentCount(void);
 
+// Id of the current session
+int GetGPSessionId(void);
+
 // heap attribute is null
 bool HeapAttIsNull(HeapTuple tup, int attnum);
 

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -295,9 +295,6 @@ char *GetTypeName(Oid typid);
 // number of GP segments
 int GetGPSegmentCount(void);
 
-// Id of the current session
-int GetGPSessionId(void);
-
 // heap attribute is null
 bool HeapAttIsNull(HeapTuple tup, int attnum);
 


### PR DESCRIPTION
Previously, inputs for duplicate motion hazard, tainted replicated,  
and non-coordinator singleton distributions were always taken 
from the first segment (with id 0). 

At the same time, in the PostgreSQL-based planner this value 
is computed using current session id. 

This patch ports aforementioned PostgreSQL planner logic to ORCA 
by making CTranslatorDXLToExpr class store session id. 
However, the instance of this class, created inside CConstExprEvaluatorDXL 
is left with a placeholder session id equal to zero, 
since it is currently used only for scalar operator evaluation. 
We can always change it when we need to. 

Other notable change is updating ORCA unit tests 
(as they use a hardcoded session id that is equal to '1')


Ticket: GG-259
