### PR TITLE
CI-5444: Implement Upload deb-packages to Releases from 6.x to 7.x

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -45,9 +45,7 @@ operating systems:
 
 A separate workflow `Greengage release` handles the uploading of Debian package
 to GitHub releases. It is triggered when a release is published and uses a
-composite action to manage package deployment. Currently supported for version
-6.x only; package build and release upload are not yet available for version
-7.x.
+composite action to manage package deployment.
 
 ### Key Features
 
@@ -160,9 +158,6 @@ The workflow is parameterized to support flexibility:
   strategy. Ubuntu 22.04 uses no version suffix for backward compatibility with
   existing artifact naming; Ubuntu 24.04 support is currently available for
   version 6.x only.
-- **Package Build and Release**: Debian package build and upload to GitHub
-  releases are currently supported for version 6.x only. Version 7.x does not
-  yet include package build steps in the CI workflow.
 
 ## Usage
 

--- a/.github/workflows/greengage-release.yml
+++ b/.github/workflows/greengage-release.yml
@@ -1,0 +1,25 @@
+# Release creation workflow
+name: Greengage release
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  upload-to-release:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - artifact_name: deb-packages
+          extensions:    deb ddeb
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - name: Upload packages to release
+        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v27
+        with:
+          extensions: ${{ matrix.extensions }}
+          artifact_name: ${{ matrix.artifact_name }}


### PR DESCRIPTION
## Implement Upload deb-packages to Releases from 6.x to 7.x (#386)

- [ci: add greengage-release.yml workflow from 6.x branch](https://github.com/GreengageDB/greengage/commit/aad4c0e2deae42b56a2ff8bf8ce2a82d17cfca7b)
  Port the `Greengage release` workflow from the `6.x` branch to enable
  automated package uploads to GitHub releases. The workflow triggers on
  release events and uploads `deb`/`ddeb` packages using the shared
  greengage-ci action
- actualize `workflows/README.md`

Task: [CI-5444](https://tracker.yandex.ru/CI-5444)