### PR TITLE
GG-375: Add volatile expression alert for replicated tables to gpcheckcat (6.x)

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -588,6 +588,65 @@ def checkDistribPolicy():
 
     checkConstraintsRepair()
 
+def checkReplicatedDistribPolicy():
+    logger.info('-----------------------------------')
+    logger.info('Checking distribution violations on replicated tables')
+
+    # SELECT all replicated tables with volatile functions in default expressions from non-system schemas
+    qry = '''
+    SELECT
+        n.nspname AS nspname,
+        c.relname AS relname,
+        a.attname AS attname,
+        pg_get_expr(ad.adbin, ad.adrelid) AS default_expr
+    FROM pg_class c
+        JOIN pg_namespace n ON c.relnamespace = n.oid
+        JOIN pg_attribute a ON c.oid = a.attrelid
+        JOIN pg_attrdef ad ON c.oid = ad.adrelid AND a.attnum = ad.adnum
+        JOIN gp_distribution_policy d ON c.oid = d.localoid
+        JOIN pg_proc p ON ad.adbin ~ (':funcid ' || p.oid || ' ')
+    WHERE c.relkind = 'r'
+        AND d.policytype = 'r'
+        AND a.attnum > 0
+        AND NOT a.attisdropped
+        AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+        AND p.provolatile = 'v';
+    '''
+
+    try:
+        db =  connect2(GV.cfg[GV.master_dbid])
+        curs = db.query(qry)
+
+        err = []
+        for row in curs.dictresult():
+            err.append([GV.cfg[GV.master_dbid], ('nspname', 'relname', 'attname', 'default_expr'), row])
+
+        if not err:
+            logger.info('[OK] replicated tables')
+        else:
+            GV.checkStatus = False
+            setError(ERROR_NOREPAIR)
+            logger.info('[FAIL] replicated tables')
+            myprint(
+                    '[ERROR]: %d columns, containing volatile expressions as defaults, '
+                    'have violated replicated table\'s distribution policy. '
+                    'This must be manually resolved. Check the gpcheckcat log for details.' % len(err)
+                )
+            logger.error('replicated tables has %d issue(s)' % len(err))
+            logger.error('Replace the VOLATILE defaults with a STABLE expression via `ALTER TABLE ... SET DEFAULT ...`, '
+                            'also sync the data among segments.')
+            logger.error('The following columns and their tables must be manually fixed and synced:')
+            for e in err:
+                logger.error(formatErr(e[0], e[1], e[2]))
+            if len(err) > 100:
+                logger.error('...')
+                logger.error(qry)
+    except Exception as e:
+        GV.checkStatus = False
+        setError(ERROR_NOREPAIR)
+        myprint('[ERROR] executing test: checkReplicatedDistribPolicy')
+        myprint('  Execution error: ' + str(e))
+
 #############
 def checkPartitionIntegrity():
     #
@@ -3310,6 +3369,14 @@ all_checks = {
             "fn": lambda: checkMixDistPolicy(),
             "version": 'main',
             "order": 17,
+            "online": True
+        },
+    "replicated_distribution_policy":
+        {
+            "description": "Check policy violations of replicated tables",
+            "fn": lambda: checkReplicatedDistribPolicy(),
+            "version": 'main',
+            "order": 18,
             "online": True,
             "defaultSkip": True
         }

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -446,6 +446,35 @@ class GpCheckCatTestCase(GpTestCase):
                 self.num_joins = 0
                 self.num_starts = 0
 
