### PR TITLE
Eliminate demo cluster creation before behave tests (#193)

### DIFF
--- a/ci/scripts/behave_gpdb.bash
+++ b/ci/scripts/behave_gpdb.bash
@@ -11,8 +11,6 @@ function gen_env(){
 
 		source /usr/local/greengage-db-devel/greengage_path.sh
 
-		source gpdb_src/gpAux/gpdemo/gpdemo-env.sh
-
 		cd "\${1}/gpdb_src/gpMgmt/"
 		BEHAVE_TAGS="${BEHAVE_TAGS}"
 		BEHAVE_FLAGS="${BEHAVE_FLAGS}"
@@ -32,10 +30,6 @@ function _main() {
 				echo "FATAL: BEHAVE_TAGS or BEHAVE_FLAGS not set"
 				exit 1
 		fi
-
-		# Run inside a subshell so it does not pollute the environment after
-		# sourcing greengage_path
-		time (make_cluster)
 
 		time gen_env
 

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -20,11 +20,15 @@ def before_all(context):
 
 def before_feature(context, feature):
     # we should be able to run gpexpand without having a cluster initialized
-    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors',
-                    'gpconfig', 'gpssh-exkeys', 'gpstop', 'gpinitsystem', 'cross_subnet',
-                    'gplogfilter']
+    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate',
+                    'gpssh-exkeys', 'gpinitsystem', 'cross_subnet']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
+
+    if not hasattr(context, "cluster_created"):
+        context.cluster_created = True
+        from test.behave_utils.ci.fixtures import init_cluster
+        use_fixture(init_cluster, context)
 
     drop_database_if_exists(context, 'testdb')
     drop_database_if_exists(context, 'bkdb')
@@ -99,11 +103,6 @@ def before_scenario(context, scenario):
     if "skip" in scenario.effective_tags:
         scenario.skip("skipping scenario tagged with @skip")
         return
-
-    if "concourse_cluster" in scenario.effective_tags and not hasattr(context, "concourse_cluster_created"):
-        from test.behave_utils.ci.fixtures import init_cluster
-        context.concourse_cluster_created = True
-        return use_fixture(init_cluster, context)
 
     if 'gpmovemirrors' in context.feature.tags:
         context.mirror_context = MirrorMgmtContext()

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -40,9 +40,7 @@ from gppylib import pgconf
 from gppylib.commands.gp import get_coordinatordatadir
 from gppylib.parseutils import canonicalize_address
 
-coordinator_data_dir = gp.get_coordinatordatadir()
-if coordinator_data_dir is None:
-    raise Exception('Please set COORDINATOR_DATA_DIRECTORY in environment')
+coordinator_data_dir = None
 
 def create_local_demo_cluster(context, extra_config='', with_mirrors='true', with_standby='true', num_primaries=None):
     stop_database_if_started(context)
@@ -51,15 +49,24 @@ def create_local_demo_cluster(context, extra_config='', with_mirrors='true', wit
         num_primaries = os.getenv('NUM_PRIMARY_MIRROR_PAIRS', 3)
 
     os.environ['PGPORT'] = '15432'
+    demoDir = os.path.abspath("%s/../gpAux/gpdemo" % os.getcwd())
+    global coordinator_data_dir
+    coordinator_data_dir = "%s/datadirs/qddir/demoDataDir-1" % demoDir
+    os.environ['COORDINATOR_DATA_DIRECTORY'] = coordinator_data_dir
+
     cmd = """
         cd ../gpAux/gpdemo &&
         export DEMO_PORT_BASE={port_base} &&
         export NUM_PRIMARY_MIRROR_PAIRS={num_primary_mirror_pairs} &&
+        export PGPORT={pgport} &&
+        export COORDINATOR_DATA_DIRECTORY={coordinator_data_dir} &&
         export WITH_STANDBY={with_standby} &&
         export WITH_MIRRORS={with_mirrors} &&
         ./demo_cluster.sh -d && ./demo_cluster.sh -c &&
         {extra_config} ./demo_cluster.sh
     """.format(port_base=os.getenv('PORT_BASE', 15432),
+               pgport=os.getenv('PGPORT', 15432),
+               coordinator_data_dir=os.getenv('COORDINATOR_DATA_DIRECTORY', coordinator_data_dir),
                num_primary_mirror_pairs=num_primaries,
                with_mirrors=with_mirrors,
                with_standby=with_standby,
@@ -121,10 +128,6 @@ def impl(context, checksum_toggle):
 
 @given('the cluster is generated with "{num_primaries}" primaries only')
 def impl(context, num_primaries):
-    os.environ['PGPORT'] = '15432'
-    demoDir = os.path.abspath("%s/../gpAux/gpdemo" % os.getcwd())
-    os.environ['COORDINATOR_DATA_DIRECTORY'] = "%s/datadirs/qddir/demoDataDir-1" % demoDir
-
     create_local_demo_cluster(context, with_mirrors='false', with_standby='false', num_primaries=num_primaries)
 
     context.gpexpand_mirrors_enabled = False
@@ -235,19 +238,27 @@ def impl(context, checksum_toggle):
             is_ok = False
 
     if not is_ok:
-        stop_database(context)
+        stop_database_if_started(context)
 
         os.environ['PGPORT'] = '15432'
         port_base = os.getenv('PORT_BASE', 15432)
+        demoDir = os.path.abspath("%s/../gpAux/gpdemo" % os.getcwd())
+        global coordinator_data_dir
+        coordinator_data_dir = "%s/datadirs/qddir/demoDataDir-1" % demoDir
+        os.environ['COORDINATOR_DATA_DIRECTORY'] = coordinator_data_dir
 
         cmd = """
         cd ../gpAux/gpdemo; \
             export DEMO_PORT_BASE={port_base} && \
             export NUM_PRIMARY_MIRROR_PAIRS={num_primary_mirror_pairs} && \
+            export PGPORT={pgport} &&
+            export COORDINATOR_DATA_DIRECTORY={coordinator_data_dir} &&
             export WITH_MIRRORS={with_mirrors} && \
             ./demo_cluster.sh -d && ./demo_cluster.sh -c && \
             env EXTRA_CONFIG="HEAP_CHECKSUM={checksum_toggle}" ./demo_cluster.sh
         """.format(port_base=port_base,
+                   pgport=os.getenv('PGPORT', 15432),
+                   coordinator_data_dir=os.getenv('COORDINATOR_DATA_DIRECTORY', coordinator_data_dir),
                    num_primary_mirror_pairs=os.getenv('NUM_PRIMARY_MIRROR_PAIRS', 3),
                    with_mirrors='true',
                    checksum_toggle=checksum_toggle)
@@ -2864,6 +2875,7 @@ def _create_cluster(context, coordinator_host, segment_host_list, hba_hostnames=
     global coordinator_data_dir
     coordinator_data_dir = os.path.join(context.working_directory, 'data/coordinator/gpseg-1')
     os.environ['COORDINATOR_DATA_DIRECTORY'] = coordinator_data_dir
+    os.environ['PGPORT'] = '10300'
 
     try:
         with closing(dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False)) as conn:

--- a/gpMgmt/test/behave_utils/ci/fixtures.py
+++ b/gpMgmt/test/behave_utils/ci/fixtures.py
@@ -4,8 +4,7 @@ from behave import fixture
 @fixture
 def init_cluster(context):
     context.execute_steps(u"""
-    Given the database is not running
-        And a working directory of the test as '/tmp/concourse_cluster'
+        Given the database is not running
         And the user runs command "rm -rf ~/gpAdminLogs/gpinitsystem*"
-        And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
+        And a standard local demo cluster is created
     """)

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -22,10 +22,7 @@ from gppylib.utils import escape_string
 PARTITION_START_DATE = '2010-01-01'
 PARTITION_END_DATE = '2013-01-01'
 
-coordinator_data_dir = get_coordinatordatadir()
-if coordinator_data_dir is None:
-    raise Exception('COORDINATOR_DATA_DIRECTORY is not set')
-
+coordinator_data_dir = None
 
 # query_sql returns a cursor object, so the caller is responsible for closing
 # the dbconn connection.
@@ -185,10 +182,12 @@ def check_return_code(context, ret_code):
 
 
 def check_database_is_running(context):
-    if not 'PGPORT' in os.environ:
-        raise Exception('PGPORT should be set')
+    if 'PGPORT' not in os.environ or 'COORDINATOR_DATA_DIRECTORY' not in os.environ:
+        return False
 
     pgport = int(os.environ['PGPORT'])
+    global coordinator_data_dir
+    coordinator_data_dir = os.environ['COORDINATOR_DATA_DIRECTORY']
 
     running_status = chk_local_db_running(get_coordinatordatadir(), pgport)
     gpdb_running = running_status[0] and running_status[1] and running_status[2] and running_status[3]


### PR DESCRIPTION
Eliminate demo cluster creation before behave tests

Currently, behave tests require explicitly creating a demo cluster and setting
the PGPORT and MASTER_DATA_DIRECTORY variables before running. Create a demo
cluster and set the variables before running feature tests.

Previously, the init_cluster fixture was used only for the concourse cluster,
which doesn't yet run on our CI. In this patch, this fixture is now used for
the demo cluster, and will be used for the concourse cluster in a separate PR.

Ticket: GG-155
(cherry picked from commit https://github.com/GreengageDB/greengage/commit/0977773599ee1c855a504c06cebacdda8ea4001d)

Fixed conflicts after porting patch from GG6: master_data_dir was renamed to
coordinator_data_dir.

##

Do not squash
