### PR TITLE
GG-381: Incorrect Host header when connecting gpfdist via K8s Ingress (6.x)

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1319,9 +1319,9 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	Assert(file->curl->x_httpheader == NULL);
 
 	/*
-	 * support multihomed http use cases. see MPP-11874
+	 * support multihomed use case and always fill 'Host' field
 	 */
-	if (IS_HTTP_URI(url))
+	if (IS_HTTP_URI(url) || IS_GPFDIST_URI(url) || IS_GPFDISTS_URI(url))
 	{
 		char domain[HOST_NAME_SIZE] = {0};
 


### PR DESCRIPTION
What happens?
Routing when using K8s Ingress and gpfdist fails with error 404.

Why it happens?
When using gpfdist or gpfdists protocols, 'Host' field of header is not filled
with URI and instead automatically gets assigned with a resolved IP. So, on the
next hop to host routing fails, because host can have several domains hosted.
RFC 7320 explicitly states this.

How do we fix this?
'Host' field of HTTP request header must be original unresolved URI used in
request (not IP).

Tests?
No tests provided as it seems gpfdist only has regression tests and checking
HTTP header is not supported. Yet, it can be manually checked using utilities
like netcat.

Changes?
Nothing had to be changed from original commit.

(cherry picked from commit 6ca2225)

Ticket: GG-381

!!!REBASE ONLY!!!