### PR TITLE
GG-391 Bump resgroup workflow version (7.x)

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -95,7 +95,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v28
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v29
     with:
       version: 7
       target_os: ${{ matrix.target_os }}

--- a/ci/scripts/run_resgroup_test.bash
+++ b/ci/scripts/run_resgroup_test.bash
@@ -34,18 +34,6 @@ sudo -u gpadmin -- bash -c "
   make PGOPTIONS='-c optimizer=$OPTIMIZER -c statement_mem=$STATEMENT_MEM' installcheck-resgroup -C gpdb_src/
 " && exitcode=0
 
-params=(
-  "./ d gpAdminLogs"
-  "gpdb_src/src/test/ d results"
-  "gpdb_src/src/test/ f regression.diffs"
-  "gpdb_src/gpAux/gpdemo/datadirs/ d log"
-)
-for param in "\${params[@]}"; do
-  read -r path type name <<< "\$param"
-  find \$path -name \$name -type \$type -exec bash -c "tar -rf '/logs/\$name.tar' '{}' ; [ '\$name' == 'regression.diffs' ] && cat '{}' || true" \;
-done
-chmod -R a+rwX /logs
-
 echo \$exitcode > /logs/.exitcode
 exit \$exitcode
 EOF


### PR DESCRIPTION
## Bump resgroup workflow version (#390)

### Problem

Previously, when resgroup tests were cancelled, logs were not always collected and uploaded as artifacts. This made debugging failures difficult.

### Solution

#### Start the QEMU VM

Initialize and boot the QEMU virtual machine.

#### Run tests via SSH

Connect to the QEMU VM via SSH and run tests.

#### Collect logs (separate step)

This step runs regardless of test outcome (`always()`), ensuring logs are preserved.

### Implementation details

Log collection is decoupled from test execution.

SSH configuration is prepared to enable interaction with Docker running inside the QEMU VM:

- `DOCKER_HOST=ssh://qemu-vm` variable is used to run Docker commands directly on the VM.

Log collection removed from `run_resgroup.sh` script.

Tests:
success: https://github.com/uaqq/greengage/actions/runs/24444386601/job/71418896131
cancelled: https://github.com/uaqq/greengage/actions/runs/24444386601/job/71444746497

Task: GG-180