### PR TITLE
Implement progress reporting for ggrebalance

### DIFF
--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -82,6 +82,12 @@ def parseargs():
                       help='Use host names when updating the pg_hba.conf file.')
     parser.add_option('--replay-lag', dest="replay_lag", type="float",
                       help='Replay lag(in GBs) allowed on mirror when rebalancing the segments.')
+    parser.add_option('-D', '--detailed-progress', dest='detailed_progress', action='store_true', default=False,
+                      help='Show a detailed progress view.')
+    parser.add_option('-S', '--simple-progress', dest='simple_progress', action='store_true', default=False,
+                      help='Show a simple progress view.')
+    parser.add_option('--no-progress', dest='no_progress', action='store_true', default=False,
+                      help='Suppress progress reports.')
     parser.add_option('-v', '--verbose', action='store_true', default=False,
                       help='debug output.')
     parser.add_option('--inplace-swap-roles', dest="inplace_swap_roles", action='store_true', default=False,
@@ -143,15 +149,20 @@ def validate_options(options, args, parser):
             'target_hosts', 'target_hosts_file', 'add_hosts', 'add_hosts_file',
             'remove_hosts', 'remove_hosts_file', 'target_datadirs', 'target_datadirs_file',
             'target_segment_count', 'mirror_mode', 'skip_rebalance', 'show_plan',
-            'skip_resource_estimation', 'analyze', 'replay_lag', 'hba_hostnames', 'inplace_swap_roles'
+            'skip_resource_estimation', 'analyze', 'replay_lag', 'hba_hostnames', 'inplace_swap_roles',
+            'detailed_progress', 'simple_progress', 'no_progress'
         ]),
 
         ('rollback_required', [
             'target_hosts', 'target_hosts_file', 'add_hosts', 'add_hosts_file',
             'remove_hosts', 'remove_hosts_file', 'target_datadirs', 'target_datadirs_file',
             'target_segment_count', 'mirror_mode', 'skip_rebalance', 'show_plan',
-            'skip_resource_estimation', 'duration', 'end', 'inplace_swap_roles'
+            'skip_resource_estimation', 'duration', 'end', 'inplace_swap_roles',
+            'detailed_progress', 'simple_progress', 'no_progress'
         ]),
+
+        ('detailed_progress', ['simple_progress', 'no_progress']),
+        ('simple_progress', ['no_progress'])
     ]
 
     def option_is_set(opt_name):
@@ -179,6 +190,11 @@ def validate_options(options, args, parser):
     if option_is_set('mirror_mode') and options.mirror_mode not in ('grouped', 'spread'):
         logger.error('Mirroring strategy %s is not supported' % options.mirror_mode)
         parser.exit(1)
+
+    if not (option_is_set('detailed_progress') or
+            option_is_set('simple_progress') or
+            option_is_set('no_progress')):
+        options.simple_progress = True
 
     return options, args
 

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
@@ -274,7 +274,7 @@ class GGRebalanceMainSM:
     def on_enter_STATE_SETUP_SCHEMA_STARTED(self) -> None:
         # Create schema and status tables.
         # It will also save plan in order to use it for recovering after interruption
-        self.rebalance_schema.createSchema(self.plan, self.options)
+        self.rebalance_schema.createSchema(self.plan, self.options, self.gg_shrink.states_rollback_flow)
         self.trigger('move_to_STATE_SETUP_SCHEMA_DONE')
 
     @wrap_func_with_faults

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
@@ -274,7 +274,7 @@ class GGRebalanceMainSM:
     def on_enter_STATE_SETUP_SCHEMA_STARTED(self) -> None:
         # Create schema and status tables.
         # It will also save plan in order to use it for recovering after interruption
-        self.rebalance_schema.createSchema(self.plan)
+        self.rebalance_schema.createSchema(self.plan, self.options)
         self.trigger('move_to_STATE_SETUP_SCHEMA_DONE')
 
     @wrap_func_with_faults

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
@@ -274,7 +274,13 @@ class GGRebalanceMainSM:
     def on_enter_STATE_SETUP_SCHEMA_STARTED(self) -> None:
         # Create schema and status tables.
         # It will also save plan in order to use it for recovering after interruption
-        self.rebalance_schema.createSchema(self.plan, self.options, self.gg_shrink.states_rollback_flow)
+        if self.options.no_progress:
+            progress_type = self.rebalance_schema.ProgressType.PROGRESS_NO
+        elif self.options.detailed_progress:
+            progress_type = self.rebalance_schema.ProgressType.PROGRESS_DETAILED
+        else:
+            progress_type = self.rebalance_schema.ProgressType.PROGRESS_SIMPLE
+        self.rebalance_schema.createSchema(self.plan, progress_type, self.gg_shrink.states_rollback_flow)
         self.trigger('move_to_STATE_SETUP_SCHEMA_DONE')
 
     @wrap_func_with_faults

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -22,6 +22,12 @@ class RebalanceSchema:
     STATE_CATEGORY_REBALANCE = 'REBALANCE'
     STATE_CATEGORY_MAIN = 'MAIN'
 
+    class ProgressType(Enum):
+        PROGRESS_NOT_DEFINED = 0
+        PROGRESS_NO = 1
+        PROGRESS_SIMPLE = 2
+        PROGRESS_DETAILED = 3
+
     def __init__(self, conn: dbconn.Connection):
         self.schema_name = 'ggrebalance'
         self.rebalance_status = 'rebalance_status'
@@ -30,8 +36,9 @@ class RebalanceSchema:
         self.saved_plan = 'saved_plan'
         self.segment_move_steps = 'segment_move_steps'
         self.conn = conn
+        self.progress_type = self.ProgressType.PROGRESS_NOT_DEFINED
 
-    def createSchema(self, plan: Plan, options: Any, shrink_rollback_states: List[str]) -> None:
+    def createSchema(self, plan: Plan, progress_type: ProgressType, shrink_rollback_states: List[str]) -> None:
         dbconn.execSQL(self.conn, 'BEGIN')
         dbconn.execSQL(self.conn, f'CREATE SCHEMA {self.schema_name}')
         dbconn.execSQL(self.conn,
@@ -71,7 +78,9 @@ RETURNS boolean AS $$
         FALSE)
 $$ LANGUAGE sql''')
 
-        if options.simple_progress:
+        self.progress_type = progress_type
+
+        if self.progress_type == self.ProgressType.PROGRESS_SIMPLE:
 
             dbconn.execSQL(self.conn, f'''
 CREATE VIEW {self.schema_name}.{self.rebalance_progress_view} AS
