### PR TITLE
Implement duration control for ggrebalance

### DIFF
--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
 
-from gppylib.mainUtils import getProgramName
-
-from psycopg2 import DatabaseError
 try:
     from gppylib.commands.unix import *
     from gppylib.commands.gp import *
@@ -19,6 +16,9 @@ try:
     from gppylib.programs.clsRecoverSegment_triples import get_segments_with_running_basebackup
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
+from datetime import datetime, time
+from threading import Timer
+from psycopg2 import DatabaseError
 
 _usage = """
     Use 'ggrebalance --help' to get list of available options.
@@ -82,6 +82,10 @@ def parseargs():
                       help='Use host names when updating the pg_hba.conf file.')
     parser.add_option('--replay-lag', dest="replay_lag", type="float",
                       help='Replay lag(in GBs) allowed on mirror when rebalancing the segments.')
+    parser.add_option('-T', '--duration', type='duration', metavar='[h][:m[:s]]',
+                      help='duration from beginning to end.')
+    parser.add_option('-E', '--end', type='datetime', metavar='datetime',
+                      help="ending date and time in the format 'YYYY-MM-DD hh:mm:ss'.")
     parser.add_option('-v', '--verbose', action='store_true', default=False,
                       help='debug output.')
     parser.add_option('--inplace-swap-roles', dest="inplace_swap_roles", action='store_true', default=False,
@@ -135,6 +139,7 @@ def validate_options(options, args, parser):
         ('add_hosts', ['add_hosts_file', 'remove_hosts', 'remove_hosts_file']),
         ('add_hosts_file', ['remove_hosts', 'remove_hosts_file']),
         ('remove_hosts', ['remove_hosts_file']),
+        ('duration', ['end']),
 
         ('target_datadirs', ['target_datadirs_file']),
 
@@ -144,14 +149,15 @@ def validate_options(options, args, parser):
             'target_hosts', 'target_hosts_file', 'add_hosts', 'add_hosts_file',
             'remove_hosts', 'remove_hosts_file', 'target_datadirs', 'target_datadirs_file',
             'target_segment_count', 'mirror_mode', 'skip_rebalance', 'show_plan',
-            'skip_resource_estimation', 'analyze', 'replay_lag', 'hba_hostnames', 'inplace_swap_roles'
+            'skip_resource_estimation', 'analyze', 'replay_lag', 'hba_hostnames', 'inplace_swap_roles',
+            'duration', 'end'
         ]),
 
         ('rollback_required', [
             'target_hosts', 'target_hosts_file', 'add_hosts', 'add_hosts_file',
             'remove_hosts', 'remove_hosts_file', 'target_datadirs', 'target_datadirs_file',
             'target_segment_count', 'mirror_mode', 'skip_rebalance', 'show_plan',
-            'skip_resource_estimation', 'duration', 'end', 'inplace_swap_roles'
+            'skip_resource_estimation', 'inplace_swap_roles'
         ]),
     ]
 
@@ -172,7 +178,18 @@ def validate_options(options, args, parser):
                     f"Can't use together options '--{condition_opt.replace('_', '-')}' and '--{incomp_opt.replace('_', '-')}'"
                     logger.error(error_msg)
                     parser.exit(1)
-    
+
+    # OptParse can return date instead of datetime so we might need to convert
+    if options.end and not isinstance(options.end, datetime):
+        options.end = datetime.combine(options.end, time(0))
+
+    if options.end and options.end < datetime.now():
+        logger.error('End time occurs in the past')
+        parser.exit(1)
+
+    if options.duration:
+        options.end = datetime.now() + options.duration
+
     if (option_is_set('target_hosts') or option_is_set('add_hosts')) and not option_is_set('target_datadirs'):
         logger.error("--target-datadirs option is required when using --target-hosts or --add-hosts")
         parser.exit(1)
@@ -250,14 +267,12 @@ def remove_pid_file(coordinator_data_directory: str):
         pass
 
 gg_main_rebalance_SM = None
-cmd_recoverseg = None
+timeout = False
 
 def sig_handler(sig, arg):
     if gg_main_rebalance_SM is not None:
-        gg_main_rebalance_SM.shutdown()
+        gg_main_rebalance_SM.shutdown(hard_shutdown = not timeout)
     else:
-        if cmd_recoverseg != None:
-            cmd_recoverseg.cancel()
         sys.exit(1)
 
 def check_down_segments(logger: Any, options: Any, dburl: dbconn.DbURL):
@@ -271,8 +286,14 @@ def check_down_segments(logger: Any, options: Any, dburl: dbconn.DbURL):
     if cnt_primaries_down != 0:
         raise Exception('Detected some primary segments are down, please recover manually')
 
+def timeout_handler():
+    global timeout
+    timeout = True
+    os.kill(os.getpid(), signal.SIGINT)
+
 def main(options, args, parser):
     conn = None
+    timeout_checker = None
     try:
         signal.signal(signal.SIGTERM, sig_handler)
         signal.signal(signal.SIGHUP, sig_handler)
@@ -288,15 +309,16 @@ def main(options, args, parser):
         if options.quiet:
             quiet_stdout_logging()
 
+        if options.end:
+            logger.info(f'Time limit is set to "{options.end}", current time is "{datetime.now()}"')
+            timer_period = math.ceil((options.end - datetime.now()).total_seconds())
+            timeout_checker = Timer(timer_period, timeout_handler)
+            timeout_checker.start()
+        else:
+            logger.info('No time limit is set')
+
         gpenv = GpCoordinatorEnvironment(
             options.coordinator_data_directory, True)
-
-        # can we remove it?
-        configurationInterface.registerConfigurationProvider(
-            configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog())
-
-        configurationInterface.getConfigurationProvider(
-        ).initializeProvider(gpenv.getCoordinatorPort())
 
         dburl = dbconn.DbURL(dbname=DBNAME, port=gpenv.getCoordinatorPort())
 
@@ -334,6 +356,8 @@ def main(options, args, parser):
     finally:
         if conn != None:
             conn.close()
+        if timeout_checker != None:
+            timeout_checker.cancel()
         remove_pid_file(get_coordinatordatadir())
 
 if __name__ == '__main__':

--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -267,11 +267,12 @@ def remove_pid_file(coordinator_data_directory: str):
         pass
 
 gg_main_rebalance_SM = None
-timeout = False
 
 def sig_handler(sig, arg):
     if gg_main_rebalance_SM is not None:
-        gg_main_rebalance_SM.shutdown(hard_shutdown = not timeout)
+        gg_main_rebalance_SM.shutdown()
+        # Set shutdown type back to 'hard' for the case we are here due to timeout
+        gg_main_rebalance_SM.set_hard_shutdown(True)
     else:
         sys.exit(1)
 
@@ -285,11 +286,6 @@ def check_down_segments(logger: Any, options: Any, dburl: dbconn.DbURL):
 
     if cnt_primaries_down != 0:
         raise Exception('Detected some primary segments are down, please recover manually')
-
-def timeout_handler():
-    global timeout
-    timeout = True
-    os.kill(os.getpid(), signal.SIGINT)
 
 def main(options, args, parser):
     conn = None
@@ -312,6 +308,12 @@ def main(options, args, parser):
         if options.end:
             logger.info(f'Time limit is set to "{options.end}", current time is "{datetime.now()}"')
             timer_period = math.ceil((options.end - datetime.now()).total_seconds())
+
+            def timeout_handler():
+                if gg_main_rebalance_SM is not None:
+                    gg_main_rebalance_SM.set_hard_shutdown(False)
+                os.kill(os.getpid(), signal.SIGINT)
+
             timeout_checker = Timer(timer_period, timeout_handler)
             timeout_checker.start()
         else:

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
@@ -129,6 +129,7 @@ class GGRebalanceMainSM:
         self.options = options
         self.gparray = gpArray
         self.conn = conn
+        self.hard_shutdown = True
 
         self.rebalance_schema = RebalanceSchema(self.conn)
 
@@ -157,8 +158,11 @@ class GGRebalanceMainSM:
     def run(self) -> None:
         self.trigger('start')
 
-    def shutdown(self, hard_shutdown: bool) -> None:
-        if hard_shutdown:
+    def set_hard_shutdown(self, hard_shutdown: bool) -> None:
+        self.hard_shutdown = hard_shutdown
+
+    def shutdown(self) -> None:
+        if self.hard_shutdown:
             self.logger.info('hard shutdown')
         else:
             self.logger.info('soft shutdown, waiting for critical operations to finish...')
@@ -170,7 +174,7 @@ class GGRebalanceMainSM:
             need_exit = False
 
         if self.gg_rebalance is not None:
-            self.gg_rebalance.shutdown(hard_shutdown)
+            self.gg_rebalance.shutdown(self.hard_shutdown)
             need_exit = False
 
         if need_exit:

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
@@ -157,7 +157,12 @@ class GGRebalanceMainSM:
     def run(self) -> None:
         self.trigger('start')
 
-    def shutdown(self) -> None:
+    def shutdown(self, hard_shutdown: bool) -> None:
+        if hard_shutdown:
+            self.logger.info('hard shutdown')
+        else:
+            self.logger.info('soft shutdown, waiting for critical operations to finish...')
+
         need_exit = True
 
         if self.gg_shrink is not None:
@@ -165,7 +170,7 @@ class GGRebalanceMainSM:
             need_exit = False
 
         if self.gg_rebalance is not None:
-            self.gg_rebalance.shutdown()
+            self.gg_rebalance.shutdown(hard_shutdown)
             need_exit = False
 
         if need_exit:

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_sm.py
@@ -336,9 +336,9 @@ class RebalanceSM:
                 fp.write(cfg_line)
         return filename
 
-    def shutdown(self) -> None:
+    def shutdown(self, hard_shutdown: bool) -> None:
         self.shutdown_requested = True
-        if self.cmd != None:
+        if hard_shutdown and self.cmd != None:
             self.cmd.cancel()
 
     def state_is_final(self, state: str) -> bool:

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
@@ -1,4 +1,4 @@
-@ggrebalance_basics @skip
+@ggrebalance_basics
 Feature: ggrebalance behave tests
 
     Scenario Outline: test 1. validate incompatible option combinations
@@ -44,6 +44,9 @@ Feature: ggrebalance behave tests
           | -r --skip-rebalance                                         | Can't use together options '--rollback-required' and '--skip-rebalance'    | stub     |stub|
           | -r --show-plan                                              | Can't use together options '--rollback-required' and '--show-plan'         | stub     |stub|
           | -r --inplace-swap-roles                                     | Can't use together options '--rollback-required' and '--inplace-swap-roles'     | stub     |stub|
+          | -c --duration 00:00:01                                      | Can't use together options '--clean-required' and '--duration'                  | stub     |stub|
+          | -c --end '2099-01-01 01:01:01'                              | Can't use together options '--clean-required' and '--end'                       | stub     |stub|
+          | --duration 00:00:01 --end '2099-01-01 01:01:01'             | Can't use together options '--duration' and '--end'                             | stub     |stub|
           | -r --skip-resource-estimation                               | Can't use together options '--rollback-required' and '--skip-resource-estimation' |the database is not running |"COORDINATOR_DATA_DIRECTORY" environment variable should be restored|
 
     Scenario: test 2. ggrebalance simple scenarios

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -478,3 +478,27 @@ Feature: ggrebalance behave tests (misc options scenarios)
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And pg_hba file "/data/gpdata/ggrebalance/data/primary/gpseg0/pg_hba.conf" on host "sdw1" contains only cidr addresses
+
+    Scenario: test 19. Check '--duration' option.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance --duration 00:00:20 --non-interactive-mode -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "soft shutdown, waiting for critical operations to finish..." to logfile with latest timestamp
+         And ggrebalance should print "Rebalance was interrupted" to logfile with latest timestamp
+
+    Scenario: test 20. Check '--end' option.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance --end '2000-01-01 01:01:00' --non-interactive-mode -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "End time occurs in the past" to logfile with latest timestamp
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance --end $(date -d '+20 seconds' '+%Y%m%dT%H%M%S') --non-interactive-mode -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "soft shutdown, waiting for critical operations to finish..." to logfile with latest timestamp
+         And ggrebalance should print "Rebalance was interrupted" to logfile with latest timestamp


### PR DESCRIPTION
Implement duration control for ggrebalance

This patch adds support for '--duration' and '--end' options. The underlying
implementation for both options is the same - a timer is started, and on its
expiration, it sets the shutdown type to 'soft' (also added by this patch) and
sends SIGINT to the tool. In the signal handler we shut down the rebalance
state machine with soft shutdown. It means that the shutdown will wait for the
critical operations (like role switchovers and mirror movements), that are
currently being executed, to finish, and then will halt the execution.
Hard shutdown (without waiting for role switchovers and mirror movements) is
still used for the abort operation performed by the user.
Also, the new options were removed from the list of incompatible options for
the 'rollback' operation, as they are compatible according to the requirements.

Plus, some redundant code was cleaned up:
 - removed cmd_recoverseg as not used;
 - removed configuration provider code as not used;
 - removed unused imports and reorganized existing ones.