### PR TITLE
GG-347: Fix pg_upgrade fail when there are extensions that need to be updated [7X]

### DIFF
--- a/src/bin/pg_upgrade/version.c
+++ b/src/bin/pg_upgrade/version.c
@@ -439,7 +439,7 @@ report_extension_updates(ClusterInfo *cluster)
 	if (found)
 	{
 		report_status(PG_REPORT, "notice");
-		gp_fatal_log(
+		pg_log(PG_REPORT,
 				"| Your installation contains extensions that should be updated\n"
 				"| with the ALTER EXTENSION command.  The file\n"
 				"|     %s\n"


### PR DESCRIPTION
In the commit c9a8039904406df9e31bb1bc1d9c48fb2d325746
pg_log(PG_REPORT, ...) was accidentally replaced with gp_fatal_log. 
Because of this change, ggupgrade fails if there are 
extensions that need to be updated. For example pageinspect.

Let's revert this change. 

Ticket: GG-347

---------

Co-authored-by: Viktor Kurilko <v.kurilko@arenadata.io>