@@ -112,8 +121,140 @@ SELECT * FROM rebalance_progress_normal_flow WHERE NOT (SELECT rollback_in_progr
 UNION ALL
 SELECT * FROM rebalance_progress_rollback_flow WHERE (SELECT rollback_in_progress FROM cond);''')
 
-        elif options.detailed_progress:
-            pass
+        elif self.progress_type == self.ProgressType.PROGRESS_DETAILED:
+
+            dbconn.execSQL(self.conn, f'''
+CREATE VIEW {self.schema_name}.{self.rebalance_progress_view} AS
+WITH
+cond AS (SELECT ggrebalance._is_rollback() AS rollback_in_progress),
+rebalance_progress_normal_flow AS
+    (
+    WITH
+    stat_processed AS (
+        SELECT
+            count(1) as tables_processed,
+            coalesce(sum(source_bytes), 0)::float AS bytes_processed,
+            coalesce(sum(source_bytes) / EXTRACT(EPOCH FROM (max(rebalance_finished) - max(rebalance_started))), 0)::float AS est_processing_rate
+        FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NOT NULL AND rebalance_finished IS NOT NULL
+        ),
+    stat_in_processing AS (
+        SELECT
+            count(1) as tables_in_processing,
+            coalesce(sum(source_bytes), 0) bytes_in_processing
+        FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none' AND rebalance_started IS NOT NULL
+        ),
+    stat_left_to_process AS (
+        SELECT
+            coalesce(sum(source_bytes), 0)::float as bytes_left_to_process
+        FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none'
+        )
+    SELECT
+        '1.1. Tables shrinked' AS stat_name,
+        tables_processed::text AS stat_value
+    FROM stat_processed
+    UNION
+    SELECT
+        '1.3. Tables left to shrink' AS stat_name,
+        count(1)::text AS stat_value
+    FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none' AND rebalance_started IS NULL AND rebalance_finished IS NULL
+    UNION
+    SELECT
+        '1.2. Tables shrink in progress' AS stat_name,
+        tables_in_processing::text AS stat_value
+    FROM stat_in_processing
+    UNION
+    SELECT
+        '2.1. Bytes processed' AS stat_name,
+        bytes_processed::text AS stat_value
+    FROM stat_processed
+    UNION
+    SELECT
+        '2.2. Bytes left to process' AS stat_name,
+        bytes_left_to_process::text AS stat_value
+    FROM stat_left_to_process
+    UNION
+    SELECT
+        '2.3. Bytes in progress' AS stat_name,
+        bytes_in_processing::text AS stat_value
+    FROM stat_in_processing
+    UNION
+    SELECT
+        '3.1. Estimated rebalance rate' AS stat_name,
+        (est_processing_rate / (1024*1024))::text || ' MB/s' AS stat_value
+    FROM stat_processed
+    UNION
+    SELECT
+        '3.2. Estimated time' AS stat_name,
+        CASE
+            WHEN p.est_processing_rate = 0 THEN 'not defined'
+            ELSE (l.bytes_left_to_process / p.est_processing_rate)::text || ' s'
+        END AS stat_value
+    FROM stat_left_to_process l, stat_processed p 
+    ORDER BY stat_name ASC
+    ),
+rebalance_progress_rollback_flow AS
+    (
+    WITH
+    stat_processed AS (
+        SELECT
+            count(1) as tables_processed,
+            coalesce(sum(source_bytes), 0)::float AS bytes_processed,
+            coalesce(sum(source_bytes) / EXTRACT(EPOCH FROM (max(rebalance_finished) - max(rebalance_started))), 0)::float AS est_processing_rate
+        FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none' AND rebalance_started IS NOT NULL AND rebalance_finished IS NOT NULL
+        ),
+    stat_in_processing AS (
+        SELECT
+            count(1) as tables_in_processing,
+            coalesce(sum(source_bytes), 0) bytes_in_processing
+        FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NOT NULL
+        ),
+    stat_left_to_process AS (
+        SELECT
+            coalesce(sum(source_bytes), 0)::float as bytes_left_to_process
+        FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done'
+        )
+    SELECT
+        '1.1 Tables rollback in progress' AS stat_name,
+        count(1)::text AS stat_value
+    FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NOT NULL AND rebalance_finished IS NULL
+    UNION
+    SELECT
+        '1.2 Tables left to rollback' AS stat_name,
+        count(1)::text AS stat_value
+    FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NULL
+    UNION
+    SELECT
+        '2.1. Bytes processed' AS stat_name,
+        bytes_processed::text AS stat_value
+    FROM stat_processed
+    UNION
+    SELECT
+        '2.2. Bytes left to process' AS stat_name,
+        bytes_left_to_process::text AS stat_value
+    FROM stat_left_to_process
+    UNION
+    SELECT
+        '2.3. Bytes in progress' AS stat_name,
+        bytes_in_processing::text AS stat_value
+    FROM stat_in_processing
+    UNION
+    SELECT
+        '3.1. Estimated rebalance rate' AS stat_name,
+        (est_processing_rate / (1024*1024))::text || ' MB/s' AS stat_value
+    FROM stat_processed
+    UNION
+    SELECT
+        '3.2. Estimated time' AS stat_name,
+        CASE
+            WHEN p.est_processing_rate = 0 THEN 'not defined'
+            ELSE (l.bytes_left_to_process / p.est_processing_rate)::text || ' s'
+        END AS stat_value
+    FROM stat_left_to_process l, stat_processed p
+    ORDER BY stat_name ASC
+    )
+SELECT * FROM rebalance_progress_normal_flow WHERE NOT (SELECT rollback_in_progress FROM cond)
+UNION ALL
+SELECT * FROM rebalance_progress_rollback_flow WHERE (SELECT rollback_in_progress FROM cond)''')
 
         dbconn.execSQL(self.conn, 'COMMIT')
 
@@ -214,12 +355,11 @@ SELECT * FROM rebalance_progress_rollback_flow WHERE (SELECT rollback_in_progres
                        f'''DELETE FROM {self.schema_name}.{self.table_rebalance_status_detail}
                        WHERE (status = '{status}')''')
 
-    def addTableToRebalance(self, db: str, schema_name: str, rel_name: str, status: str) -> None:
-        # TODO: set source_bytes here?
+    def addTableToRebalance(self, db: str, schema_name: str, rel_name: str, status: str, rel_size: int) -> None:
         dbconn.execSQL(self.conn,
                        f'''INSERT INTO {self.schema_name}.{self.table_rebalance_status_detail}
                        VALUES ('{escape_string(db)}', '{escape_string(schema_name)}', '{escape_string(rel_name)}', '{status}',
-                                'SHRINK', NULL, NULL, 0 )''')
+                                'SHRINK', NULL, NULL, {rel_size} )''')
 
     def setTableRebalanceStartTime(self, db: str, schema_name: str, rel_name: str) -> None:
         dbconn.execSQL(self.conn,
@@ -274,3 +414,18 @@ SELECT * FROM rebalance_progress_rollback_flow WHERE (SELECT rollback_in_progres
 
         return result
 
+    def getProgressType(self) -> ProgressType:
+        if self.progress_type != self.ProgressType.PROGRESS_NOT_DEFINED:
+            return self.progress_type
+        # We check the progress type basing on the existence of the progress view
+        # and number of values there.
+        if 0 == int(dbconn.querySingleton(self.conn,
+            f"SELECT CASE WHEN to_regclass('{self.schema_name}.{self.rebalance_progress_view}') IS NULL THEN 0 ELSE 1 END AS view_exists")):
+            self.progress_type = self.ProgressType.PROGRESS_NO
+        else:
+            if 3 >= int(dbconn.querySingleton(self.conn,
+                f"SELECT count(1) FROM {self.schema_name}.{self.rebalance_progress_view}")):
+                self.progress_type = self.ProgressType.PROGRESS_SIMPLE
+            else:
+                self.progress_type = self.ProgressType.PROGRESS_DETAILED
+        return self.progress_type

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -89,7 +89,7 @@ cond AS (SELECT ggrebalance._is_rollback() AS rollback_in_progress),
 rebalance_progress_normal_flow AS
     (
     SELECT
-        '1.1. Tables shrinked' AS stat_name,
+        '1.1. Tables shrunk' AS stat_name,
         count(1)::text AS stat_value
     FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NOT NULL AND rebalance_finished IS NOT NULL
     UNION
@@ -134,7 +134,7 @@ rebalance_progress_normal_flow AS
         SELECT
             count(1) as tables_processed,
             coalesce(sum(source_bytes), 0)::float AS bytes_processed,
-            coalesce(sum(source_bytes) / EXTRACT(EPOCH FROM (max(rebalance_finished) - max(rebalance_started))), 0)::float AS est_processing_rate
+            coalesce(sum(source_bytes) / EXTRACT(EPOCH FROM (max(rebalance_finished) - min(rebalance_started))), 0)::float AS est_processing_rate
         FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NOT NULL AND rebalance_finished IS NOT NULL
         ),
     stat_in_processing AS (
@@ -149,7 +149,7 @@ rebalance_progress_normal_flow AS
         FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none'
         )
     SELECT
-        '1.1. Tables shrinked' AS stat_name,
+        '1.1. Tables shrunk' AS stat_name,
         tables_processed::text AS stat_value
     FROM stat_processed
     UNION
@@ -199,7 +199,7 @@ rebalance_progress_rollback_flow AS
         SELECT
             count(1) as tables_processed,
             coalesce(sum(source_bytes), 0)::float AS bytes_processed,
-            coalesce(sum(source_bytes) / EXTRACT(EPOCH FROM (max(rebalance_finished) - max(rebalance_started))), 0)::float AS est_processing_rate
+            coalesce(sum(source_bytes) / EXTRACT(EPOCH FROM (max(rebalance_finished) - min(rebalance_started))), 0)::float AS est_processing_rate
         FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none' AND rebalance_started IS NOT NULL AND rebalance_finished IS NOT NULL
         ),
     stat_in_processing AS (

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -67,8 +67,11 @@ class RebalanceSchema:
 
         self.savePlan(plan)
 
-        states_str = ',\n'.join(f"'{s}'" for s in shrink_rollback_states)
-        dbconn.execSQL(self.conn, f'''
+        self.progress_type = progress_type
+
+        if self.progress_type != self.ProgressType.PROGRESS_NO:
+            states_str = ',\n'.join(f"'{s}'" for s in shrink_rollback_states)
+            dbconn.execSQL(self.conn, f'''
 CREATE FUNCTION ggrebalance._is_rollback()
 RETURNS boolean AS $$
     SELECT COALESCE(
@@ -77,8 +80,6 @@ RETURNS boolean AS $$
         FROM {self.schema_name}.{self.rebalance_status} WHERE state_category = 'SHRINK' ORDER BY updated DESC LIMIT 1),
         FALSE)
 $$ LANGUAGE sql''')
-
-        self.progress_type = progress_type
 
         if self.progress_type == self.ProgressType.PROGRESS_SIMPLE:
 

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -179,7 +179,7 @@ rebalance_progress_normal_flow AS
     FROM stat_in_processing
     UNION
     SELECT
-        '3.1. Estimated rebalance rate' AS stat_name,
+        '3.1. Estimated shrink rate' AS stat_name,
         (est_processing_rate / (1024*1024))::text || ' MB/s' AS stat_value
     FROM stat_processed
     UNION
@@ -239,7 +239,7 @@ rebalance_progress_rollback_flow AS
     FROM stat_in_processing
     UNION
     SELECT
-        '3.1. Estimated rebalance rate' AS stat_name,
+        '3.1. Estimated shrink rate' AS stat_name,
         (est_processing_rate / (1024*1024))::text || ' MB/s' AS stat_value
     FROM stat_processed
     UNION

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -31,7 +31,7 @@ class RebalanceSchema:
         self.segment_move_steps = 'segment_move_steps'
         self.conn = conn
 
-    def createSchema(self, plan: Plan, options: Any) -> None:
+    def createSchema(self, plan: Plan, options: Any, shrink_rollback_states: List[str]) -> None:
         dbconn.execSQL(self.conn, 'BEGIN')
         dbconn.execSQL(self.conn, f'CREATE SCHEMA {self.schema_name}')
         dbconn.execSQL(self.conn,
@@ -60,22 +60,14 @@ class RebalanceSchema:
 
         self.savePlan(plan)
 
-        # TODO: generate rollback states
-        # TODO: add check for rebalance rollback
+        states_str = ',\n'.join(f"'{s}'" for s in shrink_rollback_states)
         dbconn.execSQL(self.conn, f'''
 CREATE FUNCTION ggrebalance._is_rollback()
 RETURNS boolean AS $$
     SELECT COALESCE(
         (SELECT state IN (
-            'STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START',
-            'STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE',
-            'STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START',
-            'STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE',
-            'STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START',
-            'STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE',
-            'STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START',
-            'STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE')
-        FROM ggrebalance.rebalance_status WHERE state_category = 'SHRINK' ORDER BY updated DESC LIMIT 1),
+{states_str})
+        FROM {self.schema_name}.{self.rebalance_status} WHERE state_category = 'SHRINK' ORDER BY updated DESC LIMIT 1),
         FALSE)
 $$ LANGUAGE sql''')
 

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -108,12 +108,17 @@ rebalance_progress_normal_flow AS
 rebalance_progress_rollback_flow AS
     (
     SELECT
-        '1.1 Tables rollback in progress' AS stat_name,
+        '1.1. Tables rolled back' AS stat_name,
+        count(1)::text AS stat_value
+    FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none' AND rebalance_started IS NOT NULL AND rebalance_finished IS NOT NULL
+    UNION
+    SELECT
+        '1.2. Tables rollback in progress' AS stat_name,
         count(1)::text AS stat_value
     FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NOT NULL AND rebalance_finished IS NULL
     UNION
     SELECT
-        '1.2 Tables left to rollback' AS stat_name,
+        '1.3. Tables left to rollback' AS stat_name,
         count(1)::text AS stat_value
     FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NULL
     ORDER BY stat_name ASC
@@ -215,12 +220,17 @@ rebalance_progress_rollback_flow AS
         FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done'
         )
     SELECT
-        '1.1 Tables rollback in progress' AS stat_name,
+        '1.1. Tables rolled back' AS stat_name,
+        tables_processed::text AS stat_value
+    FROM stat_processed
+    UNION
+    SELECT
+        '1.2. Tables rollback in progress' AS stat_name,
         count(1)::text AS stat_value
     FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NOT NULL AND rebalance_finished IS NULL
     UNION
     SELECT
-        '1.2 Tables left to rollback' AS stat_name,
+        '1.3. Tables left to rollback' AS stat_name,
         count(1)::text AS stat_value
     FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NULL
     UNION

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -226,14 +226,9 @@ SELECT * FROM rebalance_progress_rollback_flow WHERE (SELECT rollback_in_progres
                        f'''UPDATE {self.schema_name}.{self.table_rebalance_status_detail} SET rebalance_started = now(), rebalance_finished = NULL
                        WHERE db_name = '{escape_string(db)}' AND schema_name = '{escape_string(schema_name)}' AND rel_name = '{escape_string(rel_name)}';''')
 
-    def setTableRebalanceEndTime(self, db: str, schema_name: str, rel_name: str) -> None:
-        dbconn.execSQL(self.conn,
-                       f'''UPDATE {self.schema_name}.{self.table_rebalance_status_detail} SET rebalance_finished = now()
-                       WHERE db_name = '{escape_string(db)}' AND schema_name = '{escape_string(schema_name)}' AND rel_name = '{escape_string(rel_name)}';''')
-
     def setStatusForTableToRebalance(self, db: str, schema_name: str, rel_name: str, status: str) -> None:
         dbconn.execSQL(self.conn,
-                       f'''UPDATE {self.schema_name}.{self.table_rebalance_status_detail} SET status = '{status}'
+                       f'''UPDATE {self.schema_name}.{self.table_rebalance_status_detail} SET status = '{status}', rebalance_finished = now()
                        WHERE db_name = '{escape_string(db)}' AND schema_name = '{escape_string(schema_name)}' AND rel_name = '{escape_string(rel_name)}';''')
 
     def getTablesToRebalanceWithStatus(self, status: str) -> cursor:

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -60,25 +60,66 @@ class RebalanceSchema:
 
         self.savePlan(plan)
 
+        # TODO: generate rollback states
+        # TODO: add check for rebalance rollback
+        dbconn.execSQL(self.conn, f'''
+CREATE FUNCTION ggrebalance._is_rollback()
+RETURNS boolean AS $$
+    SELECT COALESCE(
+        (SELECT state IN (
+            'STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START',
+            'STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE',
+            'STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START',
+            'STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE',
+            'STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START',
+            'STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE',
+            'STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START',
+            'STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE')
+        FROM ggrebalance.rebalance_status WHERE state_category = 'SHRINK' ORDER BY updated DESC LIMIT 1),
+        FALSE)
+$$ LANGUAGE sql''')
+
         if options.simple_progress:
