### PR TITLE
GG-333: Add volatile expression alert for replicated tables to gpcheckcat

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -576,9 +576,7 @@ def checkReplicatedDistribPolicy():
         JOIN pg_attribute a ON c.oid = a.attrelid
         JOIN pg_attrdef ad ON c.oid = ad.adrelid AND a.attnum = ad.adnum
         JOIN gp_distribution_policy d ON c.oid = d.localoid
-        JOIN pg_proc p ON 
-            ad.adbin ~ ':funcid \d+' AND
-            regexp_replace(ad.adbin, '.*:funcid (\d+) .*', '\\1', 'g')::int = p.oid
+        JOIN pg_proc p ON ad.adbin ~ (':funcid ' || p.oid || ' ')
     WHERE c.relkind = 'r'
         AND d.policytype = 'r'
         AND a.attnum > 0
@@ -608,6 +606,8 @@ def checkReplicatedDistribPolicy():
                         'This must be manually resolved. Check the gpcheckcat log for details.'
                     )
                 logger.error('replicated tables has %d issue(s)' % len(err))
+                logger.error('Replace the VOLATILE defaults with a STABLE expression via `ALTER TABLE ... SET DEFAULT ...`, '
+                             'also sync the data among segments.')
                 logger.error('The following columns and their tables must be manually fixed and synced:')
                 for e in err:
                     logger.error(formatErr(e[0], e[1], e[2]))

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -601,9 +601,9 @@ def checkReplicatedDistribPolicy():
                 setError(ERROR_NOREPAIR)
                 logger.info('[FAIL] replicated tables')
                 myprint(
-                        '[ERROR]: Some columns, containing volatile expressions as defaults, '
+                        '[ERROR]: %d columns, containing volatile expressions as defaults, '
                         'have violated replicated table\'s distribution policy. '
-                        'This must be manually resolved. Check the gpcheckcat log for details.'
+                        'This must be manually resolved. Check the gpcheckcat log for details.' % len(err)
                     )
                 logger.error('replicated tables has %d issue(s)' % len(err))
                 logger.error('Replace the VOLATILE defaults with a STABLE expression via `ALTER TABLE ... SET DEFAULT ...`, '

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -576,7 +576,9 @@ def checkReplicatedDistribPolicy():
         JOIN pg_attribute a ON c.oid = a.attrelid
         JOIN pg_attrdef ad ON c.oid = ad.adrelid AND a.attnum = ad.adnum
         JOIN gp_distribution_policy d ON c.oid = d.localoid
-        JOIN pg_proc p ON pg_get_expr(ad.adbin, ad.adrelid) ~ ('\m' || p.proname || '\s*\(')
+        JOIN pg_proc p ON 
+            ad.adbin ~ ':funcid \d+' AND
+            regexp_replace(ad.adbin, '.*:funcid (\d+) .*', '\\1', 'g')::int = p.oid
     WHERE c.relkind = 'r'
         AND d.policytype = 'r'
         AND a.attnum > 0

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -560,6 +560,64 @@ def checkDistribPolicy():
 
     checkConstraintsRepair()
 
+def checkReplicatedDistribPolicy():
+    logger.info('-----------------------------------')
+    logger.info('Checking distribution violations on replicated tables')
+
+    # SELECT all replicated tables with volatile functions in default expressions from non-system schemas
+    qry = '''
+    SELECT
+        n.nspname AS nspname,
+        c.relname AS relname,
+        a.attname AS attname,
+        v.def_expr AS default_expr
+    FROM pg_class c
+        JOIN pg_namespace n ON c.relnamespace = n.oid
+        JOIN pg_attribute a ON c.oid = a.attrelid
+        JOIN pg_attrdef ad ON c.oid = ad.adrelid AND a.attnum = ad.adnum
+        JOIN gp_distribution_policy d ON c.oid = d.localoid
+    CROSS JOIN LATERAL (
+        SELECT pg_get_expr(ad.adbin, ad.adrelid)
+    ) AS v(def_expr)
+    WHERE c.relkind = 'r'
+        AND d.policytype = 'r'
+        AND a.attnum > 0
+        AND NOT a.attisdropped
+        AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+        AND EXISTS (
+            SELECT 1 FROM pg_proc p
+            WHERE p.provolatile = 'v'
+                AND v.def_expr ~ ('\m' || p.proname || '\s*\(')
+        );
+    '''
+
+    try:
+        conn = connect2(GV.cfg[GV.coordinator_dbid])
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as curs:
+            curs.execute(qry)
+
+            err = []
+            for row in curs.fetchall():
+                err.append([GV.cfg[GV.coordinator_dbid], ('nspname', 'relname', 'attname', 'default_expr'), row])
+
+            if not err:
+                logger.info('[OK] replicated tables')
+            else:
+                GV.checkStatus = False
+                setError(ERROR_NOREPAIR)
+                logger.info('[FAIL] replicated tables')
+                logger.error('replicated tables has %d issue(s)' % len(err))
+                for e in err:
+                    logger.error(formatErr(e[0], e[1], e[2]))
+                if len(err) > 100:
+                    logger.error('...')
+                    logger.error(qry)
+    except Exception as e:
+        GV.checkStatus = False
+        setError(ERROR_NOREPAIR)
+        myprint('[ERROR] executing test: checkReplicatedDistribPolicy')
+        myprint('  Execution error: ' + str(e))
+
 #############
 def checkPartitionIntegrity():
     logger.info('-----------------------------------')
@@ -2346,6 +2404,14 @@ all_checks = {
             "fn": lambda: checkMixDistPolicy(),
             "version": 'main',
             "order": 17,
+            "online": True
+        },
+    "replicated_distribution_policy":
+        {
+            "description": "Check policy violations of replicated tables",
+            "fn": lambda: checkReplicatedDistribPolicy(),
+            "version": 'main',
+            "order": 18,
             "online": True
         }
 

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -570,25 +570,19 @@ def checkReplicatedDistribPolicy():
         n.nspname AS nspname,
         c.relname AS relname,
         a.attname AS attname,
-        v.def_expr AS default_expr
+        pg_get_expr(ad.adbin, ad.adrelid) AS default_expr
     FROM pg_class c
         JOIN pg_namespace n ON c.relnamespace = n.oid
         JOIN pg_attribute a ON c.oid = a.attrelid
         JOIN pg_attrdef ad ON c.oid = ad.adrelid AND a.attnum = ad.adnum
         JOIN gp_distribution_policy d ON c.oid = d.localoid
-    CROSS JOIN LATERAL (
-        SELECT pg_get_expr(ad.adbin, ad.adrelid)
-    ) AS v(def_expr)
+        JOIN pg_proc p ON pg_get_expr(ad.adbin, ad.adrelid) ~ ('\m' || p.proname || '\s*\(')
     WHERE c.relkind = 'r'
         AND d.policytype = 'r'
         AND a.attnum > 0
         AND NOT a.attisdropped
         AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
-        AND EXISTS (
-            SELECT 1 FROM pg_proc p
-            WHERE p.provolatile = 'v'
-                AND v.def_expr ~ ('\m' || p.proname || '\s*\(')
-        );
+        AND p.provolatile = 'v';
     '''
 
     try:
@@ -606,7 +600,13 @@ def checkReplicatedDistribPolicy():
                 GV.checkStatus = False
                 setError(ERROR_NOREPAIR)
                 logger.info('[FAIL] replicated tables')
+                myprint(
+                        '[ERROR]: Some columns, containing volatile expressions as defaults, '
+                        'have violated replicated table\'s distribution policy. '
+                        'This must be manually resolved. Check the gpcheckcat log for details.'
+                    )
                 logger.error('replicated tables has %d issue(s)' % len(err))
+                logger.error('The following columns and their tables must be manually fixed and synced:')
                 for e in err:
                     logger.error(formatErr(e[0], e[1], e[2]))
                 if len(err) > 100:

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -443,6 +443,45 @@ class GpCheckCatTestCase(GpTestCase):
                 self.num_starts = 0
 
     @patch('gpcheckcat.connect2')
+    def test_checkReplicatedDistribPolicy_with_error_on_execution(self,mock_connect2):
+        # Mocking the database connection to raise an exception during execution
+
+        mock_cursor = Mock()
+        mock_connect2.return_value.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_cursor.execute.side_effect = Exception("Simulated error during execution")
+
+        # Call the function to test
+        self.subject.checkReplicatedDistribPolicy()
+
+        # Assertions
+        self.assertEqual(mock_cursor.execute.call_count, 1)
+        self.assertFalse(self.subject.GV.checkStatus)
+
+    @patch('gpcheckcat.connect2')
+    def test_checkReplicatedDistribPolicy_exception_on_connect(self, mock_connect2):
+        # Mocking the database connection to raise an exception during connection
+        mock_connect2.side_effect = Exception("Simulated error during connection")
+
+        # Call the function to test
+        self.subject.checkReplicatedDistribPolicy()
+
+        # Assertions
+        self.assertEqual(mock_connect2.call_count, 1)
+        self.assertFalse(self.subject.GV.checkStatus)
+
+    @patch('gpcheckcat.connect2')
+    def test_checkReplicatedDistribPolicy_exception_on_cursor_enter(self, mock_connect2):
+        # Mocking the database connection to raise an exception when entering the cursor context
+        mock_connect2.return_value.cursor.return_value.__enter__.side_effect = Exception("Simulated error entering cursor context")
+
+        # Call the function to test
+        self.subject.checkReplicatedDistribPolicy()
+
+        # Assertions
+        self.assertEqual(mock_connect2.call_count, 1)
+        self.assertFalse(self.subject.GV.checkStatus)
+
+    @patch('gpcheckcat.connect2')
     def test_checkMixDistPolicy_with_error_on_execution(self,mock_connect2):
         # Mocking the database connection to raise an exception during execution
 

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -241,7 +241,7 @@ Feature: gpcheckcat tests
         Then psql should return a return code of 0
         When the user runs "gpcheckcat -R replicated_distribution_policy policy_violation_db"
         Then gpcheckcat should return a return code of 3
-        Then gpcheckcat should print "have violated replicated table's distribution policy" to stdout
+        Then gpcheckcat should print "2 columns, containing volatile expressions as defaults, have violated replicated table's distribution policy" to stdout
         And the user runs "dropdb constraint_db"
 
     Scenario: gpcheckcat should report, but not repair, invalid policy issues

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -235,6 +235,14 @@ Feature: gpcheckcat tests
         Then gpcheckcat should return a return code of 0
         And the user runs "dropdb constraint_db"
 
+    Scenario: gpcheckcat should report replicated tables policy violation via default volatile expressions
+        Given database "policy_violation_db" is dropped and recreated
+        And the user runs "psql policy_violation_db -f test/behave/mgmt_utils/steps/data/gpcheckcat/violate_replicated_policy.sql"
+        Then psql should return a return code of 0
+        When the user runs "gpcheckcat -R replicated_distribution_policy policy_violation_db"
+        Then gpcheckcat should return a return code of 3
+        And the user runs "dropdb constraint_db"
+
     Scenario: gpcheckcat should report, but not repair, invalid policy issues
         Given database "policy_db" is dropped and recreated
           And the path "gpcheckcat.repair.*" is removed from current working directory

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -241,6 +241,7 @@ Feature: gpcheckcat tests
         Then psql should return a return code of 0
         When the user runs "gpcheckcat -R replicated_distribution_policy policy_violation_db"
         Then gpcheckcat should return a return code of 3
+        Then gpcheckcat should print "have violated replicated table's distribution policy" to stdout
         And the user runs "dropdb constraint_db"
 
     Scenario: gpcheckcat should report, but not repair, invalid policy issues

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/violate_replicated_policy.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/violate_replicated_policy.sql
@@ -40,18 +40,6 @@ CREATE TABLE dist_replicated_non_vol(
     c INT DEFAULT fn_val()
 ) DISTRIBUTED REPLICATED;
 
-CREATE TABLE dist_by_key(
-    a FLOAT,
-    b INT,
-    c INT DEFAULT 42
-) DISTRIBUTED BY (a);
-
-CREATE TABLE dist_randomly (
-    a FLOAT,
-    b INT,
-    c INT DEFAULT 42
-) DISTRIBUTED RANDOMLY;
-
 -- Replace already used function to break policy
 CREATE OR REPLACE FUNCTION fn_vol()
         RETURNS int

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/violate_replicated_policy.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/violate_replicated_policy.sql
@@ -1,0 +1,65 @@
+CREATE FUNCTION fn_vol()
+        RETURNS int
+        LANGUAGE plpgsql
+        IMMUTABLE
+AS $$
+BEGIN
+	RETURN (random() * 1000)::int;
+END;
+$$
+EXECUTE ON ANY;
+
+CREATE FUNCTION fn_val()
+        RETURNS int
+        LANGUAGE plpgsql
+        IMMUTABLE
+AS $$
+BEGIN
+	RETURN 42;
+END;
+$$
+EXECUTE ON ANY;
+
+CREATE TABLE dist_replicated_vol1(
+    a INT,
+    b FLOAT,
+    c TEXT DEFAULT 'Lorem Ipsum',
+    d TEXT DEFAULT NULL,
+    e_vol INT DEFAULT fn_vol()
+) DISTRIBUTED REPLICATED;
+
+CREATE TABLE dist_replicated_vol2(
+    a_vol INT DEFAULT (42*fn_vol())+42,
+    b_vol INT DEFAULT fn_val() + 42,
+    c_vol FLOAT
+) DISTRIBUTED REPLICATED;
+
+CREATE TABLE dist_replicated_non_vol(
+    a FLOAT,
+    b FLOAT,
+    c INT DEFAULT fn_val()
+) DISTRIBUTED REPLICATED
+
+CREATE TABLE dist_by_key(
+    a FLOAT,
+    b INT,
+    c INT DEFAULT 42
+)
+
+CREATE TABLE dist_randomly (
+    a FLOAT,
+    b INT,
+    c INT DEFAULT 42
+) DISTRIBUTED RANDOMLY;
+
+-- Replace already used function to break policy
+CREATE OR REPLACE FUNCTION fn_vol()
+        RETURNS int
+        LANGUAGE plpgsql
+        VOLATILE
+AS $$
+BEGIN
+	RETURN (random() * 1000)::int;
+END;
+$$
+EXECUTE ON ANY;

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/violate_replicated_policy.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/violate_replicated_policy.sql
@@ -38,13 +38,13 @@ CREATE TABLE dist_replicated_non_vol(
     a FLOAT,
     b FLOAT,
     c INT DEFAULT fn_val()
-) DISTRIBUTED REPLICATED
+) DISTRIBUTED REPLICATED;
 
 CREATE TABLE dist_by_key(
     a FLOAT,
     b INT,
     c INT DEFAULT 42
-)
+) DISTRIBUTED BY (a);
 
 CREATE TABLE dist_randomly (
     a FLOAT,

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/violate_replicated_policy.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/violate_replicated_policy.sql
@@ -41,13 +41,4 @@ CREATE TABLE dist_replicated_non_vol(
 ) DISTRIBUTED REPLICATED;
 
 -- Replace already used function to break policy
-CREATE OR REPLACE FUNCTION fn_vol()
-        RETURNS int
-        LANGUAGE plpgsql
-        VOLATILE
-AS $$
-BEGIN
-	RETURN (random() * 1000)::int;
-END;
-$$
-EXECUTE ON ANY;
+ALTER FUNCTION fn_vol VOLATILE;


### PR DESCRIPTION
What happens?
Although 7cd685d protects replicated tables from main ways to
break its policy via usage of volatile expressions, some loopholes still exists
(one is used in violate_replicated_policy.sql‎ for behave test) and we can't do
much about them, except to alert the user.

How can we help the user?
gpcheckcat exists for similar purposes, so adding command to it, which alerts
the user about such data inconsistency should help. 

What command does?
Shows all columns with volatile expressions of all replicated tables among all
non-system schemas. 

Can we resync replicated table among segments?
No, as it is not obvious how to do it. If we choose to sync with one of the
segments, it raises question of what segment to choose as main to resync data
with. Even if we delegate this responsibility to user, gpcheckcat does not
contain many interactive ways to provide arguments to command to begin with.

Tests?
Unit tests for broken connection / cursor reading are provided.  Behave test to
check alert of inconsistent data also provided.