### PR TITLE
GG-360: Prohibit moving from bypassed resource group

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3852,6 +3852,8 @@ check_and_unassign_from_resgroup(PlannedStmt* stmt)
 
 	cgroupOpsRoutine->attachcgroup(bypassedGroup->groupId, MyProcPid,
 								   bypassedGroup->caps.cpuMaxPercent == CPU_MAX_PERCENT_DISABLED);
+
+	SIMPLE_FAULT_INJECTOR("check_and_unassign_from_resgroup_entry_bypassed");
 }
 
 /*

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3726,6 +3726,31 @@ ResGroupGetGroupIdBySessionId(int sessionId)
 }
 
 /*
+ * is resource group bypassed by session id
+ */
+bool
+IsResGroupBypassedBySessionId(int sessionId)
+{
+	bool bypassed = false;
+	SessionState *curSessionState;
+
+	LWLockAcquire(SessionStateLock, LW_SHARED);
+	curSessionState = AllSessionStateEntries->usedList;
+	while (curSessionState != NULL)
+	{
+		if (curSessionState->sessionId == sessionId)
+		{
+			bypassed = curSessionState->bypassResGroupId != InvalidOid;
+			break;
+		}
+		curSessionState = curSessionState->next;
+	}
+	LWLockRelease(SessionStateLock);
+
+	return bypassed;
+}
+
+/*
  * In resource group mode, how much memory should a query take in bytes.
  */
 uint64
@@ -3822,6 +3847,8 @@ check_and_unassign_from_resgroup(PlannedStmt* stmt)
 	pgstat_report_resgroup(bypassedGroup->groupId);
 	bypassedSlot.group = groupInfo.group;
 	bypassedSlot.groupId = groupInfo.groupId;
+	/* Share bypassed group id for prohibit moving. */
+	MySessionState->bypassResGroupId = groupInfo.groupId;
 
 	cgroupOpsRoutine->attachcgroup(bypassedGroup->groupId, MyProcPid,
 								   bypassedGroup->caps.cpuMaxPercent == CPU_MAX_PERCENT_DISABLED);

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3847,8 +3847,15 @@ check_and_unassign_from_resgroup(PlannedStmt* stmt)
 	pgstat_report_resgroup(bypassedGroup->groupId);
 	bypassedSlot.group = groupInfo.group;
 	bypassedSlot.groupId = groupInfo.groupId;
+	/*
+	 * SessionStateLock is required since IsResGroupBypassedBySessionId will
+	 * traverse the current session array and check corresponding
+	 * bypassResGroupId with shared lock on SessionStateLock.
+	 */
+	LWLockAcquire(SessionStateLock, LW_EXCLUSIVE);
 	/* Share bypassed group id for prohibit moving. */
 	MySessionState->bypassResGroupId = groupInfo.groupId;
+	LWLockRelease(SessionStateLock);
 
 	cgroupOpsRoutine->attachcgroup(bypassedGroup->groupId, MyProcPid,
 								   bypassedGroup->caps.cpuMaxPercent == CPU_MAX_PERCENT_DISABLED);

--- a/src/backend/utils/resgroup/resgroup_helper.c
+++ b/src/backend/utils/resgroup/resgroup_helper.c
@@ -493,6 +493,11 @@ pg_resgroup_move_query(PG_FUNCTION_ARGS)
 					(errcode(ERRCODE_UNDEFINED_OBJECT),
 							(errmsg("cannot find process: %d", pid))));
 
+		if (IsResGroupBypassedBySessionId(sessionId))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							(errmsg("cannot move a process from bypassed group"))));
+
 		currentGroupId = ResGroupGetGroupIdBySessionId(sessionId);
 		if (currentGroupId == InvalidOid)
 			ereport(ERROR,

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -220,6 +220,7 @@ extern Oid SessionGetResGroupId(SessionState *session);
 extern void HandleMoveResourceGroup(void);
 extern void ResGroupMoveQuery(int sessionId, Oid groupId, const char *groupName);
 extern Oid ResGroupGetGroupIdBySessionId(int sessionId);
+extern bool IsResGroupBypassedBySessionId(int sessionId);
 extern char *getCpuSetByRole(const char *cpuset);
 extern void checkCpuSetByRole(const char *cpuset);
 extern bool checkTablespaceInIOlimit(Oid tblspcid, bool errout);

--- a/src/test/isolation2/expected/resgroup/resgroup_move_query.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_move_query.out
@@ -44,6 +44,30 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 CREATE EXTENSION
 
 
+-- test0: cannot move bypassed sessions
+1: SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry_bypassed', 'suspend', 1, current_setting('gp_session_id')::int);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: SELECT pg_sleep(1);  <waiting ...>
+SELECT gp_wait_until_triggered_fault('check_and_unassign_from_resgroup_entry_bypassed', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+SELECT pg_resgroup_move_query(pid, 'default_group') FROM pg_stat_activity WHERE query LIKE '%pg_sleep(1)%' AND sess_id != current_setting('gp_session_id')::int;
+ERROR:  cannot move a process from bypassed group
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry_bypassed', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1<:  <... completed>
+ pg_sleep 
+----------
+          
+(1 row)
 
 -- test1: cannot move IDLE sessions
 1: SET ROLE role_move_query;

--- a/src/test/isolation2/sql/resgroup/resgroup_move_query.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_move_query.sql
@@ -34,6 +34,13 @@ CREATE ROLE role_move_query_small RESOURCE GROUP rg_move_query_small;
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 
 
+-- test0: cannot move bypassed sessions
+1: SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry_bypassed', 'suspend', 1, current_setting('gp_session_id')::int);
+1&: SELECT pg_sleep(1);
+SELECT gp_wait_until_triggered_fault('check_and_unassign_from_resgroup_entry_bypassed', 1, 1);
+SELECT pg_resgroup_move_query(pid, 'default_group') FROM pg_stat_activity WHERE query LIKE '%pg_sleep(1)%' AND sess_id != current_setting('gp_session_id')::int;
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry_bypassed', 'reset', 1);
+1<:
 
 -- test1: cannot move IDLE sessions
 1: SET ROLE role_move_query;


### PR DESCRIPTION
Prohibit moving from bypassed resource group

Some "simple" queries could be bypassed by the check_and_unassign_from_resgroup
function. After this, attempting to move these bypassed queries to another
resource group would return an incorrect error message stating "process <pid>
is in IDLE state." However, the pg_stat_activity view showed that these queries
were still active. This occurred because, before bypassing the queries, the
UnassignResGroup->sessionResetSlot functions reset the current session's
resGroupSlot field, which the ResGroupGetGroupIdBySessionId function used to
determine the current group when moving the session. If no current group was
specified, the pg_resgroup_move_query move function assumed the session was in
an idle state. Proper error messages should be issued regarding the inability
to move these bypassed queries. Store the group ID in the bypassResGroupId
field of the current session and add a new IsResGroupBypassedBySessionId
function to check for the setting of this field. Add the corresponding test.

Ticket: GG-360