### PR TITLE
Make --add-hosts and --remove-hosts options compatible

### DIFF
--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -132,8 +132,7 @@ def validate_options(options, args, parser):
         # (condition_option, incompatible_options)
         ('target_hosts', ['add_hosts', 'add_hosts_file', 'remove_hosts', 'remove_hosts_file', 'target_hosts_file']),
         ('target_hosts_file', ['add_hosts', 'add_hosts_file', 'remove_hosts', 'remove_hosts_file']),
-        ('add_hosts', ['add_hosts_file', 'remove_hosts', 'remove_hosts_file']),
-        ('add_hosts_file', ['remove_hosts', 'remove_hosts_file']),
+        ('add_hosts', ['add_hosts_file']),
         ('remove_hosts', ['remove_hosts_file']),
 
         ('target_datadirs', ['target_datadirs_file']),

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
@@ -17,15 +17,21 @@ Feature: ggrebalance behave tests
           | --target-hosts sdw1,sdw2 --target-hosts-file /tmp/hosts.txt | Can't use together options '--target-hosts' and '--target-hosts-file' |  stub |stub|
           | --target-hosts sdw1,sdw2 --add-hosts sdw3                   | Can't use together options '--target-hosts' and '--add-hosts'         | stub       |stub|
           | --target-hosts sdw1,sdw2 --remove-hosts sdw3                | Can't use together options '--target-hosts' and '--remove-hosts'      | stub       |stub|
+          | --target-hosts-file /tmp/hosts.txt --add-hosts sdw3         | Can't use together options '--target-hosts-file' and '--add-hosts'    |  stub      |stub|
+          | --target-hosts-file /tmp/hosts.txt --remove-hosts sdw3      | Can't use together options '--target-hosts-file' and '--remove-hosts' |  stub      |stub|
+          | --target-hosts-file /tmp/hosts.txt --add-hosts-file /tmp/add.txt    | Can't use together options '--target-hosts-file' and '--add-hosts-file'    |  stub      |stub|
+          | --target-hosts-file /tmp/hosts.txt --remove-hosts-file /tmp/rm.txt  | Can't use together options '--target-hosts-file' and '--remove-hosts-file' |  stub      |stub|
           | --add-hosts sdw3 --add-hosts-file /tmp/add.txt              | Can't use together options '--add-hosts' and '--add-hosts-file'       | stub       |stub|
           | --remove-hosts sdw3 --remove-hosts-file /tmp/rm.txt         | Can't use together options '--remove-hosts' and '--remove-hosts-file' | stub       |stub|
-          | --add-hosts sdw3 --remove-hosts sdw3                        | Can't use together options '--add-hosts' and '--remove-hosts'         | stub       |stub|
           | --target-datadirs '/data/p/gpseg{content},/data/m/gpseg{content}' --target-datadirs-file /tmp/datadirs.txt | Can't use together options '--target-datadirs' and '--target-datadirs-file' | stub |stub|
           | --mirror-mode grouped --skip-rebalance                      | Can't use together options '--skip-rebalance' and '--mirror-mode'     | stub       |stub|
           | -m spread --skip-rebalance                                  | Can't use together options '--skip-rebalance' and '--mirror-mode'     | stub       |stub|
           | --skip-rebalance --inplace-swap-roles                       | Can't use together options '--skip-rebalance' and '--inplace-swap-roles'     | stub     |stub|
           | -c --target-hosts sdw1,sdw2                                 | Can't use together options '--clean-required' and '--target-hosts'    | stub       |stub|
           | -c --add-hosts sdw3                                         | Can't use together options '--clean-required' and '--add-hosts'       | stub       |stub|
+          | -c --add-hosts-file /tmp/add.txt                            | Can't use together options '--clean-required' and '--add-hosts-file'  | stub       |stub|
+          | -c --remove-hosts sdw3                                      | Can't use together options '--clean-required' and '--remove-hosts'       | stub       |stub|
+          | -c --remove-hosts-file /tmp/rm.txt                          | Can't use together options '--clean-required' and '--remove-hosts-file'  | stub       |stub|
           | -c --target-datadirs '/data/p/gpseg{content},/data/m/gpseg{content}' | Can't use together options '--clean-required' and '--target-datadirs'   | stub    |stub|
           | -c -x 2                                                     | Can't use together options '--clean-required' and '--target-segment-count' | stub    |stub|
           | -c --mirror-mode grouped                                    | Can't use together options '--clean-required' and '--mirror-mode'       | stub     |stub|
@@ -38,6 +44,9 @@ Feature: ggrebalance behave tests
           | -c --skip-resource-estimation                               | Can't use together options '--clean-required' and '--skip-resource-estimation' | stub |stub|
           | -r --target-hosts sdw1,sdw2                                 | Can't use together options '--rollback-required' and '--target-hosts'    | stub       |stub|
           | -r --add-hosts sdw3                                         | Can't use together options '--rollback-required' and '--add-hosts'       | stub       |stub|
+          | -r --add-hosts-file /tmp/add.txt                            | Can't use together options '--rollback-required' and '--add-hosts-file'  | stub       |stub|
+          | -r --remove-hosts sdw3                                      | Can't use together options '--rollback-required' and '--remove-hosts'       | stub       |stub|
+          | -r --remove-hosts-file /tmp/rm.txt                          | Can't use together options '--rollback-required' and '--remove-hosts-file'  | stub       |stub|
           | -r --target-datadirs '/data/p/gpseg{content},/data/m/gpseg{content}' | Can't use together options '--rollback-required' and '--target-datadirs'   | stub    |stub|
           | -r -x 2                                                     | Can't use together options '--rollback-required' and '--target-segment-count' | stub    |stub|
           | -r --mirror-mode grouped                                    | Can't use together options '--rollback-required' and '--mirror-mode'       | stub     |stub|

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -102,6 +102,33 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 4, row count = 100
          And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 4, row count = 100
 
+    Scenario: test 6.1 Check rebalance with both '--add-hosts' and '--remove-hosts' (result should be the same as with the usage of '--target-hosts' in the previous test).
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1", with 4 segments on each
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -x 4 --add-hosts 'sdw2, sdw3' --remove-hosts 'sdw1' -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And the cluster configuration has 0 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 0 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw3' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw3' and content > -1 and role = 'm' and status = 'u'"
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 4, row count = 100
+
     Scenario: test 7. Check rebalance with '--target-hosts-file'.
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'


### PR DESCRIPTION
Make --add-hosts and --remove-hosts options compatible

Problem description:
Options --add-hosts and --remove-hosts (and respective --add-hosts-file and
--remove-hosts-file) couldn't be used together. It contradicted the
requirements.

Fix:
This patch makes the mentioned options compatible and adds a test to check the
result of both options application.
Plus, this patch updates the ggrebalance_basic test to fully test all
incompatible combinations that involve these options.