### PR TITLE
CI-5462 Replace ubuntu-latest runners with ubuntu-24.04 (7.x)

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v25
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v28
     with:
       version: 7
       target_os: ${{ matrix.target_os }}
@@ -41,7 +41,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v24
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v28
     with:
       version: 7
       target_os: ${{ matrix.target_os }}
@@ -59,7 +59,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v19
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v28
     with:
       version: 7
       target_os: ${{ matrix.target_os }}
@@ -77,7 +77,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v19
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v28
     with:
       version: 7
       target_os: ${{ matrix.target_os }}
@@ -95,7 +95,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v13
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v28
     with:
       version: 7
       target_os: ${{ matrix.target_os }}
@@ -113,7 +113,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-jit.yml@v19
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-jit.yml@v28
     with:
       version: 7
       target_os: ${{ matrix.target_os }}
@@ -131,7 +131,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-upload.yml@v21
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-upload.yml@v28
     with:
       version: 7
       target_os: ${{ matrix.target_os }}

--- a/.github/workflows/greengage-sql-dump.yml
+++ b/.github/workflows/greengage-sql-dump.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   create-sql-dump-regression:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 180
     if: |
       github.event.workflow_run.event == 'push' &&
@@ -102,7 +102,7 @@ jobs:
           EOF
 
   verify-dumps-created:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: create-sql-dump-regression
     if: always()
     steps:


### PR DESCRIPTION
## Replace ubuntu-latest runners with ubuntu-24.04 (7.x) (#368)

Github will introduce new ubuntu-latest with ubuntu 26.04 version.
So there could be errors in pipelines with new version. 
It is needed to define a fixed tag 24.04 for all GG actions.

Task: CI-5460