+    def test_checkReplicatedDistribPolicy_with_error_on_execution(self):
+        # Mocking the database connection to raise an exception during execution
+
+        self.db_connection.query.side_effect = Exception("Simulated error during execution")
+
+        # Call the function to test
+        self.subject.checkReplicatedDistribPolicy()
+
+        # Assertions
+        self.assertEqual(self.db_connection.query.call_count, 1)
+        self.assertEqual(self.db_connection.query.dictresult.call_count, 0)
+        self.assertFalse(self.subject.GV.checkStatus)
+        self.subject.setError.assert_any_call(self.subject.ERROR_NOREPAIR)
+
+    @patch('gpcheckcat.connect2')
+    def test_checkReplicatedDistribPolicy_exception_on_connect(self, mock_connect2):
+        # Mocking the database connection to raise an exception during connection
+        mock_connect2.side_effect = Exception("Simulated error during connection")
+
+        # Call the function to test
+        self.subject.checkReplicatedDistribPolicy()
+
+        # Assertions
+        self.assertEqual(mock_connect2.call_count, 1)
+        self.assertFalse(self.subject.GV.checkStatus)
+        self.assertEqual(mock_connect2.query.call_count, 0)
+        self.assertEqual(mock_connect2.query.dictresult.call_count, 0)
+        self.subject.setError.assert_any_call(self.subject.ERROR_NOREPAIR)
+
     def test_checkMixDistPolicy_with_error_on_execution(self):
         # Mocking the database connection to raise an exception during execution
 

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -169,6 +169,15 @@ Feature: gpcheckcat tests
         Then gpcheckcat should return a return code of 0
         And the user runs "dropdb constraint_db"
 
+    Scenario: gpcheckcat should report replicated tables policy violation via default volatile expressions
+        Given database "policy_violation_db" is dropped and recreated
+        And the user runs "psql policy_violation_db -f test/behave/mgmt_utils/steps/data/gpcheckcat/violate_replicated_policy.sql"
+        Then psql should return a return code of 0
+        When the user runs "gpcheckcat -R replicated_distribution_policy policy_violation_db"
+        Then gpcheckcat should return a return code of 3
+        Then gpcheckcat should print "2 columns, containing volatile expressions as defaults, have violated replicated table's distribution policy" to stdout
+        And the user runs "dropdb constraint_db"
+
     Scenario: gpcheckcat should report, but not repair, invalid policy issues
         Given database "policy_db" is dropped and recreated
           And the path "gpcheckcat.repair.*" is removed from current working directory

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/violate_replicated_policy.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/violate_replicated_policy.sql
@@ -1,0 +1,44 @@
+CREATE FUNCTION fn_vol()
+        RETURNS int
+        LANGUAGE plpgsql
+        IMMUTABLE
+AS $$
+BEGIN
+	RETURN (random() * 1000)::int;
+END;
+$$
+EXECUTE ON ANY;
+
+CREATE FUNCTION fn_val()
+        RETURNS int
+        LANGUAGE plpgsql
+        IMMUTABLE
+AS $$
+BEGIN
+	RETURN 42;
+END;
+$$
+EXECUTE ON ANY;
+
+CREATE TABLE dist_replicated_vol1(
+    a INT,
+    b FLOAT,
+    c TEXT DEFAULT 'Lorem Ipsum',
+    d TEXT DEFAULT NULL,
+    e_vol INT DEFAULT fn_vol()
+) DISTRIBUTED REPLICATED;
+
+CREATE TABLE dist_replicated_vol2(
+    a_vol INT DEFAULT (42*fn_vol())+42,
+    b_vol INT DEFAULT fn_val() + 42,
+    c_vol FLOAT
+) DISTRIBUTED REPLICATED;
+
+CREATE TABLE dist_replicated_non_vol(
+    a FLOAT,
+    b FLOAT,
+    c INT DEFAULT fn_val()
+) DISTRIBUTED REPLICATED;
+
+-- Replace already used function to break policy
+ALTER FUNCTION fn_vol() VOLATILE;


### PR DESCRIPTION
What happens?
Although c2bf4c9 protects replicated tables from main ways to break its policy
via usage of volatile expressions, some loopholes still exists (one is used in
violate_replicated_policy.sql for behave test) and we can't do much about them,
except to alert the user.

How can we help the user?
gpcheckcat exists for similar purposes, so adding command to it, which alerts
the user about such data inconsistency should help.

What command does?
Shows all columns with volatile expressions of all replicated tables among all
non-system schemas.

Can we resync replicated table among segments?
No, as it is not obvious how to do it. If we choose to sync with one of the
segments, it raises question of what segment to choose as main to resync data
with. Even if we delegate this responsibility to user, gpcheckcat does not
contain many interactive ways to provide arguments to command to begin with.

Tests?
Unit tests for broken connection / cursor reading are provided. Behave test to
check alert of inconsistent data also provided.

Changes?
Changed cursor reading method due to its impelemtation difference in 6.x, also
removed one UT test dependant on updated cursor.

(cherry picked from commit 105dd4d)

Ticket: GG-375

!!!REBASE ONLY!!!