### PR TITLE
GG-390 Bump resgroup workflow version (6.x)

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -103,7 +103,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v28
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v29
     with:
       version: 6
       target_os: ${{ matrix.target_os }}

--- a/ci/scripts/run_resgroup_test.bash
+++ b/ci/scripts/run_resgroup_test.bash
@@ -18,7 +18,9 @@ then
   ssh-keygen -P "" -f ssh_keys/id_rsa
 fi
 
-trap cleanup EXIT
+if [[ -z $CI ]]; then
+  trap cleanup EXIT
+fi
 
 #install gpdb and setup gpadmin user
 bash ci/scripts/init_containers.sh $project cdw sdw1

--- a/ci/scripts/run_resgroup_test.bash
+++ b/ci/scripts/run_resgroup_test.bash
@@ -81,26 +81,4 @@ EOF
 exitcode=$?
 echo "$exitcode" > "$logdir/$logfile"
 
-docker compose -p $project -f ci/docker-compose.yaml exec -T cdw bash -ex <<EOF
-  cd /home/gpadmin
-  tar -czf /logs/gpAdminLogs.tar.gz gpAdminLogs/
-  tar -czf /logs/gpAux.tar.gz gpdb_src/gpAux/gpdemo/datadirs/gpAdminLogs/
-  tar -czf /logs/pg_log.tar.gz gpdb_src/gpAux/gpdemo/datadirs/qddir/demoDataDir-1/pg_log/ gpdb_src/gpAux/gpdemo/datadirs/standby/pg_log
-  #regression.diffs may not exist if tests were successful
-  tar --ignore-failed-read -czf /logs/results.tar.gz gpdb_src/src/test/isolation2/resgroup/results/resgroup/ gpdb_src/src/test/isolation2/resgroup/regression.diffs
-EOF
-
-docker compose -p $project -f ci/docker-compose.yaml exec -T sdw1 bash -ex <<EOF
-  cd /home/gpadmin
-  tar -czf /logs/gpAdminLogs.tar.gz gpAdminLogs/
-  tar -czf /logs/gpAux.tar.gz gpdb_src/gpAux/gpdemo/datadirs/gpAdminLogs/
-  tar -czf /logs/pg_log.tar.gz \
-    gpdb_src/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/pg_log \
-    gpdb_src/gpAux/gpdemo/datadirs/dbfast2/demoDataDir1/pg_log \
-    gpdb_src/gpAux/gpdemo/datadirs/dbfast3/demoDataDir2/pg_log \
-    gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0/pg_log \
-    gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1/pg_log \
-    gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror3/demoDataDir2/pg_log
-EOF
-
 exit "$exitcode"


### PR DESCRIPTION
## Bump resgroup workflow version (#391)

### Problem

Previously, when resgroup tests were cancelled, logs were not always collected and uploaded as artifacts. This made debugging failures difficult.

### Solution

#### Start the QEMU VM

Initialize and boot the QEMU virtual machine.

#### Run tests via SSH

Connect to the QEMU VM via SSH and run tests.

#### Collect logs (separate step)

This step runs regardless of test outcome (`always()`), ensuring logs are preserved.

### Implementation details

Log collection is decoupled from test execution.

SSH configuration is prepared to enable interaction with Docker running inside the QEMU VM:

- `DOCKER_HOST=ssh://qemu-vm` variable is used to run Docker commands directly on the VM.

Log collection removed from `run_resgroup.sh` script.
CI condition was added to run_resgroup.sh script.

Task: GG-180