### PR TITLE
Fix handling of --segment-batch-size parameter of gprecoverseg/gpmovemirrors

### DIFF
--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -37,9 +37,9 @@ def parseargs():
 
     parser.add_option('-x', '--target-segment-count', type='int', dest='target_segment_count', metavar='<target_segment_count>',
                       help='Target segments number of the whole cluster')
-    parser.add_option('-B', '--batch-size', type='int', default=4, dest='batch_size', metavar='<batch_size>',
+    parser.add_option('-B', '--batch-size', type='int', default=16, dest='batch_size', metavar='<batch_size>',
                       help='Max worker number in WorkerPool instance. Valid values are 1-%d.' % MAX_BATCH_SIZE)
-    parser.add_option('-n', '--parallel', type="int", default=4, dest="parallel", metavar='<parallel>',
+    parser.add_option('-n', '--parallel', type="int", default=16, dest="parallel", metavar='<parallel>',
                       help='Max number of workers at a time. Valid values are 1-%d.' % MAX_PARALLEL_WORKERS)
     parser.add_option('-c', '--clean', action='store_true', dest="clean_required",
                       help='remove the rebalance schema.')

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_sm.py
@@ -185,6 +185,13 @@ class RebalanceSM:
             if batch_size > MAX_COORDINATOR_NUM_WORKERS:
                 batch_size = MAX_COORDINATOR_NUM_WORKERS
             gpmovemirrors_options += f' -B {batch_size}'
+        if self.options.batch_size is not None:
+            segment_batch_size = self.options.batch_size
+            # gpmovemirrors has its own limitation for segment batch size,
+            # need to consider it here.
+            if segment_batch_size > MAX_SEGHOST_NUM_WORKERS:
+                segment_batch_size = MAX_SEGHOST_NUM_WORKERS
+            gpmovemirrors_options += f' -b {segment_batch_size}'
         if self.options.hba_hostnames:
             gpmovemirrors_options = gpmovemirrors_options + ' --hba-hostnames'
         if self.options.logfile_directory is not None:
@@ -290,6 +297,13 @@ class RebalanceSM:
                 if batch_size > MAX_COORDINATOR_NUM_WORKERS:
                     batch_size = MAX_COORDINATOR_NUM_WORKERS
                 recoverseg_options += f' -B {batch_size}'
+            if self.options.batch_size is not None:
+                segment_batch_size = self.options.batch_size
+                # gprecoverseg has its own limitation for segment batch size,
+                # need to consider it here.
+                if segment_batch_size > MAX_SEGHOST_NUM_WORKERS:
+                    segment_batch_size = MAX_SEGHOST_NUM_WORKERS
+                recoverseg_options += f' -b {segment_batch_size}'
             if self.options.replay_lag is not None:
                 recoverseg_options = recoverseg_options + f' --replay-lag {self.options.replay_lag}'
             if self.options.logfile_directory is not None:

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -1,7 +1,7 @@
 @ggrebalance_rebalance @skip
 Feature: ggrebalance behave tests (rebalance scenarios)
 
-    Scenario Outline: test 1. rebalance - check scenario, when we remove/add a host and rebalance the cluster (with different parallel size).
+    Scenario Outline: test 1. rebalance - check scenario, when we remove/add a host and rebalance the cluster (with different parallel and batch size).
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
@@ -14,7 +14,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance --non-interactive-mode --parallel <parallel_size> -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode --parallel <parallel_size> --batch-size <batch_size> -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
@@ -44,7 +44,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When the user runs "ggrebalance -c"
         Then ggrebalance should return a return code of 0
         And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance --non-interactive-mode --parallel <parallel_size> -x 6 --add-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --non-interactive-mode --parallel <parallel_size> --batch-size <batch_size> -x 6 --add-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
@@ -72,11 +72,10 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should print "Cluster is already balanced, no segment moves will be held." to logfile with latest timestamp
 
     Examples:
-        | parallel_size |
-        | 1             |
-        | 16            |
-        | 64            |
-        | 96            |
+        | parallel_size | batch_size |
+        | 1             | 1          |
+        | 64            | 64         |
+        | 96            | 128        |
 
     Scenario: test 2. rebalance - check rebalance after shrink.
         Given the database is not running


### PR DESCRIPTION
Fix handling of --segment-batch-size parameter of gprecoverseg/gpmovemirrors

Problem description:
Option '--batch_size' was not translated into the '--segment-batch-size' ('-b')
parameter of gprecoverseg/gpmovemirrors, while it should be according to our
requirements.

This patch:
 - adds handling of the '--segment-batch-size' parameter of
gprecoverseg/gpmovemirrors;
 - updates the default values of ggrebalance's '--batch-size' and '--parallel'
options;
 - adds '--batch-size' into the test that checked '--parallel' option;
 - removes test case with '--parallel'=16, as now this value is the default,
and covered in many other test cases.
