### PR TITLE
Fix skip of table rebalance on shrink re-enter if ALTER TABLE failed on COMMIT

### DIFF
--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -262,12 +262,6 @@ class GGShrink:
                     self.trigger('move_to_STATE_END_FROM_ROLLBACK')
                     return
 
-        # In some rare cases there can be tables left, that
-        # have been already redistributed, but the status is still 'none'.
-        # To handle it, we cleanup all tables with status 'none' at the first
-        # enter of rollback operation.
-        self.rebalance_schema.clearTablesToRebalanceWithStatus('none')
-
         self.trigger('start')
 
     def get_state_after_interrupt(self, prev_state) -> str:
@@ -527,6 +521,12 @@ class GGShrink:
 
     @wrap_func_with_faults
     def on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE(self) -> None:
+        # In some rare cases there can be tables left, that
+        # have been already redistributed, but the status is still 'none'.
+        # To handle it, we cleanup all tables with status 'none' at the first
+        # enter of rollback operation.
+        self.rebalance_schema.clearTablesToRebalanceWithStatus('none')
+
         self.trigger('move_to_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START')
 
     @wrap_func_with_faults

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -18,7 +18,7 @@ try:
     from gppylib.system.environment import *
     from gppylib.utils import escape_string, escapeDoubleQuoteInSQLString
     from ggrebalance_modules.planner import *
-    from ggrebalance_modules.rebalance_schema import RebalanceSchema, STATE_NOT_DEFINED
+    from ggrebalance_modules.rebalance_schema import RebalanceSchema, STATE_NOT_DEFINED, get_table_distr_segment_count
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
@@ -628,13 +628,7 @@ class GGShrink:
             return True
 
         def table_is_rebalanced(self, conn: dbconn.Connection) -> bool:
-            if dbconn.querySingleton(conn, f"""
-                SELECT p.numsegments
-                FROM pg_class c
-                JOIN pg_namespace n ON c.relnamespace = n.oid
-                JOIN gp_distribution_policy p ON c.oid = p.localoid
-                WHERE c.relname = '{escape_string(self.rel_name)}' AND n.nspname = '{escape_string(self.schema_name)}'
-                """) != self.target_segment_count:
+            if get_table_distr_segment_count(conn, self.schema_name, self.rel_name) != self.target_segment_count:
                 return False
             return True
 

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -613,41 +613,59 @@ class GGShrink:
                 fun(self, attempt)
             return func_with_faults
 
-        def table_exists(self, conn: dbconn.Connection, schema_name: str, rel_name: str) -> bool:
+        def table_exists(self, conn: dbconn.Connection) -> bool:
             if dbconn.querySingleton(conn, f"""
                 SELECT count(1)
                 FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid
-                WHERE c.relname = '{escape_string(rel_name)}' AND n.nspname = '{escape_string(schema_name)}' AND c.relnamespace = n.oid
+                WHERE c.relname = '{escape_string(self.rel_name)}' AND n.nspname = '{escape_string(self.schema_name)}'
                 """) == 0:
                 return False
             return True
 
-        def db_exists(self, conn: dbconn.Connection, db_name: str) -> bool:
-            if dbconn.querySingleton(conn, f"""SELECT count(*) FROM pg_database WHERE datname = '{escape_string(db_name)}'""") == 0:
+        def db_exists(self, conn: dbconn.Connection) -> bool:
+            if dbconn.querySingleton(conn, f"""SELECT count(*) FROM pg_database WHERE datname = '{escape_string(self.db_name)}'""") == 0:
                 return False
             return True
+
+        def table_is_rebalanced(self, conn: dbconn.Connection) -> bool:
+            if dbconn.querySingleton(conn, f"""
+                SELECT p.numsegments
+                FROM pg_class c
+                JOIN pg_namespace n ON c.relnamespace = n.oid
+                JOIN gp_distribution_policy p ON c.oid = p.localoid
+                WHERE c.relname = '{escape_string(self.rel_name)}' AND n.nspname = '{escape_string(self.schema_name)}'
+                """) != self.target_segment_count:
+                return False
+            return True
+
+        def rebalance_table(self, conn: dbconn.Connection) -> None:
+            dbconn.execSQL(conn,
+                           f'''ALTER TABLE {escapeDoubleQuoteInSQLString(self.schema_name, True)}.{escapeDoubleQuoteInSQLString(self.rel_name, True)}
+                           REBALANCE {self.target_segment_count}''')
 
         @wrap_table_rebalance_with_faults
         def process_table(self, attempt: int) -> None:
             self.shrink.logger.info(f'Start table rebalance for "{self.db_name}"."{self.schema_name}"."{self.rel_name}" to {self.target_segment_count} segments (attempt {attempt})')
-            if self.db_exists(self.shrink.rebalance_schema.conn, self.db_name):
+            if self.db_exists(self.shrink.rebalance_schema.conn):
                 dburl = dbconn.DbURL(dbname=self.db_name, port=self.shrink.gpEnv.getCoordinatorPort())
                 with closing(dbconn.connect(dburl, encoding='UTF8')) as conn:
                     dbconn.execSQL(conn, 'BEGIN')
 
