### PR TITLE
GG-355: Changing GUC gp_role during session leads to segfault on a segment

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -495,11 +495,11 @@ assign_gp_session_role(const char *newval, void *extra)
 
 
 /*
- * Check and Assign routines for "gp_role" option.  This variable has context
- * PGC_SUSET so that is can only be set by a superuser via the SET command.
- * (It can also be set using an option on postmaster start, but this isn't
- * interesting beccause the derived global CdbRole is always set (along with
- * CdbSessionRole) on backend startup for a new connection.
+ * Check and Assign routines for "gp_role" option. Initially,
+ * this variable had context PGC_SUSET so that is could only be set by
+ * a superuser via the SET command. In greengage, we swapped it
+ * to PGC_BACKEND, as the code responsible for changing Gp_role at runtime
+ * is outdated and doesn't work anymore.
  *
  * See src/backend/util/misc/guc.c for option definition.
  */
@@ -548,6 +548,16 @@ assign_gp_role(const char *newval, void *extra)
 		cdb_cleanup(0, 0);
 
 	Gp_role = newrole;
+
+	/*
+	 * The functionality of the code below is questionable,
+	 * as it can easily result in a segmentation fault,
+	 * for example, when trying to 'set gp_role to dispatch;'
+	 * during a running session
+	 *
+	 * We work around this issue by not allowing to change
+	 * gp_role at runtime.
+	 */
 
 	if (do_connect)
 	{

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -495,11 +495,11 @@ assign_gp_session_role(const char *newval, void *extra)
 
 
 /*
- * Check and Assign routines for "gp_role" option. Initially,
- * this variable had context PGC_SUSET so that is could only be set by
- * a superuser via the SET command. In greengage, we swapped it
+ * Check and Assign routines for "gp_role" option.
+ * Note: initially, this variable had context PGC_SUSET so that is could only
+ * be set by a superuser via the SET command. In greengage, we swapped it
  * to PGC_BACKEND, as the code responsible for changing Gp_role at runtime
- * is outdated and doesn't work anymore.
+ * is outdated.
  *
  * See src/backend/util/misc/guc.c for option definition.
  */

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -5066,7 +5066,7 @@ struct config_string ConfigureNamesString_gp[] =
 	},
 
 	{
-		{"gp_role", PGC_SUSET, CLIENT_CONN_OTHER,
+		{"gp_role", PGC_BACKEND, GP_WORKER_IDENTITY,
 			gettext_noop("Sets the role for the session."),
 			gettext_noop("Valid values are DISPATCH, EXECUTE, and UTILITY."),
 			GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -55,17 +55,21 @@
  * time and are local to the backend process resulting from the
  * connection.	The default is dispatch which is the normal setting
  * for a user of Greengage connecting to a node of  the Greengage cluster.
- * Neither parameter appears in the configuration file.
+ * Neither parameter appears in the configuration file, and both do not
+ * change during the lifetime of PostgreSQL session.
+ * The main difference is that:
  *
  * gp_session_role
  *
- * - does not affect the operation of the backend, and
- * - does not change during the lifetime of PostgreSQL session.
+ * - does not affect the operation of the backend
  *
  * gp_role
  *
- * - determines the operating role of the backend, and
- * - may be changed by a superuser via the SET command.
+ * - determines the operating role of the backend
+ *
+ * (Note that there is no point in keeping both of these parameters,
+ * as they remain intact only because changing this legacy logic
+ * will take some effort)
  *
  * The connection time value of gp_session_role used by a
  * libpq-based client application can be specified using the

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -730,4 +730,9 @@ FETCH c2;
 (1 row)
 
 END;
+-- test that it is impossible to switch Gp_role amidst of a session
+SET gp_role TO EXECUTE;
+ERROR:  parameter "gp_role" cannot be set after connection start
+SET gp_session_role TO EXECUTE;
+ERROR:  parameter "gp_session_role" cannot be set after connection start
 DROP TABLE guc_gp_t1;

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -730,7 +730,7 @@ FETCH c2;
 (1 row)
 
 END;
--- test that it is impossible to switch Gp_role amidst of a session
+-- test that it is impossible to switch gp_role and gp_session_role amidst of a session
 SET gp_role TO EXECUTE;
 ERROR:  parameter "gp_role" cannot be set after connection start
 SET gp_session_role TO EXECUTE;

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -441,7 +441,7 @@ FETCH c1;
 FETCH c2;
 END;
 
--- test that it is impossible to switch Gp_role amidst of a session
+-- test that it is impossible to switch gp_role and gp_session_role amidst of a session
 SET gp_role TO EXECUTE;
 SET gp_session_role TO EXECUTE;
 

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -441,4 +441,8 @@ FETCH c1;
 FETCH c2;
 END;
 
+-- test that it is impossible to switch Gp_role amidst of a session
+SET gp_role TO EXECUTE;
+SET gp_session_role TO EXECUTE;
+
 DROP TABLE guc_gp_t1;


### PR DESCRIPTION
When changing gp_role to any role other than utility during a session, 
primary segments would segfault because the new value of the guc 
gets dispatched to them.

This functionality and the related code seems dubious and largely 
outdated, and there is no point in fixing it. So let's make a quick fix
of the immediate problem that may affect the users by making sure
that this code path never gets executed.

There is a proper fix of it already, f6297b96eeb4937629bd796333f6118340613197
but it never made it way to 6.x version. Sadly, I wasn't able to port 
it in a timely manner.
Therefore cleanup of the outdated logic remains as a separate task. 