### PR TITLE
Fix some options' dependence on the 'parallel' option

### DIFF
--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_sm.py
@@ -185,10 +185,10 @@ class RebalanceSM:
             if batch_size > MAX_COORDINATOR_NUM_WORKERS:
                 batch_size = MAX_COORDINATOR_NUM_WORKERS
             gpmovemirrors_options += f' -B {batch_size}'
-            if self.options.hba_hostnames:
-                gpmovemirrors_options = gpmovemirrors_options + ' --hba-hostnames'
-            if self.options.logfile_directory is not None:
-                gpmovemirrors_options = gpmovemirrors_options + f' -l "{str(self.options.logfile_directory)}"'
+        if self.options.hba_hostnames:
+            gpmovemirrors_options = gpmovemirrors_options + ' --hba-hostnames'
+        if self.options.logfile_directory is not None:
+            gpmovemirrors_options = gpmovemirrors_options + f' -l "{str(self.options.logfile_directory)}"'
         try:
             self.cmd = GpMoveMirrors("Running gpmovemirrors", options=gpmovemirrors_options)
             self.cmd.run(validateAfter=True)
@@ -290,10 +290,10 @@ class RebalanceSM:
                 if batch_size > MAX_COORDINATOR_NUM_WORKERS:
                     batch_size = MAX_COORDINATOR_NUM_WORKERS
                 recoverseg_options += f' -B {batch_size}'
-                if self.options.replay_lag is not None:
-                    recoverseg_options = recoverseg_options + f' --replay-lag {self.options.replay_lag}'
-                if self.options.logfile_directory is not None:
-                    recoverseg_options = recoverseg_options + f' -l "{str(self.options.logfile_directory)}"'
+            if self.options.replay_lag is not None:
+                recoverseg_options = recoverseg_options + f' --replay-lag {self.options.replay_lag}'
+            if self.options.logfile_directory is not None:
+                recoverseg_options = recoverseg_options + f' -l "{str(self.options.logfile_directory)}"'
             try:
                 self.cmd = GpRecoverSeg("Running gprecoverseg", options=recoverseg_options)
                 self.cmd.run(validateAfter=True)


### PR DESCRIPTION
Fix some options' dependence on the 'parallel' option

Problem description:
Options '--log-dir', '--replay-lag' and '--hba-hostnames' were applied only if
`options.parallel` was set to some value. Reason was wrong indentation.

This patch fixes the indentation.