-                    table_exists = self.table_exists(conn, self.schema_name, self.rel_name)
-                    if table_exists:
-                        dbconn.execSQL(conn,
-                                    f'''ALTER TABLE {escapeDoubleQuoteInSQLString(self.schema_name, True)}.{escapeDoubleQuoteInSQLString(self.rel_name, True)}
-                                    REBALANCE {self.target_segment_count}''')
+                    if self.table_exists(conn):
+                        if not self.table_is_rebalanced(conn):
+                            self.rebalance_table(conn)
+                        else:
+                            self.shrink.logger.info(f'''Table "{self.db_name}"."{self.schema_name}"."{self.rel_name}" is already rebalanced''')
                         if self.shrink.options.analyze:
                             dbconn.execSQL(conn,
                                            f'''ANALYZE {escapeDoubleQuoteInSQLString(self.schema_name, True)}.{escapeDoubleQuoteInSQLString(self.rel_name, True)}''')
                     else:
                         self.shrink.logger.info(f'''Table "{self.db_name}"."{self.schema_name}"."{self.rel_name}" doesn't exist, skipping actual rebalance''')
 
-                    self.shrink.rebalance_schema.setStatusForTableToRebalance(self.db_name, self.schema_name, self.rel_name, self.table_status_after_rebalance)
                     dbconn.execSQL(conn, 'COMMIT')
+
+                    inject_fault(f'before_set_status_{self.db_name}.{self.schema_name}.{self.rel_name}')
+                    self.shrink.rebalance_schema.setStatusForTableToRebalance(self.db_name, self.schema_name, self.rel_name, self.table_status_after_rebalance)
             else:
                 self.shrink.logger.info(f'''DB "{self.db_name}" doesn't exist, skipping actual rebalance for "{self.schema_name}"."{self.rel_name}"''')
             self.shrink.logger.info(f'Complete table rebalance for "{self.db_name}"."{self.schema_name}"."{self.rel_name}"')

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -262,6 +262,12 @@ class GGShrink:
                     self.trigger('move_to_STATE_END_FROM_ROLLBACK')
                     return
 
+        # In some rare cases there can be tables left, that
+        # have been already redistributed, but the status is still 'none'.
+        # To handle it, we cleanup all tables with status 'none' at the first
+        # enter of rollback operation.
+        self.rebalance_schema.clearTablesToRebalanceWithStatus('none')
+
         self.trigger('start')
 
     def get_state_after_interrupt(self, prev_state) -> str:

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
@@ -283,6 +283,7 @@ Feature: ggrebalance behave tests
         | on_enter_STATE_SHRINK_TABLES_DONE_end                                       |
         | on_enter_STATE_SHRINK_CATALOG_STARTED_begin                                 |
         | fault_rebalance_table_test_db_2.test_schema_2.test_table_1                  |
+        | before_set_status_test_db_2.test_schema_2.test_table_1                      |
 
     Scenario Outline: test 2.3. shrink - check rollback after interrupted state (interruption is done after the point of no return). Rollback fails. So just continue shrink.
         Given the database is not running
@@ -400,6 +401,7 @@ Feature: ggrebalance behave tests
         | on_enter_STATE_SHRINK_TABLES_DONE_end                                       |
         | on_enter_STATE_SHRINK_CATALOG_STARTED_begin                                 |
         | fault_rebalance_table_test_db_2.test_schema_2.test_table_1                  |
+        | before_set_status_test_db_2.test_schema_2.test_table_1                      |
 
     Scenario Outline: test 3.1. shrink - check continue after interrupted rollback state. In this case we fail in rollback too early, and normal shrink will be complete.
         Given the database is not running
@@ -527,6 +529,7 @@ Feature: ggrebalance behave tests
         | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_end                 |
         | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START_begin                  |
         | on_enter_STATE_SHRINK_TABLES_DONE_begin                    | fault_rebalance_table_test_db_2.test_schema_2.test_table_1              |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin                    | before_set_status_test_db_2.test_schema_2.test_table_1                  |
 
     Scenario Outline: test 3.3. shrink - check continue after interrupted rollback state (interruption is done after rebalance schema is dropped)
         Given the database is not running

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
@@ -127,6 +127,7 @@ Feature: ggrebalance behave tests
         | on_enter_STATE_SHRINK_SEGMENTS_STOP_STARTED_end                             |
         | fault_rebalance_table_test_db_2.test_schema_2.test_table_1                  |
         | fault_segment_stop_dbid_3                                                   |
+        | before_set_status_test_db_2.test_schema_2.test_table_1                      |
 
     Scenario Outline: test 1.3. test shrink continue after cluster restart
         Given the database is not running


### PR DESCRIPTION
Fix skip of table rebalance on shrink re-enter if ALTER TABLE failed on COMMIT

Problem description:
During table redistribution at shrink, if the COMMIT operation for the
transaction with ALTER TABLE ... REBALANCE failed, the table was not
redistributed at shrink operation re-enter, and was be not accessible after
the shrink, though ggrebalance reported that shrink process had finished Ok.

Root cause:
The table status was already set to Done in the ggrebalance schema, as the
status setting is done in a separate transaction (because the ggrebalance
schema resides in the different database for the most cases).

Fix:
We do not have transactions that can handle 2 different databases, so we need
to handle the possible misalignment of table status in the ggrebalance schema
and real status of the table by the means of ggrebalance application.
This patch moves the status setting after the COMMIT operation, therefore, if
COMMIT fails, the status will not be set to Done. But it opens another issue -
possible failure when setting the status, while the table is actually already
rebalanced. It led to an attempt to rebalance the already rebalanced table on
re-enter. To fix it, we now check if the table is rebalanced (according to
the catalog) before rebalancing it. A new function 'table_is_rebalanced()' is
introduced for that purpose.
Also, this patch simplifies the existing similar functions 'table_exists()' and
'db_exists()' (by removing the function parameters, that are replaced with the
object attributes, and by removing the redundant filter condition in the query
which duplicates the join condition), and adds 'rebalance_table()' function
to improve readability of the modified piece of code.