### PR TITLE
Protect replicated tables with volatile functions from rewrite (6.x)

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -2863,6 +2863,14 @@ AddRelationNewConstraints(Relation rel,
 			(IsA(expr, Const) &&((Const *) expr)->constisnull))
 			continue;
 
+		/* Protect replicated tables from volatile expressions as DEFAULT value */
+		if (GpPolicyIsReplicated(rel->rd_cdbpolicy) &&
+			contain_volatile_functions_not_nextval(expr))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+					 errmsg("volatile expressions are not supported as "
+							"default values for columns in replicated tables")));
+
 		StoreAttrDefault(rel, colDef->attnum, expr, is_internal);
 
 		cooked = (CookedConstraint *) palloc(sizeof(CookedConstraint));

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -820,6 +820,21 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId, char relstorage, boo
 		}
 		else if (colDef->cooked_default != NULL)
 		{
+			/* 
+			 *  The parent table might have a volatile function as the default value
+			 *  for a column, for example if it is distributed by a key,
+			 *  and the target table might be replicated. Such columns are prohibited
+			 *  for replicated tables, so enforce this rule here.
+			 */
+			if (GpPolicyIsReplicated(policy) &&
+				contain_volatile_functions_not_nextval(colDef->cooked_default))
+				ereport(ERROR,
+					(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+					 errmsg("volatile expressions are not supported as "
+							"default values for columns in replicated tables"),
+					 errdetail("Volatile expression(s) originate from the table(s) "
+							"specified in the LIKE clause(s)")));
+
 			CookedConstraint *cooked;
 
 			cooked = (CookedConstraint *) palloc(sizeof(CookedConstraint));
@@ -15486,6 +15501,26 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		if (ldistro && ldistro->ptype == POLICYTYPE_REPLICATED)
 		{
 			rep_pol = true;
+
+			/*
+			 *  Check default columns for existence of volatile expressions,
+			 *  which are prohibited for replicated tables.
+			 */
+			TupleConstr *constr = rel->rd_att->constr;
+			if (constr)
+			{
+				for (int i = constr->num_defval - 1; i >= 0; i--)
+				{
+					char *adbin = constr->defval[i].adbin;
+					if (adbin && contain_volatile_functions_not_nextval(stringToNode(adbin)))
+						ereport(ERROR,
+								(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
+								 errmsg("volatile expressions are not supported as "
+										"default values for columns in replicated tables"),
+								 errdetail("Cannot change policy as some of the columns have volatile "
+										   "expressions as defaults.")));
+				}
+			}
 
 			if (GpPolicyIsReplicated(rel->rd_cdbpolicy))
 				ereport(WARNING,

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -3039,3 +3039,53 @@ SELECT * FROM test_part WHERE field2 IN (SELECT field1 FROM test_ref) ORDER BY 1
 
 DROP TABLE test_ref;
 DROP TABLE test_part;
+-- Test that adding new column with default value as volatile function
+-- on replicated tables fails.
+-- https://github.com/GreengageDB/greengage/pull/321
+-- start_ignore
+DROP TABLE IF EXISTS dist_replicated;
+DROP FUNCTION IF EXISTS fn_vol() CASCADE;
+DROP FUNCTION IF EXISTS fn_val() CASCADE;
+-- end_ignore
+CREATE TABLE dist_replicated(a int) DISTRIBUTED REPLICATED;
+INSERT INTO dist_replicated(a) SELECT v FROM generate_series(1,10) v;
+CREATE FUNCTION fn_vol()
+        RETURNS int
+        LANGUAGE plpgsql
+        VOLATILE
+AS $$
+BEGIN
+	RETURN floor(random() * 100 + 1);
+END;
+$$
+EXECUTE ON ANY;
+CREATE FUNCTION fn_val()
+        RETURNS int
+        LANGUAGE plpgsql
+        IMMUTABLE
+AS $$
+BEGIN
+	RETURN 42;
+END;
+$$
+EXECUTE ON ANY;
+ALTER TABLE dist_replicated ADD COLUMN x int DEFAULT fn_vol();
+ERROR:  volatile expressions are not supported as default values for columns in replicated tables
+ALTER TABLE dist_replicated ADD COLUMN x int DEFAULT (fn_vol() + 1) * (42 + 42);
+ERROR:  volatile expressions are not supported as default values for columns in replicated tables
+ALTER TABLE dist_replicated ADD COLUMN x int DEFAULT fn_val();
+ALTER TABLE dist_replicated ALTER COLUMN x SET DEFAULT fn_vol();
+ERROR:  volatile expressions are not supported as default values for columns in replicated tables
+ALTER TABLE dist_replicated ALTER COLUMN x SET DEFAULT (fn_vol() + 1) * (42 + 42);
+ERROR:  volatile expressions are not supported as default values for columns in replicated tables
+ALTER TABLE dist_replicated ALTER COLUMN x SET DEFAULT fn_val();
+CREATE TABLE dist_by_key(x int DEFAULT fn_vol()) DISTRIBUTED BY (x);
+ALTER TABLE dist_by_key SET DISTRIBUTED REPLICATED;
+ERROR:  volatile expressions are not supported as default values for columns in replicated tables
+DETAIL:  Cannot change policy as some of the columns have volatile expressions as defaults.
+ALTER TABLE dist_by_key ALTER COLUMN x SET DEFAULT fn_val();
+ALTER TABLE dist_by_key SET DISTRIBUTED REPLICATED;
+DROP TABLE dist_replicated;
+DROP TABLE dist_by_key;
+DROP FUNCTION fn_vol();
+DROP FUNCTION fn_val();

--- a/src/test/regress/expected/create_table.out
+++ b/src/test/regress/expected/create_table.out
@@ -230,3 +230,51 @@ CREATE UNLOGGED TABLE unlogged_toast (a text);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greengage Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 TRUNCATE unlogged_toast;
+-- Test that creating replicated table with default value as 
+-- volatile function in some column fails.
+-- https://github.com/GreengageDB/greengage/pull/321
+-- start_ignore
+DROP TABLE IF EXISTS dist_replicated;
+DROP TABLE IF EXISTS parent_vol;
+DROP TABLE IF EXISTS parent_val;
+DROP TABLE IF EXISTS child;
+DROP FUNCTION IF EXISTS fn_vol() CASCADE;
+DROP FUNCTION IF EXISTS fn_val() CASCADE;
+-- end_ignore
+CREATE FUNCTION fn_vol()
+        RETURNS int
+        LANGUAGE plpgsql
+        VOLATILE
+AS $$
+BEGIN
+	RETURN floor(random() * 100 + 1);
+END;
+$$
+EXECUTE ON ANY;
+CREATE FUNCTION fn_val()
+        RETURNS int
+        LANGUAGE plpgsql
+        IMMUTABLE
+AS $$
+BEGIN
+	RETURN 42;
+END;
+$$
+EXECUTE ON ANY;
+CREATE TABLE dist_replicated(id int, x int DEFAULT fn_vol()) DISTRIBUTED REPLICATED;
+ERROR:  volatile expressions are not supported as default values for columns in replicated tables
+CREATE TABLE dist_replicated(id int, x int DEFAULT (fn_vol() + 1) * (42 + 42)) DISTRIBUTED REPLICATED;
+ERROR:  volatile expressions are not supported as default values for columns in replicated tables
+CREATE TABLE dist_replicated(id int, x int DEFAULT fn_val()) DISTRIBUTED REPLICATED;
+CREATE TABLE parent_vol (a int DEFAULT fn_vol()) DISTRIBUTED BY (a);
+CREATE TABLE parent_val (a int DEFAULT fn_val()) DISTRIBUTED BY (a);
+CREATE TABLE child (LIKE parent_vol INCLUDING DEFAULTS) DISTRIBUTED REPLICATED;
+ERROR:  volatile expressions are not supported as default values for columns in replicated tables
+DETAIL:  Volatile expression(s) originate from the table(s) specified in the LIKE clause(s)
+CREATE TABLE child (LIKE parent_val INCLUDING DEFAULTS) DISTRIBUTED REPLICATED;
+DROP TABLE dist_replicated;
+DROP TABLE parent_vol;
+DROP TABLE parent_val;
+DROP TABLE child;
+DROP FUNCTION fn_vol();
+DROP FUNCTION fn_val();

--- a/src/test/regress/sql/alter_table.sql
+++ b/src/test/regress/sql/alter_table.sql
@@ -1857,3 +1857,52 @@ SELECT * FROM test_part WHERE field2 IN (SELECT field1 FROM test_ref) ORDER BY 1
 
 DROP TABLE test_ref;
 DROP TABLE test_part;
+
+-- Test that adding new column with default value as volatile function
+-- on replicated tables fails.
+-- https://github.com/GreengageDB/greengage/pull/321
+-- start_ignore
+DROP TABLE IF EXISTS dist_replicated;
+DROP FUNCTION IF EXISTS fn_vol() CASCADE;
+DROP FUNCTION IF EXISTS fn_val() CASCADE;
+-- end_ignore
+CREATE TABLE dist_replicated(a int) DISTRIBUTED REPLICATED;
+INSERT INTO dist_replicated(a) SELECT v FROM generate_series(1,10) v;
+CREATE FUNCTION fn_vol()
+        RETURNS int
+        LANGUAGE plpgsql
+        VOLATILE
+AS $$
+BEGIN
+	RETURN floor(random() * 100 + 1);
+END;
+$$
+EXECUTE ON ANY;
+CREATE FUNCTION fn_val()
+        RETURNS int
+        LANGUAGE plpgsql
+        IMMUTABLE
+AS $$
+BEGIN
+	RETURN 42;
+END;
+$$
+EXECUTE ON ANY;
+
+ALTER TABLE dist_replicated ADD COLUMN x int DEFAULT fn_vol();
+ALTER TABLE dist_replicated ADD COLUMN x int DEFAULT (fn_vol() + 1) * (42 + 42);
+ALTER TABLE dist_replicated ADD COLUMN x int DEFAULT fn_val();
+
+ALTER TABLE dist_replicated ALTER COLUMN x SET DEFAULT fn_vol();
+ALTER TABLE dist_replicated ALTER COLUMN x SET DEFAULT (fn_vol() + 1) * (42 + 42);
+ALTER TABLE dist_replicated ALTER COLUMN x SET DEFAULT fn_val();
+
+CREATE TABLE dist_by_key(x int DEFAULT fn_vol()) DISTRIBUTED BY (x);
+ALTER TABLE dist_by_key SET DISTRIBUTED REPLICATED;
+ALTER TABLE dist_by_key ALTER COLUMN x SET DEFAULT fn_val();
+ALTER TABLE dist_by_key SET DISTRIBUTED REPLICATED;
+
+DROP TABLE dist_replicated;
+DROP TABLE dist_by_key;
+DROP FUNCTION fn_vol();
+DROP FUNCTION fn_val();

--- a/src/test/regress/sql/create_table.sql
+++ b/src/test/regress/sql/create_table.sql
@@ -259,3 +259,51 @@ DROP TABLE unlogged1, public.unlogged2;
 -- Leave the table on purpose for pg_dump and gp_replica_check tests.
 CREATE UNLOGGED TABLE unlogged_toast (a text);
 TRUNCATE unlogged_toast;
+
+-- Test that creating replicated table with default value as 
+-- volatile function in some column fails.
+-- https://github.com/GreengageDB/greengage/pull/321
+-- start_ignore
+DROP TABLE IF EXISTS dist_replicated;
+DROP TABLE IF EXISTS parent_vol;
+DROP TABLE IF EXISTS parent_val;
+DROP TABLE IF EXISTS child;
+DROP FUNCTION IF EXISTS fn_vol() CASCADE;
+DROP FUNCTION IF EXISTS fn_val() CASCADE;
+-- end_ignore
+CREATE FUNCTION fn_vol()
+        RETURNS int
+        LANGUAGE plpgsql
+        VOLATILE
+AS $$
+BEGIN
+	RETURN floor(random() * 100 + 1);
+END;
+$$
+EXECUTE ON ANY;
+CREATE FUNCTION fn_val()
+        RETURNS int
+        LANGUAGE plpgsql
+        IMMUTABLE
+AS $$
+BEGIN
+	RETURN 42;
+END;
+$$
+EXECUTE ON ANY;
+
+CREATE TABLE dist_replicated(id int, x int DEFAULT fn_vol()) DISTRIBUTED REPLICATED;
+CREATE TABLE dist_replicated(id int, x int DEFAULT (fn_vol() + 1) * (42 + 42)) DISTRIBUTED REPLICATED;
+CREATE TABLE dist_replicated(id int, x int DEFAULT fn_val()) DISTRIBUTED REPLICATED;
+
+CREATE TABLE parent_vol (a int DEFAULT fn_vol()) DISTRIBUTED BY (a);
+CREATE TABLE parent_val (a int DEFAULT fn_val()) DISTRIBUTED BY (a);
+CREATE TABLE child (LIKE parent_vol INCLUDING DEFAULTS) DISTRIBUTED REPLICATED;
+CREATE TABLE child (LIKE parent_val INCLUDING DEFAULTS) DISTRIBUTED REPLICATED;
+
+DROP TABLE dist_replicated;
+DROP TABLE parent_vol;
+DROP TABLE parent_val;
+DROP TABLE child;
+DROP FUNCTION fn_vol();
+DROP FUNCTION fn_val();


### PR DESCRIPTION
What happens?
Distribution policy of replicated tables can be violated via usage of ALTER
TABLE (or CREATE TABLE) and a volatile expression as a default
value.

Why it happens?
No check for this case is made anywhere in the code, thus different data may
appear on segment's table.

How do we fix this?
Main check for expression volatility and table's distribution policy
inside AddRelationNewConstraintsn(), additional ones in
ATExecCookedColumnDefault() and ATExecSetDistributedBy() are made, to output
an error before table is altered or created.

Tests?
Two tests were developed. One for volatile case, which is prohibited. Another
one for immutable - it works. These cases applied to both ALTER TABLE (ADD
COLUMN, ALTER COLUMN, SET DISTRIBUTED) and CREATE TABLE.

Changes from original commit:
Logic to prohibit violating policy via usage of LIKE during CREATE TABLE was
moved to DefineRelation(), as ATExecCookedColumnDefault() route does not exists
in 6.x.

Changes in tests: 
minor changes due to functions syntax difference and order of
error detail message, also some changes to ao and aocs tests were removed as
those tests are not present in 6.x.

(cherry picked from commit 7cd685d)

Ticket: GG-203

!!!REBASE-ONLY!!!