+
             dbconn.execSQL(self.conn, f'''
 CREATE VIEW {self.schema_name}.{self.rebalance_progress_view} AS
-SELECT
-    '1.1. Tables shrinked' AS stat_name,
-    count(1)::text AS stat_value
-FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NOT NULL AND rebalance_finished IS NOT NULL
-UNION
-SELECT
-    '1.3. Tables left to shrink' AS stat_name,
-    count(1)::text AS stat_value
-FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none' AND rebalance_started IS NULL AND rebalance_finished IS NULL
-UNION
-SELECT
-    '1.2. Tables shrink in progress' AS stat_name,
-    count(1)::text AS stat_value
-FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none' AND rebalance_started IS NOT NULL
-ORDER BY stat_name ASC;
-                            ''')
+WITH
+cond AS (SELECT ggrebalance._is_rollback() AS rollback_in_progress),
+rebalance_progress_normal_flow AS
+    (
+    SELECT
+        '1.1. Tables shrinked' AS stat_name,
+        count(1)::text AS stat_value
+    FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NOT NULL AND rebalance_finished IS NOT NULL
+    UNION
+    SELECT
+        '1.3. Tables left to shrink' AS stat_name,
+        count(1)::text AS stat_value
+    FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none' AND rebalance_started IS NULL AND rebalance_finished IS NULL
+    UNION
+    SELECT
+        '1.2. Tables shrink in progress' AS stat_name,
+        count(1)::text AS stat_value
+    FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none' AND rebalance_started IS NOT NULL
+    ORDER BY stat_name ASC
+    ),
+rebalance_progress_rollback_flow AS
+    (
+    SELECT
+        '1.1 Tables rollback in progress' AS stat_name,
+        count(1)::text AS stat_value
+    FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NOT NULL AND rebalance_finished IS NULL
+    UNION
+    SELECT
+        '1.2 Tables left to rollback' AS stat_name,
+        count(1)::text AS stat_value
+    FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NULL
+    ORDER BY stat_name ASC
+    )
+SELECT * FROM rebalance_progress_normal_flow WHERE NOT (SELECT rollback_in_progress FROM cond)
+UNION ALL
+SELECT * FROM rebalance_progress_rollback_flow WHERE (SELECT rollback_in_progress FROM cond);''')
+
         elif options.detailed_progress:
             pass
 

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -26,11 +26,12 @@ class RebalanceSchema:
         self.schema_name = 'ggrebalance'
         self.rebalance_status = 'rebalance_status'
         self.table_rebalance_status_detail = 'table_rebalance_status_detail'
+        self.rebalance_progress_view = 'rebalance_progress'
         self.saved_plan = 'saved_plan'
         self.segment_move_steps = 'segment_move_steps'
         self.conn = conn
 
-    def createSchema(self, plan: Plan) -> None:
+    def createSchema(self, plan: Plan, options: Any) -> None:
         dbconn.execSQL(self.conn, 'BEGIN')
         dbconn.execSQL(self.conn, f'CREATE SCHEMA {self.schema_name}')
         dbconn.execSQL(self.conn,
@@ -39,7 +40,12 @@ class RebalanceSchema:
                        DISTRIBUTED REPLICATED''')
         dbconn.execSQL(self.conn,
                        f'''CREATE TABLE {self.schema_name}.{self.table_rebalance_status_detail}
-                       (db_name TEXT, schema_name TEXT, rel_name TEXT, status TEXT,
+                       (db_name TEXT, schema_name TEXT, rel_name TEXT,
+                       status TEXT,
+                       rebalance_type TEXT,
+                       rebalance_started TIMESTAMP WITH TIME ZONE,
+                       rebalance_finished TIMESTAMP WITH TIME ZONE,
+                       source_bytes NUMERIC,
                        CONSTRAINT unique_fqn UNIQUE (db_name, schema_name, rel_name))
                        DISTRIBUTED REPLICATED''')
         dbconn.execSQL(self.conn,
@@ -53,6 +59,28 @@ class RebalanceSchema:
                        DISTRIBUTED REPLICATED''')
 
         self.savePlan(plan)
+
+        if options.simple_progress:
+            dbconn.execSQL(self.conn, f'''
+CREATE VIEW {self.schema_name}.{self.rebalance_progress_view} AS
+SELECT
+    '1.1. Tables shrinked' AS stat_name,
+    count(1)::text AS stat_value
+FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NOT NULL AND rebalance_finished IS NOT NULL
+UNION
+SELECT
+    '1.3. Tables left to shrink' AS stat_name,
+    count(1)::text AS stat_value
+FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none' AND rebalance_started IS NULL AND rebalance_finished IS NULL
+UNION
+SELECT
+    '1.2. Tables shrink in progress' AS stat_name,
+    count(1)::text AS stat_value
+FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none' AND rebalance_started IS NOT NULL
+ORDER BY stat_name ASC;
+                            ''')
+        elif options.detailed_progress:
+            pass
 
         dbconn.execSQL(self.conn, 'COMMIT')
 
@@ -154,9 +182,21 @@ class RebalanceSchema:
                        WHERE (status = '{status}')''')
 
     def addTableToRebalance(self, db: str, schema_name: str, rel_name: str, status: str) -> None:
+        # TODO: set source_bytes here?
         dbconn.execSQL(self.conn,
                        f'''INSERT INTO {self.schema_name}.{self.table_rebalance_status_detail}
-                       VALUES ('{escape_string(db)}', '{escape_string(schema_name)}', '{escape_string(rel_name)}', '{status}')''')
+                       VALUES ('{escape_string(db)}', '{escape_string(schema_name)}', '{escape_string(rel_name)}', '{status}',
+                                'SHRINK', NULL, NULL, 0 )''')
+
+    def setTableRebalanceStartTime(self, db: str, schema_name: str, rel_name: str) -> None:
+        dbconn.execSQL(self.conn,
+                       f'''UPDATE {self.schema_name}.{self.table_rebalance_status_detail} SET rebalance_started = now(), rebalance_finished = NULL
+                       WHERE db_name = '{escape_string(db)}' AND schema_name = '{escape_string(schema_name)}' AND rel_name = '{escape_string(rel_name)}';''')
+
+    def setTableRebalanceEndTime(self, db: str, schema_name: str, rel_name: str) -> None:
+        dbconn.execSQL(self.conn,
+                       f'''UPDATE {self.schema_name}.{self.table_rebalance_status_detail} SET rebalance_finished = now()
+                       WHERE db_name = '{escape_string(db)}' AND schema_name = '{escape_string(schema_name)}' AND rel_name = '{escape_string(rel_name)}';''')
 
     def setStatusForTableToRebalance(self, db: str, schema_name: str, rel_name: str, status: str) -> None:
         dbconn.execSQL(self.conn,
@@ -165,7 +205,7 @@ class RebalanceSchema:
 
     def getTablesToRebalanceWithStatus(self, status: str) -> cursor:
         return dbconn.query(self.conn, f"""SELECT db_name, schema_name, rel_name FROM
-                            {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = '{status}'""")
+                            {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = '{status}' ORDER BY db_name, schema_name, rel_name""")
 
     def saveExecutionSteps(self, steps: List[RebalanceStep]) -> None:
         dbconn.execSQL(self.conn, 'BEGIN')

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -72,7 +72,7 @@ class RebalanceSchema:
         if self.progress_type != self.ProgressType.PROGRESS_NO:
             states_str = ',\n'.join(f"'{s}'" for s in shrink_rollback_states)
             dbconn.execSQL(self.conn, f'''
