### PR TITLE
CI-5461 Replace ubuntu-latest runners with ubuntu-24.04 (6.x)

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v26
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v28
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
@@ -48,7 +48,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v26
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v28
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
@@ -67,7 +67,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v26
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v28
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
@@ -85,7 +85,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v19
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v28
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
@@ -103,7 +103,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v23
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v28
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
@@ -121,7 +121,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-upload.yml@v21
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-upload.yml@v28
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
@@ -141,7 +141,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v10
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v28
     with:
       version: 6
       target_os: ${{ matrix.target_os }}

--- a/.github/workflows/greengage-release.yml
+++ b/.github/workflows/greengage-release.yml
@@ -13,7 +13,7 @@ jobs:
         include:
         - artifact_name: deb-packages
           extensions:    deb ddeb
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       actions: read


### PR DESCRIPTION
## Replace ubuntu-latest runners with ubuntu-24.04 (6.x) (#369)

Github will introduce new ubuntu-latest with ubuntu 26.04 version.
So there could be errors in pipelines with new version.
It is needed to define a fixed tag 24.04 for all GG actions.

Task: CI-5460