### PR TITLE
GG-379: Fix a typo and expand credcheck coverage

### DIFF
--- a/gpcontrib/credcheck/Makefile
+++ b/gpcontrib/credcheck/Makefile
@@ -18,7 +18,7 @@ DATA = sql/$(EXTENSION)--$(EXTVERSION).sql
 REGRESS_OPTS  = --inputdir=test --load-extension=credcheck
 TESTS = setup 01_username 02_password 03_rename 04_alter_pwd \
 	05_reuse_history 06_reuse_interval 07_valid_until \
-	08_first_login teardown
+	08_first_login 09_banned_role teardown
 
 REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))
 

--- a/gpcontrib/credcheck/credcheck.c
+++ b/gpcontrib/credcheck/credcheck.c
@@ -2278,7 +2278,7 @@ pgaf_shmem_startup(void)
 #if PG_VERSION_NUM >= 90600
 		pgaf->lock = &(GetNamedLWLockTranche(PGAF_TRANCHE_NAME))->lock;
 #else
-		pgph->lock = LWLockAssign();
+		pgaf->lock = LWLockAssign();
 #endif
 	}
 

--- a/gpcontrib/credcheck/test/expected/09_banned_role.out
+++ b/gpcontrib/credcheck/test/expected/09_banned_role.out
@@ -1,0 +1,47 @@
+-- start_matchsubs
+-- m/ \(credcheck.c:\d+\)/
+-- s/ \(credcheck.c:\d+\)//
+-- end_matchsubs
+CREATE EXTENSION credcheck;
+SELECT pg_banned_role_reset();
+ pg_banned_role_reset 
+----------------------
+                    0
+(1 row)
+
+CREATE USER credtest WITH PASSWORD 'H8Hdre=S2';
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+\! PGPASSWORD='J8YuRe=6O' psql -h localhost -U credtest -d regression -w
+psql: FATAL:  password authentication failed for user "credtest"
+\! PGPASSWORD='J8YuRe=6O' psql -h localhost -U credtest -d regression -w
+psql: FATAL:  password authentication failed for user "credtest"
+\! PGPASSWORD='J8YuRe=6O' psql -h localhost -U credtest -d regression -w
+psql: FATAL:  rejecting connection, user 'credtest' has been banned
+Note that its locks and other resources will not be released until then.
+SELECT rolname, failure_count FROM pg_banned_role;
+ rolname  | failure_count 
+----------+---------------
+ credtest |             3
+(1 row)
+
+SELECT pg_banned_role_reset('credtest');
+ pg_banned_role_reset 
+----------------------
+                    1
+(1 row)
+
+SELECT rolname, failure_count FROM pg_banned_role;
+ rolname | failure_count 
+---------+---------------
+(0 rows)
+
+\! PGPASSWORD='J8YuRe=6O' psql -h localhost -U credtest -d regression -w
+psql: FATAL:  password authentication failed for user "credtest"
+SELECT pg_banned_role_reset();
+ pg_banned_role_reset 
+----------------------
+                    1
+(1 row)
+
+DROP USER credtest;
+DROP EXTENSION credcheck CASCADE;

--- a/gpcontrib/credcheck/test/sql/09_banned_role.sql
+++ b/gpcontrib/credcheck/test/sql/09_banned_role.sql
@@ -1,0 +1,31 @@
+-- start_matchsubs
+-- m/ \(credcheck.c:\d+\)/
+-- s/ \(credcheck.c:\d+\)//
+-- end_matchsubs
+-- start_ignore
+DROP USER IF EXISTS credtest;
+DROP EXTENSION IF EXISTS credcheck CASCADE;
+-- end_ignore
+CREATE EXTENSION credcheck;
+SELECT pg_banned_role_reset();
+CREATE USER credtest WITH PASSWORD 'H8Hdre=S2';
+-- start_ignore
+\! sed -i '/credtest/d' $MASTER_DATA_DIRECTORY/pg_hba.conf;
+\! echo 'host	all	credtest	samehost	md5' | tee -a $MASTER_DATA_DIRECTORY/pg_hba.conf;
+\! gpconfig -c credcheck.max_auth_failure -v 3;
+\! gpstop -u;
+-- end_ignore
+\! PGPASSWORD='J8YuRe=6O' psql -h localhost -U credtest -d regression -w
+\! PGPASSWORD='J8YuRe=6O' psql -h localhost -U credtest -d regression -w
+\! PGPASSWORD='J8YuRe=6O' psql -h localhost -U credtest -d regression -w
+SELECT rolname, failure_count FROM pg_banned_role;
+SELECT pg_banned_role_reset('credtest');
+SELECT rolname, failure_count FROM pg_banned_role;
+\! PGPASSWORD='J8YuRe=6O' psql -h localhost -U credtest -d regression -w
+-- start_ignore
+\! gpconfig -r credcheck.max_auth_failure;
+\! gpstop -u;
+-- end_ignore
+SELECT pg_banned_role_reset();
+DROP USER credtest;
+DROP EXTENSION credcheck CASCADE;


### PR DESCRIPTION
Fix a typo and expand credcheck coverage

Commit e2ee694 adapted the credcheck extension for Greengage 6X, but it
contained a typo when initializing the role ban lock. This typo wasn't detected
in time due to a lack of test coverage for this functionality, leading to a
segfault. Fix the typo and expand test coverage for the role ban functionality.

Ticket: GG-379