-CREATE FUNCTION ggrebalance._is_rollback()
+CREATE FUNCTION {self.schema_name}._is_rollback()
 RETURNS boolean AS $$
     SELECT COALESCE(
         (SELECT state IN (
@@ -86,7 +86,7 @@ $$ LANGUAGE sql''')
             dbconn.execSQL(self.conn, f'''
 CREATE VIEW {self.schema_name}.{self.rebalance_progress_view} AS
 WITH
-cond AS (SELECT ggrebalance._is_rollback() AS rollback_in_progress),
+cond AS (SELECT {self.schema_name}._is_rollback() AS rollback_in_progress),
 rebalance_progress_normal_flow AS
     (
     SELECT
@@ -132,7 +132,7 @@ SELECT * FROM rebalance_progress_rollback_flow WHERE (SELECT rollback_in_progres
             dbconn.execSQL(self.conn, f'''
 CREATE VIEW {self.schema_name}.{self.rebalance_progress_view} AS
 WITH
-cond AS (SELECT ggrebalance._is_rollback() AS rollback_in_progress),
+cond AS (SELECT {self.schema_name}._is_rollback() AS rollback_in_progress),
 rebalance_progress_normal_flow AS
     (
     WITH

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -718,11 +718,16 @@ class GGShrink:
             if database_name != 'template0':
                 databases_to_process.append(database_name)
 
+        if self.rebalance_schema.getProgressType() == self.rebalance_schema.ProgressType.PROGRESS_DETAILED:
+            str_rel_size = 'pg_catalog.pg_relation_size(c.oid) as rel_size'
+        else:
+            str_rel_size = '0 as rel_size'
+
         for db in databases_to_process:
             dburl = dbconn.DbURL(dbname=db, port=self.gpEnv.getCoordinatorPort())
             with closing(dbconn.connect(dburl, encoding='UTF8')) as conn:
                 cursor = dbconn.query(conn,
-                                      f'''SELECT n.nspname, c.relname, c.relkind, pe.writable is not null as external_writable
+                                      f'''SELECT n.nspname, c.relname, c.relkind, pe.writable is not null as external_writable, {str_rel_size}
                                       FROM pg_class c
                                       JOIN pg_namespace n ON c.relnamespace = n.oid
                                       JOIN gp_distribution_policy p ON c.oid = p.localoid
@@ -731,10 +736,10 @@ class GGShrink:
                                       c.relpersistence != 't' AND
                                       p.numsegments {cmp} {self.shrink_plan.getTargetSegmentCount()} AND
                                       n.nspname NOT IN ('pg_catalog', 'information_schema', '{self.rebalance_schema.getSchemaName()}')''')
-                for schema_name, rel_name, rel_kind, external_writable in cursor:
+                for schema_name, rel_name, rel_kind, external_writable, rel_size in cursor:
                     if rel_kind == 'f' and not external_writable:
                         continue
-                    self.rebalance_schema.addTableToRebalance(db, schema_name, rel_name, status)
+                    self.rebalance_schema.addTableToRebalance(db, schema_name, rel_name, status, rel_size)
 
         dbconn.execSQL(self.conn, 'COMMIT')
 

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -780,8 +780,7 @@ class GGShrink:
         self.logger.info(f'Tables to process {cursor.rowcount}')
 
         if cursor.rowcount > 0:
-            num_workers=min(cursor.rowcount, self.options.parallel)
-            self.workers_for_tables_rebalance = WorkerPool(numWorkers=num_workers)
+            self.workers_for_tables_rebalance = WorkerPool(numWorkers=min(cursor.rowcount, self.options.parallel))
 
             for db_name, schema_name, rel_name in cursor:
                 task = self.TableRebalanceTask(self,

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -219,6 +219,7 @@ class GGShrink:
         self.conn = conn
         self.shutdown_requested = False
         self.workers_for_tables_rebalance = None
+        self.tables_rebalance_failed = False
         self.workers_for_segment_stop = None
         self.gparray = gpArray
         self.gparray_dump_file = gpArrayDumpFilename
@@ -475,6 +476,7 @@ class GGShrink:
                     self.workers_for_segment_stop.addCommand(cmd)
             if self.shutdown_requested:
                 break
+            # TODO: remove?
             print_progress(self.workers_for_segment_stop, interval=1)
             for task in self.workers_for_segment_stop.getCompletedItems():
                 if task.was_successful():
@@ -653,6 +655,7 @@ class GGShrink:
         @wrap_table_rebalance_with_faults
         def process_table(self, attempt: int) -> None:
             self.shrink.logger.info(f'Start table rebalance for "{self.db_name}"."{self.schema_name}"."{self.rel_name}" to {self.target_segment_count} segments (attempt {attempt})')
+            self.shrink.rebalance_schema.setTableRebalanceStartTime(self.db_name, self.schema_name, self.rel_name)
             if self.db_exists(self.shrink.rebalance_schema.conn, self.db_name):
                 dburl = dbconn.DbURL(dbname=self.db_name, port=self.shrink.gpEnv.getCoordinatorPort())
                 with closing(dbconn.connect(dburl, encoding='UTF8')) as conn:
@@ -669,6 +672,9 @@ class GGShrink:
                     else:
                         self.shrink.logger.info(f'''Table "{self.db_name}"."{self.schema_name}"."{self.rel_name}" doesn't exist, skipping actual rebalance''')
 
+                    # TODO: merge setTableRebalanceEndTime and setStatusForTableToRebalance
+                    inject_fault(f'before_set_status_{self.db_name}.{self.schema_name}.{self.rel_name}')
+                    self.shrink.rebalance_schema.setTableRebalanceEndTime(self.db_name, self.schema_name, self.rel_name)
                     self.shrink.rebalance_schema.setStatusForTableToRebalance(self.db_name, self.schema_name, self.rel_name, self.table_status_after_rebalance)
                     dbconn.execSQL(conn, 'COMMIT')
             else:
@@ -691,7 +697,9 @@ class GGShrink:
                         logger.warning(f"{str(e)}")
                     else:
                         logger.error(f"{str(e)}")
-                        raise Exception(f'Failed to process the db object for {attempt_max_cnt} attempts')
+                        logger.error(f'Failed to process the db object "{self.db_name}"."{self.schema_name}"."{self.rel_name}" for {attempt_max_cnt} attempts')
+                        self.shrink.tables_rebalance_failed = True
+                        self.shrink.workers_for_tables_rebalance.haltWork()
                     continue
                 break
 
@@ -738,7 +746,8 @@ class GGShrink:
         self.logger.info(f'Tables to process {cursor.rowcount}')
 
         if cursor.rowcount > 0:
-            self.workers_for_tables_rebalance = WorkerPool(numWorkers=min(cursor.rowcount, self.options.parallel))
+            num_workers=min(cursor.rowcount, self.options.parallel)
+            self.workers_for_tables_rebalance = WorkerPool(numWorkers=num_workers)
 
             for db_name, schema_name, rel_name in cursor:
                 task = self.TableRebalanceTask(self,
@@ -749,16 +758,13 @@ class GGShrink:
                                                target_status)
                 self.workers_for_tables_rebalance.addCommand(task)
 
-            print_progress(self.workers_for_tables_rebalance, interval=1)
-
+            self.workers_for_tables_rebalance.join()
             self.workers_for_tables_rebalance.haltWork()
             self.workers_for_tables_rebalance.joinWorkers()
-
-            for task in self.workers_for_tables_rebalance.getCompletedItems():
-                if not task.was_successful():
-                    raise Exception(f'Failed to do ALTER REBALANCE: {task.get_results().stderr}')
-
             self.workers_for_tables_rebalance = None
+
+            if self.tables_rebalance_failed:
+                raise Exception('failed to redistribute some tables during shrink')
 
     def state_can_rollback(self, state: str) -> bool:
         if (state in self.states_main_shrink_flow):

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -25,28 +25,6 @@ except ImportError as e:
 
 DBNAME = 'postgres'
 
-def print_progress(pool: WorkerPool, interval: int = 10) -> None:
-    """
-    Waits for a WorkerPool to complete, printing a progress percentage marker
-    once at the beginning of the call, and thereafter at the provided interval
-    (default ten seconds). A final 100% marker is printed upon completion.
-    """
-    def print_completed_percentage() -> bool:
-        # pool.completed can change asynchronously; save its value.
-        completed = pool.completed
-
-        pct = 0
-        if pool.assigned:
-            pct = float(completed) / pool.assigned
-
-        pool.logger.info(f'{pct:.2%} of jobs completed')
-        return completed >= pool.assigned
-
-    # print_completed_percentage() returns True if we're done.
-    while not print_completed_percentage():
-        if pool.join(interval):
-            return
-
 class GGShrink:
     timeout = SEGMENT_STOP_TIMEOUT_DEFAULT
 
@@ -476,8 +454,7 @@ class GGShrink:
                     self.workers_for_segment_stop.addCommand(cmd)
             if self.shutdown_requested:
                 break
-            # TODO: remove?
-            print_progress(self.workers_for_segment_stop, interval=1)
+            self.workers_for_segment_stop.join()
             for task in self.workers_for_segment_stop.getCompletedItems():
                 if task.was_successful():
                     segments_stop_successful.append(task.segment)

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -713,15 +713,59 @@ class GGShrink:
                 databases_to_process.append(database_name)
 
         if self.rebalance_schema.getProgressType() == self.rebalance_schema.ProgressType.PROGRESS_DETAILED:
-            str_rel_size = 'pg_catalog.pg_relation_size(c.oid) as rel_size'
+            if is_rollback:
+                # In case if shrink's rollback, function 'ggrebalance_get_data_move_size()' is used to retrieve
+                # the amount of data we need to move. It invokes 'pg_relation_size()' on the shrunk segments.
+                # As during rollback, CTAS approach is used for table redistribution,
+                # therefore we will move all the data for the relations with partitioned distribution policy.
+                # For the relations with replicated distribution policy, we calculate the size on one segment,
+                # and multiply by the number of original segments (as here CTAS is used as well - we will re-create data on each segment).
+                str_data_move_size = f'''
+                    CASE
+                        WHEN p.policytype = 'r' THEN (__ggrebalance_temp_schema.ggrebalance_get_data_move_size(c.oid, p.numsegments) / p.numsegments) * {self.gparray.get_segment_count()}
+                        ELSE __ggrebalance_temp_schema.ggrebalance_get_data_move_size(c.oid, p.numsegments)
+                    END AS data_move_size'''
+            else:
+                # In case of normal shrink operation, function 'ggrebalance_get_data_move_size()'
+                # behaves a bit different - it calculates data only from the shrunk segments -
+                # as for shrink we use INSERT-like operation, not CTAS.
+                # And we do not need to move data of the replicated tables.
+                str_data_move_size = f'''
+                    CASE
+                        WHEN p.policytype = 'r' THEN 0
+                        ELSE __ggrebalance_temp_schema.ggrebalance_get_data_move_size(c.oid, {self.shrink_plan.getTargetSegmentCount()})
+                    END AS data_move_size'''
         else:
-            str_rel_size = '0 as rel_size'
+            str_data_move_size = '0 as data_move_size'
 
         for db in databases_to_process:
             dburl = dbconn.DbURL(dbname=db, port=self.gpEnv.getCoordinatorPort())
             with closing(dbconn.connect(dburl, encoding='UTF8')) as conn:
+                if self.rebalance_schema.getProgressType() == self.rebalance_schema.ProgressType.PROGRESS_DETAILED:
+                    # 'public' schema may be missing, so create our own temp schema to carry the function
+                    dbconn.execSQL(conn, 'CREATE SCHEMA __ggrebalance_temp_schema');
+                    dbconn.execSQL(conn, f'''
+                        CREATE OR REPLACE FUNCTION __ggrebalance_temp_schema.ggrebalance_get_data_move_size(p_rel_oid OID, gp_segment_id_limit INT)
+                        RETURNS NUMERIC
+                        AS $$
+                        DECLARE
+                            rec RECORD;
+                            total NUMERIC := 0;
+                        BEGIN
+                            FOR rec IN
+                                SELECT
+                                    pg_catalog.pg_relation_size(c.oid) AS size_bytes
+                                FROM gp_dist_random('pg_class') c
+                                WHERE c.oid = p_rel_oid
+                                AND c.gp_segment_id {'<' if is_rollback else '>='} gp_segment_id_limit
+                            LOOP
+                                total := total + rec.size_bytes;
+                            END LOOP;
+                            RETURN total;
+                        END;
+                        $$ LANGUAGE plpgsql STABLE''')
                 cursor = dbconn.query(conn,
-                                      f'''SELECT n.nspname, c.relname, c.relkind, pe.writable is not null as external_writable, {str_rel_size}
+                                      f'''SELECT n.nspname, c.relname, c.relkind, pe.writable is not null as external_writable, {str_data_move_size}
                                       FROM pg_class c
                                       JOIN pg_namespace n ON c.relnamespace = n.oid
                                       JOIN gp_distribution_policy p ON c.oid = p.localoid
@@ -730,10 +774,13 @@ class GGShrink:
                                       c.relpersistence != 't' AND
                                       p.numsegments {cmp} {self.shrink_plan.getTargetSegmentCount()} AND
                                       n.nspname NOT IN ('pg_catalog', 'information_schema', '{self.rebalance_schema.getSchemaName()}')''')
-                for schema_name, rel_name, rel_kind, external_writable, rel_size in cursor:
+                for schema_name, rel_name, rel_kind, external_writable, data_move_size in cursor:
                     if rel_kind == 'f' and not external_writable:
                         continue
-                    self.rebalance_schema.addTableToRebalance(db, schema_name, rel_name, status, rel_size)
+                    self.rebalance_schema.addTableToRebalance(db, schema_name, rel_name, status, data_move_size)
+
+                if self.rebalance_schema.getProgressType() == self.rebalance_schema.ProgressType.PROGRESS_DETAILED:
+                    dbconn.execSQL(conn, 'DROP SCHEMA __ggrebalance_temp_schema CASCADE')
 
         dbconn.execSQL(self.conn, 'COMMIT')
 

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -748,22 +748,12 @@ class GGShrink:
                         CREATE OR REPLACE FUNCTION __ggrebalance_temp_schema.ggrebalance_get_data_move_size(p_rel_oid OID, gp_segment_id_limit INT)
                         RETURNS NUMERIC
                         AS $$
-                        DECLARE
-                            rec RECORD;
-                            total NUMERIC := 0;
-                        BEGIN
-                            FOR rec IN
-                                SELECT
-                                    pg_catalog.pg_relation_size(c.oid) AS size_bytes
-                                FROM gp_dist_random('pg_class') c
-                                WHERE c.oid = p_rel_oid
-                                AND c.gp_segment_id {'<' if is_rollback else '>='} gp_segment_id_limit
-                            LOOP
-                                total := total + rec.size_bytes;
-                            END LOOP;
-                            RETURN total;
-                        END;
-                        $$ LANGUAGE plpgsql STABLE''')
+                        WITH cte AS MATERIALIZED (
+                            SELECT * FROM gp_dist_random('pg_class') c
+                            WHERE c.oid = p_rel_oid
+                            AND c.gp_segment_id {'<' if is_rollback else '>='} gp_segment_id_limit
+                        ) SELECT sum(pg_catalog.pg_relation_size(cte.oid)) FROM cte;
+                        $$ LANGUAGE sql STABLE''')
                 cursor = dbconn.query(conn,
                                       f'''SELECT n.nspname, c.relname, c.relkind, pe.writable is not null as external_writable, {str_data_move_size}
                                       FROM pg_class c

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -715,7 +715,7 @@ class GGShrink:
         if self.rebalance_schema.getProgressType() == self.rebalance_schema.ProgressType.PROGRESS_DETAILED:
             if is_rollback:
                 # In case if shrink's rollback, function 'ggrebalance_get_data_move_size()' is used to retrieve
-                # the amount of data we need to move. It invokes 'pg_relation_size()' on the shrunk segments.
+                # the amount of data we need to move. It invokes 'pg_relation_size()' on the segments left after shrink.
                 # As during rollback, CTAS approach is used for table redistribution,
                 # therefore we will move all the data for the relations with partitioned distribution policy.
                 # For the relations with replicated distribution policy, we calculate the size on one segment,

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -672,9 +672,7 @@ class GGShrink:
                     else:
                         self.shrink.logger.info(f'''Table "{self.db_name}"."{self.schema_name}"."{self.rel_name}" doesn't exist, skipping actual rebalance''')
 
-                    # TODO: merge setTableRebalanceEndTime and setStatusForTableToRebalance
                     inject_fault(f'before_set_status_{self.db_name}.{self.schema_name}.{self.rel_name}')
-                    self.shrink.rebalance_schema.setTableRebalanceEndTime(self.db_name, self.schema_name, self.rel_name)
                     self.shrink.rebalance_schema.setStatusForTableToRebalance(self.db_name, self.schema_name, self.rel_name, self.table_status_after_rebalance)
                     dbconn.execSQL(conn, 'COMMIT')
             else:

--- a/gpMgmt/doc/ggrebalance_help
+++ b/gpMgmt/doc/ggrebalance_help
@@ -68,7 +68,8 @@ As the first step, ggrebalance will create a rebalance plan. If the plan with
 given parameters is feasible (meaning that the tool can end up with a balanced
 cluster configuration), it will continue execution.
 Next, the tool will create a 'ggrebalance' schema in the cluster to track its
-status. The plan is also saved in the schema.
+status. The plan is also saved in the schema. The schema is created in the
+'postgres' database.
 Then ggrebalance will perform cluster shrink or expand, if the target number
 of segments differs from the current one. During this phase, the tool will
 execute ALTER TABLE ... REBALANCE operations on the existing tables
@@ -81,6 +82,10 @@ a new rebalance operation.
 
 If the tool operation is interrupted and rolled back, the schema is removed as a
 result of the rollback operation.
+
+If options '--detailed-progress' or '--simple-progress' are used, a view called
+'rebalance_progress' is created in the 'ggrebalance' schema. It allows to track
+the status of current operation of the tool.
 
 ******************************************************
 OPTIONS

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
@@ -27,6 +27,9 @@ Feature: ggrebalance behave tests
           | --mirror-mode grouped --skip-rebalance                      | Can't use together options '--skip-rebalance' and '--mirror-mode'     | stub       |stub|
           | -m spread --skip-rebalance                                  | Can't use together options '--skip-rebalance' and '--mirror-mode'     | stub       |stub|
           | --skip-rebalance --inplace-swap-roles                       | Can't use together options '--skip-rebalance' and '--inplace-swap-roles'     | stub     |stub|
+          | --detailed-progress --simple-progress                       | Can't use together options '--detailed-progress' and '--simple-progress'     | stub     |stub|
+          | --detailed-progress --no-progress                           | Can't use together options '--detailed-progress' and '--no-progress'         | stub     |stub|
+          | --simple-progress --no-progress                             | Can't use together options '--simple-progress' and '--no-progress'           | stub     |stub|
           | -c --target-hosts sdw1,sdw2                                 | Can't use together options '--clean-required' and '--target-hosts'    | stub       |stub|
           | -c --add-hosts sdw3                                         | Can't use together options '--clean-required' and '--add-hosts'       | stub       |stub|
           | -c --add-hosts-file /tmp/add.txt                            | Can't use together options '--clean-required' and '--add-hosts-file'  | stub       |stub|
@@ -42,6 +45,9 @@ Feature: ggrebalance behave tests
           | -c --hba-hostnames                                          | Can't use together options '--clean-required' and '--hba-hostnames'     | stub     |stub|
           | -c --inplace-swap-roles                                         | Can't use together options '--clean-required' and '--inplace-swap-roles'     | stub     |stub|
           | -c --skip-resource-estimation                               | Can't use together options '--clean-required' and '--skip-resource-estimation' | stub |stub|
+          | -c --detailed-progress                                      | Can't use together options '--clean-required' and '--detailed-progress'        | stub |stub|
+          | -c --simple-progress                                        | Can't use together options '--clean-required' and '--simple-progress'          | stub |stub|
+          | -c --no-progress                                            | Can't use together options '--clean-required' and '--no-progress'              | stub |stub|
           | -r --target-hosts sdw1,sdw2                                 | Can't use together options '--rollback-required' and '--target-hosts'    | stub       |stub|
           | -r --add-hosts sdw3                                         | Can't use together options '--rollback-required' and '--add-hosts'       | stub       |stub|
           | -r --add-hosts-file /tmp/add.txt                            | Can't use together options '--rollback-required' and '--add-hosts-file'  | stub       |stub|
@@ -52,6 +58,9 @@ Feature: ggrebalance behave tests
           | -r --mirror-mode grouped                                    | Can't use together options '--rollback-required' and '--mirror-mode'       | stub     |stub|
           | -r --skip-rebalance                                         | Can't use together options '--rollback-required' and '--skip-rebalance'    | stub     |stub|
           | -r --show-plan                                              | Can't use together options '--rollback-required' and '--show-plan'         | stub     |stub|
+          | -r --detailed-progress                                      | Can't use together options '--rollback-required' and '--detailed-progress' | stub     |stub|
+          | -r --simple-progress                                        | Can't use together options '--rollback-required' and '--simple-progress'   | stub     |stub|
+          | -r --no-progress                                            | Can't use together options '--rollback-required' and '--no-progress'       | stub     |stub|
           | -r --inplace-swap-roles                                     | Can't use together options '--rollback-required' and '--inplace-swap-roles'     | stub     |stub|
           | -r --skip-resource-estimation                               | Can't use together options '--rollback-required' and '--skip-resource-estimation' |the database is not running |"COORDINATOR_DATA_DIRECTORY" environment variable should be restored|
 

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -115,7 +115,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -x 4 --add-hosts 'sdw2, sdw3' --remove-hosts 'sdw1' -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode -x 4 --add-hosts 'sdw2, sdw3' --remove-hosts 'sdw1' -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has 0 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -577,7 +577,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
             """
         Then validate that following rows are in the stored rows
           |  stat_name                       | stat_value |
-          |  1.1. Tables shrinked            | 0          |
+          |  1.1. Tables shrunk              | 0          |
           |  1.2. Tables shrink in progress  | 0          |
           |  1.3. Tables left to shrink      | 10         |
          And all files in gpAdminLogs directory are deleted
@@ -594,7 +594,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
             """
         Then validate that following rows are in the stored rows
           |  stat_name                       | stat_value |
-          |  1.1. Tables shrinked            | 0          |
+          |  1.1. Tables shrunk              | 0          |
           |  1.2. Tables shrink in progress  | 1          |
           |  1.3. Tables left to shrink      | 9          |
          And all files in gpAdminLogs directory are deleted
@@ -611,7 +611,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
             """
         Then validate that following rows are in the stored rows
           |  stat_name                       | stat_value |
-          |  1.1. Tables shrinked            | 3          |
+          |  1.1. Tables shrunk              | 3          |
           |  1.2. Tables shrink in progress  | 1          |
           |  1.3. Tables left to shrink      | 6          |
          And all files in gpAdminLogs directory are deleted
@@ -628,7 +628,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
             """
         Then validate that following rows are in the stored rows
           |  stat_name                       | stat_value |
-          |  1.1. Tables shrinked            | 9          |
+          |  1.1. Tables shrunk              | 9          |
           |  1.2. Tables shrink in progress  | 1          |
           |  1.3. Tables left to shrink      | 0          |
          And all files in gpAdminLogs directory are deleted
@@ -643,7 +643,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
             """
         Then validate that following rows are in the stored rows
           |  stat_name                       | stat_value |
-          |  1.1. Tables shrinked            | 10         |
+          |  1.1. Tables shrunk              | 10         |
           |  1.2. Tables shrink in progress  | 0          |
           |  1.3. Tables left to shrink      | 0          |
          And all files in gpAdminLogs directory are deleted
@@ -751,7 +751,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
             """
         Then validate that following rows are in the stored rows
           |  stat_name                       | stat_value  |
-          |  1.1. Tables shrinked            | 0           |
+          |  1.1. Tables shrunk              | 0           |
           |  1.2. Tables shrink in progress  | 0           |
           |  1.3. Tables left to shrink      | 10          |
           |  2.1. Bytes processed            | 0           |
@@ -783,7 +783,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
             """
         Then validate that following rows are in the stored rows
           |  stat_name                       | stat_value  |
-          |  1.1. Tables shrinked            | 0           |
+          |  1.1. Tables shrunk              | 0           |
           |  1.2. Tables shrink in progress  | 1           |
           |  1.3. Tables left to shrink      | 9           |
           |  2.1. Bytes processed            | 0           |
@@ -815,7 +815,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
             """
         Then validate that following rows are in the stored rows
           |  stat_name                       | stat_value  |
-          |  1.1. Tables shrinked            | 3           |
+          |  1.1. Tables shrunk              | 3           |
           |  1.2. Tables shrink in progress  | 1           |
           |  1.3. Tables left to shrink      | 6           |
           |  2.1. Bytes processed            | > 0         |
@@ -847,7 +847,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
             """
         Then validate that following rows are in the stored rows
           |  stat_name                       | stat_value  |
-          |  1.1. Tables shrinked            | 9           |
+          |  1.1. Tables shrunk              | 9           |
           |  1.2. Tables shrink in progress  | 1           |
           |  1.3. Tables left to shrink      | 0           |
           |  2.1. Bytes processed            | > 0         |
@@ -877,7 +877,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
             """
         Then validate that following rows are in the stored rows
           |  stat_name                       | stat_value  |
-          |  1.1. Tables shrinked            | 10          |
+          |  1.1. Tables shrunk              | 10          |
           |  1.2. Tables shrink in progress  | 0           |
           |  1.3. Tables left to shrink      | 0           |
           |  2.1. Bytes processed            | > 0         |

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -530,7 +530,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And ggrebalance should print "soft shutdown, waiting for critical operations to finish..." to logfile with latest timestamp
          And ggrebalance should print "Rebalance was interrupted" to logfile with latest timestamp
 
-    Scenario: test 21. Check '--simple-progress' option.
+    Scenario: test 21. Check '--simple-progress' option with normal flow.
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
@@ -609,6 +609,38 @@ Feature: ggrebalance behave tests (misc options scenarios)
         When the user runs "ggrebalance -n 1 --non-interactive-mode"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT * FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value |
+          |  1.1. Tables shrinked            | 10         |
+          |  1.2. Tables shrink in progress  | 0          |
+          |  1.3. Tables left to shrink      | 0          |
+
+    # TODO: test with full rebalance, not only shrink
+    # TODO: merge with the preceding test
+    Scenario: test 22. Check '--simple-progress' option with rollback flow.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_0" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_2" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_4" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_5" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_6" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_7" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_8" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_9" in "test_db_1" with "500" rows
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "on_enter_STATE_SHRINK_TABLES_DONE_end"
+        When the user runs "ggrebalance --simple-progress --non-interactive-mode -n 1 -x 3  --skip-rebalance"
+        Then ggrebalance should return a return code of 1
          And unset fault inject
         When execute following sql in db "postgres" and store result in the context
             """
@@ -619,3 +651,58 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  1.1. Tables shrinked            | 10         |
           |  1.2. Tables shrink in progress  | 0          |
           |  1.3. Tables left to shrink      | 0          |
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_end"
+        When the user runs "ggrebalance -r -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT * FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value |
+          |  1.1 Tables rollback in progress | 0          |
+          |  1.2 Tables left to rollback     | 10         |
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_0"
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "failed to redistribute some tables during shrink" to logfile with latest timestamp
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT * FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value |
+          |  1.1 Tables rollback in progress | 1          |
+          |  1.2 Tables left to rollback     | 9          |
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_3"
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "failed to redistribute some tables during shrink" to logfile with latest timestamp
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT * FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value |
+          |  1.1 Tables rollback in progress | 1          |
+          |  1.2 Tables left to rollback     | 6          |
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_9"
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "failed to redistribute some tables during shrink" to logfile with latest timestamp
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT * FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value |
+          |  1.1 Tables rollback in progress | 1          |
+          |  1.2 Tables left to rollback     | 0          |

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -743,7 +743,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
                     WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
-                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.1. Estimated shrink rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
                     WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
                     ELSE stat_value
                 END AS stat_value
@@ -757,7 +757,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  2.1. Bytes processed            | 0           |
           |  2.2. Bytes left to process      | > 0         |
           |  2.3. Bytes in progress          | 0           |
-          |  3.1. Estimated rebalance rate   | 0 MB/s      |
+          |  3.1. Estimated shrink rate      | 0 MB/s      |
           |  3.2. Estimated time             | not defined |
          And all files in gpAdminLogs directory are deleted
 
@@ -775,7 +775,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
                     WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
-                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.1. Estimated shrink rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
                     WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
                     ELSE stat_value
                 END AS stat_value
@@ -789,7 +789,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  2.1. Bytes processed            | 0           |
           |  2.2. Bytes left to process      | > 0         |
           |  2.3. Bytes in progress          | > 0         |
-          |  3.1. Estimated rebalance rate   | 0 MB/s      |
+          |  3.1. Estimated shrink rate      | 0 MB/s      |
           |  3.2. Estimated time             | not defined |
          And all files in gpAdminLogs directory are deleted
 
@@ -807,7 +807,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
                     WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
-                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.1. Estimated shrink rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
                     WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
                     ELSE stat_value
                 END AS stat_value
@@ -821,7 +821,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  2.1. Bytes processed            | > 0         |
           |  2.2. Bytes left to process      | > 0         |
           |  2.3. Bytes in progress          | > 0         |
-          |  3.1. Estimated rebalance rate   | > 0 MB/s    |
+          |  3.1. Estimated shrink rate      | > 0 MB/s    |
           |  3.2. Estimated time             | > 0 s       |
          And all files in gpAdminLogs directory are deleted
 
@@ -839,7 +839,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
                     WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
-                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.1. Estimated shrink rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
                     WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
                     ELSE stat_value
                 END AS stat_value
@@ -853,7 +853,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  2.1. Bytes processed            | > 0         |
           |  2.2. Bytes left to process      | > 0         |
           |  2.3. Bytes in progress          | > 0         |
-          |  3.1. Estimated rebalance rate   | > 0 MB/s    |
+          |  3.1. Estimated shrink rate      | > 0 MB/s    |
           |  3.2. Estimated time             | > 0 s       |
          And all files in gpAdminLogs directory are deleted
 
@@ -869,7 +869,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
                     WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
-                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.1. Estimated shrink rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
                     WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
                     ELSE stat_value
                 END AS stat_value
@@ -883,7 +883,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  2.1. Bytes processed            | > 0         |
           |  2.2. Bytes left to process      | 0           |
           |  2.3. Bytes in progress          | 0           |
-          |  3.1. Estimated rebalance rate   | > 0 MB/s    |
+          |  3.1. Estimated shrink rate      | > 0 MB/s    |
           |  3.2. Estimated time             | 0 s         |
          And all files in gpAdminLogs directory are deleted
 
@@ -900,7 +900,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
                     WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
-                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.1. Estimated shrink rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
                     WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
                     ELSE stat_value
                 END AS stat_value
@@ -913,7 +913,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  2.1. Bytes processed            | 0           |
           |  2.2. Bytes left to process      | > 0         |
           |  2.3. Bytes in progress          | 0           |
-          |  3.1. Estimated rebalance rate   | 0 MB/s      |
+          |  3.1. Estimated shrink rate      | 0 MB/s      |
           |  3.2. Estimated time             | not defined |
          And all files in gpAdminLogs directory are deleted
 
@@ -931,7 +931,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
                     WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
-                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.1. Estimated shrink rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
                     WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
                     ELSE stat_value
                 END AS stat_value
@@ -944,7 +944,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  2.1. Bytes processed            | 0           |
           |  2.2. Bytes left to process      | > 0         |
           |  2.3. Bytes in progress          | > 0         |
-          |  3.1. Estimated rebalance rate   | 0 MB/s      |
+          |  3.1. Estimated shrink rate      | 0 MB/s      |
           |  3.2. Estimated time             | not defined |
          And all files in gpAdminLogs directory are deleted
 
@@ -962,7 +962,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
                     WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
-                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.1. Estimated shrink rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
                     WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
                     ELSE stat_value
                 END AS stat_value
@@ -975,7 +975,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  2.1. Bytes processed            | > 0         |
           |  2.2. Bytes left to process      | > 0         |
           |  2.3. Bytes in progress          | > 0         |
-          |  3.1. Estimated rebalance rate   | > 0 MB/s    |
+          |  3.1. Estimated shrink rate      | > 0 MB/s    |
           |  3.2. Estimated time             | > 0 s       |
          And all files in gpAdminLogs directory are deleted
 
@@ -993,7 +993,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
                     WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
-                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.1. Estimated shrink rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
                     WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
                     ELSE stat_value
                 END AS stat_value
@@ -1006,7 +1006,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  2.1. Bytes processed            | > 0         |
           |  2.2. Bytes left to process      | > 0         |
           |  2.3. Bytes in progress          | > 0         |
-          |  3.1. Estimated rebalance rate   | > 0 MB/s    |
+          |  3.1. Estimated shrink rate      | > 0 MB/s    |
           |  3.2. Estimated time             | > 0 s       |
          And all files in gpAdminLogs directory are deleted
 
@@ -1023,7 +1023,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
                     WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
                     WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
-                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.1. Estimated shrink rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
                     WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
                     ELSE stat_value
                 END AS stat_value
@@ -1036,5 +1036,5 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  2.1. Bytes processed            | > 0         |
           |  2.2. Bytes left to process      | 0           |
           |  2.3. Bytes in progress          | 0           |
-          |  3.1. Estimated rebalance rate   | > 0 MB/s    |
+          |  3.1. Estimated shrink rate      | > 0 MB/s    |
           |  3.2. Estimated time             | 0 s         |

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -529,3 +529,93 @@ Feature: ggrebalance behave tests (misc options scenarios)
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "soft shutdown, waiting for critical operations to finish..." to logfile with latest timestamp
          And ggrebalance should print "Rebalance was interrupted" to logfile with latest timestamp
+
+    Scenario: test 21. Check '--simple-progress' option.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_0" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_2" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_4" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_5" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_6" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_7" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_8" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_9" in "test_db_1" with "500" rows
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "on_enter_STATE_PREPARE_SHRINK_SCHEMA_DONE_begin"
+        When the user runs "ggrebalance --simple-progress --non-interactive-mode -n 1 -x 3  --skip-rebalance"
+        Then ggrebalance should return a return code of 1
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT * FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value |
+          |  1.1. Tables shrinked            | 0          |
+          |  1.2. Tables shrink in progress  | 0          |
+          |  1.3. Tables left to shrink      | 10         |
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_0"
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "failed to redistribute some tables during shrink" to logfile with latest timestamp
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT * FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value |
+          |  1.1. Tables shrinked            | 0          |
+          |  1.2. Tables shrink in progress  | 1          |
+          |  1.3. Tables left to shrink      | 9          |
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_3"
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "failed to redistribute some tables during shrink" to logfile with latest timestamp
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT * FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value |
+          |  1.1. Tables shrinked            | 3          |
+          |  1.2. Tables shrink in progress  | 1          |
+          |  1.3. Tables left to shrink      | 6          |
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_9"
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "failed to redistribute some tables during shrink" to logfile with latest timestamp
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT * FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value |
+          |  1.1. Tables shrinked            | 9          |
+          |  1.2. Tables shrink in progress  | 1          |
+          |  1.3. Tables left to shrink      | 0          |
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT * FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value |
+          |  1.1. Tables shrinked            | 10         |
+          |  1.2. Tables shrink in progress  | 0          |
+          |  1.3. Tables left to shrink      | 0          |

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -530,7 +530,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And ggrebalance should print "soft shutdown, waiting for critical operations to finish..." to logfile with latest timestamp
          And ggrebalance should print "Rebalance was interrupted" to logfile with latest timestamp
 
-    Scenario: test 21. Check '--simple-progress' option with normal flow.
+    Scenario: test 21. Check '--simple-progress' option.
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
@@ -550,7 +550,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
 
          # Check progress report before any table is redistributed
          And set fault inject "on_enter_STATE_PREPARE_SHRINK_SCHEMA_DONE_begin"
-        When the user runs "ggrebalance --simple-progress --non-interactive-mode -n 1 -x 3  --skip-rebalance"
+        When the user runs "ggrebalance --simple-progress --non-interactive-mode -n 1 -x 3 --skip-rebalance"
         Then ggrebalance should return a return code of 1
          And unset fault inject
         When execute following sql in db "postgres" and store result in the context
@@ -706,3 +706,330 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  stat_name                       | stat_value |
           |  1.1 Tables rollback in progress | 0          |
           |  1.2 Tables left to rollback     | 0          |
+
+    Scenario: test 21. Check '--detailed-progress' option with normal flow.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_0" in "test_db_1" with "1000000" rows
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "1000000" rows
+         And there is a "heap" table "test_schema_1.test_table_2" in "test_db_1" with "1000000" rows
+         And there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "1000000" rows
+         And there is a "heap" table "test_schema_1.test_table_4" in "test_db_1" with "1000000" rows
+         And there is a "heap" table "test_schema_1.test_table_5" in "test_db_1" with "1000000" rows
+         And there is a "heap" table "test_schema_1.test_table_6" in "test_db_1" with "1000000" rows
+         And there is a "heap" table "test_schema_1.test_table_7" in "test_db_1" with "1000000" rows
+         And there is a "heap" table "test_schema_1.test_table_8" in "test_db_1" with "1000000" rows
+         And there is a "heap" table "test_schema_1.test_table_9" in "test_db_1" with "1000000" rows
+         And all files in gpAdminLogs directory are deleted
+
+         # Check progress report before any table is redistributed
+         And set fault inject "on_enter_STATE_PREPARE_SHRINK_SCHEMA_DONE_begin"
+        When the user runs "ggrebalance --detailed-progress --non-interactive-mode -n 1 -x 3 --skip-rebalance"
+        Then ggrebalance should return a return code of 1
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT
+                stat_name,
+                CASE
+                    WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
+                    ELSE stat_value
+                END AS stat_value
+            FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value  |
+          |  1.1. Tables shrinked            | 0           |
+          |  1.2. Tables shrink in progress  | 0           |
+          |  1.3. Tables left to shrink      | 10          |
+          |  2.1. Bytes processed            | 0           |
+          |  2.2. Bytes left to process      | > 0         |
+          |  2.3. Bytes in progress          | 0           |
+          |  3.1. Estimated rebalance rate   | 0 MB/s      |
+          |  3.2. Estimated time             | not defined |
+         And all files in gpAdminLogs directory are deleted
+
+         # Check progress report before finish of first table redistribution
+         And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_0"
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "failed to redistribute some tables during shrink" to logfile with latest timestamp
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT
+                stat_name,
+                CASE
+                    WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
+                    ELSE stat_value
+                END AS stat_value
+            FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value  |
+          |  1.1. Tables shrinked            | 0           |
+          |  1.2. Tables shrink in progress  | 1           |
+          |  1.3. Tables left to shrink      | 9           |
+          |  2.1. Bytes processed            | 0           |
+          |  2.2. Bytes left to process      | > 0         |
+          |  2.3. Bytes in progress          | > 0         |
+          |  3.1. Estimated rebalance rate   | 0 MB/s      |
+          |  3.2. Estimated time             | not defined |
+         And all files in gpAdminLogs directory are deleted
+
+         # Check progress report when some tables have been redistributed
+         And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_3"
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "failed to redistribute some tables during shrink" to logfile with latest timestamp
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT
+                stat_name,
+                CASE
+                    WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
+                    ELSE stat_value
+                END AS stat_value
+            FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value  |
+          |  1.1. Tables shrinked            | 3           |
+          |  1.2. Tables shrink in progress  | 1           |
+          |  1.3. Tables left to shrink      | 6           |
+          |  2.1. Bytes processed            | > 0         |
+          |  2.2. Bytes left to process      | > 0         |
+          |  2.3. Bytes in progress          | > 0         |
+          |  3.1. Estimated rebalance rate   | > 0 MB/s    |
+          |  3.2. Estimated time             | > 0 s       |
+         And all files in gpAdminLogs directory are deleted
+
+         # Check progress report before finish of last table redistribution
+         And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_9"
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "failed to redistribute some tables during shrink" to logfile with latest timestamp
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT
+                stat_name,
+                CASE
+                    WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
+                    ELSE stat_value
+                END AS stat_value
+            FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value  |
+          |  1.1. Tables shrinked            | 9           |
+          |  1.2. Tables shrink in progress  | 1           |
+          |  1.3. Tables left to shrink      | 0           |
+          |  2.1. Bytes processed            | > 0         |
+          |  2.2. Bytes left to process      | > 0         |
+          |  2.3. Bytes in progress          | > 0         |
+          |  3.1. Estimated rebalance rate   | > 0 MB/s    |
+          |  3.2. Estimated time             | > 0 s       |
+         And all files in gpAdminLogs directory are deleted
+
+         # Check progress report when all tables have been redistributed
+         And set fault inject "on_enter_STATE_SHRINK_TABLES_DONE_end"
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT
+                stat_name,
+                CASE
+                    WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
+                    ELSE stat_value
+                END AS stat_value
+            FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value  |
+          |  1.1. Tables shrinked            | 10          |
+          |  1.2. Tables shrink in progress  | 0           |
+          |  1.3. Tables left to shrink      | 0           |
+          |  2.1. Bytes processed            | > 0         |
+          |  2.2. Bytes left to process      | 0           |
+          |  2.3. Bytes in progress          | 0           |
+          |  3.1. Estimated rebalance rate   | > 0 MB/s    |
+          |  3.2. Estimated time             | 0 s         |
+         And all files in gpAdminLogs directory are deleted
+
+         # Check progress report at rollback before any table is rolled back
+         And set fault inject "on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_end"
+        When the user runs "ggrebalance -r -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT
+                stat_name,
+                CASE
+                    WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
+                    ELSE stat_value
+                END AS stat_value
+            FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value  |
+          |  1.1 Tables rollback in progress | 0           |
+          |  1.2 Tables left to rollback     | 10          |
+          |  2.1. Bytes processed            | 0           |
+          |  2.2. Bytes left to process      | > 0         |
+          |  2.3. Bytes in progress          | 0           |
+          |  3.1. Estimated rebalance rate   | 0 MB/s      |
+          |  3.2. Estimated time             | not defined |
+         And all files in gpAdminLogs directory are deleted
+
+         # Check progress report at rollback before finish of first table redistribution
+         And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_0"
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "failed to redistribute some tables during shrink" to logfile with latest timestamp
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT
+                stat_name,
+                CASE
+                    WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
+                    ELSE stat_value
+                END AS stat_value
+            FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value  |
+          |  1.1 Tables rollback in progress | 1           |
+          |  1.2 Tables left to rollback     | 9           |
+          |  2.1. Bytes processed            | 0           |
+          |  2.2. Bytes left to process      | > 0         |
+          |  2.3. Bytes in progress          | > 0         |
+          |  3.1. Estimated rebalance rate   | 0 MB/s      |
+          |  3.2. Estimated time             | not defined |
+         And all files in gpAdminLogs directory are deleted
+
+         # Check progress report at rollback when some tables have been redistributed
+         And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_3"
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "failed to redistribute some tables during shrink" to logfile with latest timestamp
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT
+                stat_name,
+                CASE
+                    WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
+                    ELSE stat_value
+                END AS stat_value
+            FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value  |
+          |  1.1 Tables rollback in progress | 1           |
+          |  1.2 Tables left to rollback     | 6           |
+          |  2.1. Bytes processed            | > 0         |
+          |  2.2. Bytes left to process      | > 0         |
+          |  2.3. Bytes in progress          | > 0         |
+          |  3.1. Estimated rebalance rate   | > 0 MB/s    |
+          |  3.2. Estimated time             | > 0 s       |
+         And all files in gpAdminLogs directory are deleted
+
+         # Check progress report at rollback before finish of last table redistribution
+         And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_9"
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "failed to redistribute some tables during shrink" to logfile with latest timestamp
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT
+                stat_name,
+                CASE
+                    WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
+                    ELSE stat_value
+                END AS stat_value
+            FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value  |
+          |  1.1 Tables rollback in progress | 1           |
+          |  1.2 Tables left to rollback     | 0           |
+          |  2.1. Bytes processed            | > 0         |
+          |  2.2. Bytes left to process      | > 0         |
+          |  2.3. Bytes in progress          | > 0         |
+          |  3.1. Estimated rebalance rate   | > 0 MB/s    |
+          |  3.2. Estimated time             | > 0 s       |
+         And all files in gpAdminLogs directory are deleted
+
+         # Check progress report at rollback when all tables have been redistributed
+         And set fault inject "on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_begin"
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT
+                stat_name,
+                CASE
+                    WHEN stat_name = '2.1. Bytes processed' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.2. Bytes left to process' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '2.3. Bytes in progress' AND stat_value != '0' THEN '> 0'
+                    WHEN stat_name = '3.1. Estimated rebalance rate' AND stat_value != '0 MB/s' THEN '> 0 MB/s'
+                    WHEN stat_name = '3.2. Estimated time' AND stat_value != 'not defined' AND stat_value != '0 s' THEN '> 0 s'
+                    ELSE stat_value
+                END AS stat_value
+            FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value  |
+          |  1.1 Tables rollback in progress | 0           |
+          |  1.2 Tables left to rollback     | 0           |
+          |  2.1. Bytes processed            | > 0         |
+          |  2.2. Bytes left to process      | 0           |
+          |  2.3. Bytes in progress          | 0           |
+          |  3.1. Estimated rebalance rate   | > 0 MB/s    |
+          |  3.2. Estimated time             | 0 s         |

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -658,9 +658,10 @@ Feature: ggrebalance behave tests (misc options scenarios)
             SELECT * FROM ggrebalance.rebalance_progress;
             """
         Then validate that following rows are in the stored rows
-          |  stat_name                       | stat_value |
-          |  1.1 Tables rollback in progress | 0          |
-          |  1.2 Tables left to rollback     | 10         |
+          |  stat_name                        | stat_value |
+          |  1.1. Tables rolled back          | 0          |
+          |  1.2. Tables rollback in progress | 0          |
+          |  1.3. Tables left to rollback     | 10         |
          And all files in gpAdminLogs directory are deleted
 
          # Check progress report at rollback before finish of first table redistribution
@@ -674,9 +675,10 @@ Feature: ggrebalance behave tests (misc options scenarios)
             SELECT * FROM ggrebalance.rebalance_progress;
             """
         Then validate that following rows are in the stored rows
-          |  stat_name                       | stat_value |
-          |  1.1 Tables rollback in progress | 1          |
-          |  1.2 Tables left to rollback     | 9          |
+          |  stat_name                        | stat_value |
+          |  1.1. Tables rolled back          | 0          |
+          |  1.2. Tables rollback in progress | 1          |
+          |  1.3. Tables left to rollback     | 9          |
          And all files in gpAdminLogs directory are deleted
 
          # Check progress report at rollback when some tables have been redistributed
@@ -690,9 +692,10 @@ Feature: ggrebalance behave tests (misc options scenarios)
             SELECT * FROM ggrebalance.rebalance_progress;
             """
         Then validate that following rows are in the stored rows
-          |  stat_name                       | stat_value |
-          |  1.1 Tables rollback in progress | 1          |
-          |  1.2 Tables left to rollback     | 6          |
+          |  stat_name                        | stat_value |
+          |  1.1. Tables rolled back          | 3          |
+          |  1.2. Tables rollback in progress | 1          |
+          |  1.3. Tables left to rollback     | 6          |
          And all files in gpAdminLogs directory are deleted
 
          # Check progress report at rollback before finish of last table redistribution
@@ -706,9 +709,10 @@ Feature: ggrebalance behave tests (misc options scenarios)
             SELECT * FROM ggrebalance.rebalance_progress;
             """
         Then validate that following rows are in the stored rows
-          |  stat_name                       | stat_value |
-          |  1.1 Tables rollback in progress | 1          |
-          |  1.2 Tables left to rollback     | 0          |
+          |  stat_name                        | stat_value |
+          |  1.1. Tables rolled back          | 9          |
+          |  1.2. Tables rollback in progress | 1          |
+          |  1.3. Tables left to rollback     | 0          |
          And all files in gpAdminLogs directory are deleted
 
          # Check progress report at rollback when all tables have been redistributed
@@ -721,9 +725,10 @@ Feature: ggrebalance behave tests (misc options scenarios)
             SELECT * FROM ggrebalance.rebalance_progress;
             """
         Then validate that following rows are in the stored rows
-          |  stat_name                       | stat_value |
-          |  1.1 Tables rollback in progress | 0          |
-          |  1.2 Tables left to rollback     | 0          |
+          |  stat_name                        | stat_value |
+          |  1.1. Tables rolled back          | 10         |
+          |  1.2. Tables rollback in progress | 0          |
+          |  1.3. Tables left to rollback     | 0          |
          And all files in gpAdminLogs directory are deleted
         When the user runs "ggrebalance -n 1 --non-interactive-mode"
         Then ggrebalance should return a return code of 0
@@ -907,14 +912,15 @@ Feature: ggrebalance behave tests (misc options scenarios)
             FROM ggrebalance.rebalance_progress;
             """
         Then validate that following rows are in the stored rows
-          |  stat_name                       | stat_value  |
-          |  1.1 Tables rollback in progress | 0           |
-          |  1.2 Tables left to rollback     | 10          |
-          |  2.1. Bytes processed            | 0           |
-          |  2.2. Bytes left to process      | > 0         |
-          |  2.3. Bytes in progress          | 0           |
-          |  3.1. Estimated shrink rate      | 0 MB/s      |
-          |  3.2. Estimated time             | not defined |
+          |  stat_name                        | stat_value  |
+          |  1.1. Tables rolled back          | 0           |
+          |  1.2. Tables rollback in progress | 0           |
+          |  1.3. Tables left to rollback     | 10          |
+          |  2.1. Bytes processed             | 0           |
+          |  2.2. Bytes left to process       | > 0         |
+          |  2.3. Bytes in progress           | 0           |
+          |  3.1. Estimated shrink rate       | 0 MB/s      |
+          |  3.2. Estimated time              | not defined |
          And all files in gpAdminLogs directory are deleted
 
          # Check progress report at rollback before finish of first table redistribution
@@ -938,14 +944,15 @@ Feature: ggrebalance behave tests (misc options scenarios)
             FROM ggrebalance.rebalance_progress;
             """
         Then validate that following rows are in the stored rows
-          |  stat_name                       | stat_value  |
-          |  1.1 Tables rollback in progress | 1           |
-          |  1.2 Tables left to rollback     | 9           |
-          |  2.1. Bytes processed            | 0           |
-          |  2.2. Bytes left to process      | > 0         |
-          |  2.3. Bytes in progress          | > 0         |
-          |  3.1. Estimated shrink rate      | 0 MB/s      |
-          |  3.2. Estimated time             | not defined |
+          |  stat_name                        | stat_value  |
+          |  1.1. Tables rolled back          | 0           |
+          |  1.2. Tables rollback in progress | 1           |
+          |  1.3. Tables left to rollback     | 9           |
+          |  2.1. Bytes processed             | 0           |
+          |  2.2. Bytes left to process       | > 0         |
+          |  2.3. Bytes in progress           | > 0         |
+          |  3.1. Estimated shrink rate       | 0 MB/s      |
+          |  3.2. Estimated time              | not defined |
          And all files in gpAdminLogs directory are deleted
 
          # Check progress report at rollback when some tables have been redistributed
@@ -969,14 +976,15 @@ Feature: ggrebalance behave tests (misc options scenarios)
             FROM ggrebalance.rebalance_progress;
             """
         Then validate that following rows are in the stored rows
-          |  stat_name                       | stat_value  |
-          |  1.1 Tables rollback in progress | 1           |
-          |  1.2 Tables left to rollback     | 6           |
-          |  2.1. Bytes processed            | > 0         |
-          |  2.2. Bytes left to process      | > 0         |
-          |  2.3. Bytes in progress          | > 0         |
-          |  3.1. Estimated shrink rate      | > 0 MB/s    |
-          |  3.2. Estimated time             | > 0 s       |
+          |  stat_name                        | stat_value  |
+          |  1.1. Tables rolled back          | 3           |
+          |  1.2. Tables rollback in progress | 1           |
+          |  1.3. Tables left to rollback     | 6           |
+          |  2.1. Bytes processed             | > 0         |
+          |  2.2. Bytes left to process       | > 0         |
+          |  2.3. Bytes in progress           | > 0         |
+          |  3.1. Estimated shrink rate       | > 0 MB/s    |
+          |  3.2. Estimated time              | > 0 s       |
          And all files in gpAdminLogs directory are deleted
 
          # Check progress report at rollback before finish of last table redistribution
@@ -1000,14 +1008,15 @@ Feature: ggrebalance behave tests (misc options scenarios)
             FROM ggrebalance.rebalance_progress;
             """
         Then validate that following rows are in the stored rows
-          |  stat_name                       | stat_value  |
-          |  1.1 Tables rollback in progress | 1           |
-          |  1.2 Tables left to rollback     | 0           |
-          |  2.1. Bytes processed            | > 0         |
-          |  2.2. Bytes left to process      | > 0         |
-          |  2.3. Bytes in progress          | > 0         |
-          |  3.1. Estimated shrink rate      | > 0 MB/s    |
-          |  3.2. Estimated time             | > 0 s       |
+          |  stat_name                        | stat_value  |
+          |  1.1. Tables rolled back          | 9           |
+          |  1.2. Tables rollback in progress | 1           |
+          |  1.3. Tables left to rollback     | 0           |
+          |  2.1. Bytes processed             | > 0         |
+          |  2.2. Bytes left to process       | > 0         |
+          |  2.3. Bytes in progress           | > 0         |
+          |  3.1. Estimated shrink rate       | > 0 MB/s    |
+          |  3.2. Estimated time              | > 0 s       |
          And all files in gpAdminLogs directory are deleted
 
          # Check progress report at rollback when all tables have been redistributed
@@ -1030,11 +1039,12 @@ Feature: ggrebalance behave tests (misc options scenarios)
             FROM ggrebalance.rebalance_progress;
             """
         Then validate that following rows are in the stored rows
-          |  stat_name                       | stat_value  |
-          |  1.1 Tables rollback in progress | 0           |
-          |  1.2 Tables left to rollback     | 0           |
-          |  2.1. Bytes processed            | > 0         |
-          |  2.2. Bytes left to process      | 0           |
-          |  2.3. Bytes in progress          | 0           |
-          |  3.1. Estimated shrink rate      | > 0 MB/s    |
-          |  3.2. Estimated time             | 0 s         |
+          |  stat_name                        | stat_value  |
+          |  1.1. Tables rolled back          | 10          |
+          |  1.2. Tables rollback in progress | 0           |
+          |  1.3. Tables left to rollback     | 0           |
+          |  2.1. Bytes processed             | > 0         |
+          |  2.2. Bytes left to process       | 0           |
+          |  2.3. Bytes in progress           | 0           |
+          |  3.1. Estimated shrink rate       | > 0 MB/s    |
+          |  3.2. Estimated time              | 0 s         |

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -547,6 +547,8 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "heap" table "test_schema_1.test_table_8" in "test_db_1" with "500" rows
          And there is a "heap" table "test_schema_1.test_table_9" in "test_db_1" with "500" rows
          And all files in gpAdminLogs directory are deleted
+
+         # Check progress report before any table is redistributed
          And set fault inject "on_enter_STATE_PREPARE_SHRINK_SCHEMA_DONE_begin"
         When the user runs "ggrebalance --simple-progress --non-interactive-mode -n 1 -x 3  --skip-rebalance"
         Then ggrebalance should return a return code of 1
@@ -561,6 +563,8 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  1.2. Tables shrink in progress  | 0          |
           |  1.3. Tables left to shrink      | 10         |
          And all files in gpAdminLogs directory are deleted
+
+         # Check progress report before finish of first table redistribution
          And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_0"
         When the user runs "ggrebalance -n 1 --non-interactive-mode"
         Then ggrebalance should return a return code of 1
@@ -576,6 +580,8 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  1.2. Tables shrink in progress  | 1          |
           |  1.3. Tables left to shrink      | 9          |
          And all files in gpAdminLogs directory are deleted
+
+         # Check progress report when some tables have been redistributed
          And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_3"
         When the user runs "ggrebalance -n 1 --non-interactive-mode"
         Then ggrebalance should return a return code of 1
@@ -591,6 +597,8 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  1.2. Tables shrink in progress  | 1          |
           |  1.3. Tables left to shrink      | 6          |
          And all files in gpAdminLogs directory are deleted
+
+         # Check progress report before finish of last table redistribution
          And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_9"
         When the user runs "ggrebalance -n 1 --non-interactive-mode"
         Then ggrebalance should return a return code of 1
@@ -606,42 +614,11 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  1.2. Tables shrink in progress  | 1          |
           |  1.3. Tables left to shrink      | 0          |
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -n 1 --non-interactive-mode"
-        Then ggrebalance should return a return code of 0
-         And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
-        When execute following sql in db "postgres" and store result in the context
-            """
-            SELECT * FROM ggrebalance.rebalance_progress;
-            """
-        Then validate that following rows are in the stored rows
-          |  stat_name                       | stat_value |
-          |  1.1. Tables shrinked            | 10         |
-          |  1.2. Tables shrink in progress  | 0          |
-          |  1.3. Tables left to shrink      | 0          |
 
-    # TODO: test with full rebalance, not only shrink
-    # TODO: merge with the preceding test
-    Scenario: test 22. Check '--simple-progress' option with rollback flow.
-        Given the database is not running
-         And a working directory of the test as '/data/gpdata/ggrebalance'
-         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
-         And database "test_db_1" exists
-         And schema "test_schema_1" exists in "test_db_1"
-         And there is a "heap" table "test_schema_1.test_table_0" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_2" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_4" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_5" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_6" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_7" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_8" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_9" in "test_db_1" with "500" rows
-         And all files in gpAdminLogs directory are deleted
+         # Check progress report when all tables have been redistributed
          And set fault inject "on_enter_STATE_SHRINK_TABLES_DONE_end"
-        When the user runs "ggrebalance --simple-progress --non-interactive-mode -n 1 -x 3  --skip-rebalance"
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
         Then ggrebalance should return a return code of 1
-         And unset fault inject
         When execute following sql in db "postgres" and store result in the context
             """
             SELECT * FROM ggrebalance.rebalance_progress;
@@ -652,6 +629,8 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  1.2. Tables shrink in progress  | 0          |
           |  1.3. Tables left to shrink      | 0          |
          And all files in gpAdminLogs directory are deleted
+
+         # Check progress report at rollback before any table is rolled back
          And set fault inject "on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_end"
         When the user runs "ggrebalance -r -n 1 --non-interactive-mode"
         Then ggrebalance should return a return code of 1
@@ -665,6 +644,8 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  1.1 Tables rollback in progress | 0          |
           |  1.2 Tables left to rollback     | 10         |
          And all files in gpAdminLogs directory are deleted
+
+         # Check progress report at rollback before finish of first table redistribution
          And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_0"
         When the user runs "ggrebalance -n 1 --non-interactive-mode"
         Then ggrebalance should return a return code of 1
@@ -679,6 +660,8 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  1.1 Tables rollback in progress | 1          |
           |  1.2 Tables left to rollback     | 9          |
          And all files in gpAdminLogs directory are deleted
+
+         # Check progress report at rollback when some tables have been redistributed
          And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_3"
         When the user runs "ggrebalance -n 1 --non-interactive-mode"
         Then ggrebalance should return a return code of 1
@@ -693,6 +676,8 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  1.1 Tables rollback in progress | 1          |
           |  1.2 Tables left to rollback     | 6          |
          And all files in gpAdminLogs directory are deleted
+
+         # Check progress report at rollback before finish of last table redistribution
          And set fault inject "before_set_status_test_db_1.test_schema_1.test_table_9"
         When the user runs "ggrebalance -n 1 --non-interactive-mode"
         Then ggrebalance should return a return code of 1
@@ -705,4 +690,19 @@ Feature: ggrebalance behave tests (misc options scenarios)
         Then validate that following rows are in the stored rows
           |  stat_name                       | stat_value |
           |  1.1 Tables rollback in progress | 1          |
+          |  1.2 Tables left to rollback     | 0          |
+         And all files in gpAdminLogs directory are deleted
+
+         # Check progress report at rollback when all tables have been redistributed
+         And set fault inject "on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_begin"
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 1
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT * FROM ggrebalance.rebalance_progress;
+            """
+        Then validate that following rows are in the stored rows
+          |  stat_name                       | stat_value |
+          |  1.1 Tables rollback in progress | 0          |
           |  1.2 Tables left to rollback     | 0          |

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -530,24 +530,42 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And ggrebalance should print "soft shutdown, waiting for critical operations to finish..." to logfile with latest timestamp
          And ggrebalance should print "Rebalance was interrupted" to logfile with latest timestamp
 
-    Scenario: test 21. Check '--simple-progress' option.
+    Scenario: test 21. Check '--no-progress', '--simple-progress' and '--detailed-progress' options.
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
          And database "test_db_1" exists
          And schema "test_schema_1" exists in "test_db_1"
-         And there is a "heap" table "test_schema_1.test_table_0" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_2" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_4" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_5" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_6" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_7" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_8" in "test_db_1" with "500" rows
-         And there is a "heap" table "test_schema_1.test_table_9" in "test_db_1" with "500" rows
+         And there is a "heap" table "test_schema_1.test_table_0" in "test_db_1" with "50000" rows
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "50000" rows
+         And there is a "heap" table "test_schema_1.test_table_2" in "test_db_1" with "50000" rows
+         And there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "50000" rows
+         And there is a "heap" table "test_schema_1.test_table_4" in "test_db_1" with "50000" rows
+         And there is a "heap" table "test_schema_1.test_table_5" in "test_db_1" with "50000" rows
+         And there is a "heap" table "test_schema_1.test_table_6" in "test_db_1" with "50000" rows
+         And there is a "heap" table "test_schema_1.test_table_7" in "test_db_1" with "50000" rows
+         And there is a "heap" table "test_schema_1.test_table_8" in "test_db_1" with "50000" rows
+         And there is a "heap" table "test_schema_1.test_table_9" in "test_db_1" with "50000" rows
          And all files in gpAdminLogs directory are deleted
 
+         # Check for '--no-progress'
+         And set fault inject "on_enter_STATE_PREPARE_SHRINK_SCHEMA_DONE_begin"
+        When the user runs "ggrebalance --no-progress --non-interactive-mode -n 1 -x 3 --skip-rebalance"
+        Then ggrebalance should return a return code of 1
+         And unset fault inject
+        When execute following sql in db "postgres" and store result in the context
+            """
+            SELECT to_regclass('ggrebalance.rebalance_progress') IS NOT NULL AS progress_view_exists;
+            """
+        Then validate that following rows are in the stored rows
+          |  progress_view_exists  |
+          |  f                     |
+        When the user runs "ggrebalance -r -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rollback is complete" to logfile with latest timestamp
+         And all files in gpAdminLogs directory are deleted
+
+         # Checks for '--simple-progress'
          # Check progress report before any table is redistributed
          And set fault inject "on_enter_STATE_PREPARE_SHRINK_SCHEMA_DONE_begin"
         When the user runs "ggrebalance --simple-progress --non-interactive-mode -n 1 -x 3 --skip-rebalance"
@@ -706,25 +724,12 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  stat_name                       | stat_value |
           |  1.1 Tables rollback in progress | 0          |
           |  1.2 Tables left to rollback     | 0          |
-
-    Scenario: test 21. Check '--detailed-progress' option with normal flow.
-        Given the database is not running
-         And a working directory of the test as '/data/gpdata/ggrebalance'
-         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
-         And database "test_db_1" exists
-         And schema "test_schema_1" exists in "test_db_1"
-         And there is a "heap" table "test_schema_1.test_table_0" in "test_db_1" with "1000000" rows
-         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "1000000" rows
-         And there is a "heap" table "test_schema_1.test_table_2" in "test_db_1" with "1000000" rows
-         And there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "1000000" rows
-         And there is a "heap" table "test_schema_1.test_table_4" in "test_db_1" with "1000000" rows
-         And there is a "heap" table "test_schema_1.test_table_5" in "test_db_1" with "1000000" rows
-         And there is a "heap" table "test_schema_1.test_table_6" in "test_db_1" with "1000000" rows
-         And there is a "heap" table "test_schema_1.test_table_7" in "test_db_1" with "1000000" rows
-         And there is a "heap" table "test_schema_1.test_table_8" in "test_db_1" with "1000000" rows
-         And there is a "heap" table "test_schema_1.test_table_9" in "test_db_1" with "1000000" rows
          And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rollback is complete" to logfile with latest timestamp
 
+         # Checks for '--detailed-progress'
          # Check progress report before any table is redistributed
          And set fault inject "on_enter_STATE_PREPARE_SHRINK_SCHEMA_DONE_begin"
         When the user runs "ggrebalance --detailed-progress --non-interactive-mode -n 1 -x 3 --skip-rebalance"


### PR DESCRIPTION
Implement progress reporting for ggrebalance

This patch adds support for options:
1. '--detailed-progress',
2. '--simple-progress',
3. '--no-progress'.

When detailed or simple progress options are used, a view 'rebalance_progress'
is created in the ggrebalance schema. It allows to track the status of current
ggrebalance operation. The amount of details in the view depends on the
progress option selection.

As now the progress can be tracked via the mentioned view, function
'print_progress()' is totally removed, as it was a temporary solution.

Note: currently progress report is focused only on the shrink operation.

Plus fix test 'test 6.1' from 'ggrebalance_misc_options' suite
('--non-interactive-mode' was missing).