### PR TITLE
GG-401: Fix isolation2 dependencies to avoid rebuilds

### DIFF
--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -53,13 +53,13 @@ explain.pm:
 data:
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/data
 
-isolation2_regress.o: submake-libpgport
+isolation2_regress.o: | submake-libpgport
 
 .PHONY: scan_flaky_fault_injectors
 scan_flaky_fault_injectors:
 	$(top_builddir)/src/test/regress/scan_flaky_fault_injectors.sh
 
-pg_isolation2_regress$(X): isolation2_main.o pg_regress.o submake-libpgport submake-libpq
+pg_isolation2_regress$(X): isolation2_main.o pg_regress.o | submake-libpgport submake-libpq
 	$(CC) $(CFLAGS) $(filter %.o,$^) $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@
 
 clean distclean:


### PR DESCRIPTION
Commit 44e96ec948f9caa7c8c667716a6d6c2d71e29716 added submake dependencies to
isolation2 Makefile. Unfortunately this caused isolation2_regress.so to be
rebuilt every time it was used, so on every installcheck. This caused
permission issues in diskquota CI. This patch switches to using order-only
dependencies in Makefile, as already done in many other Makefiles using
submake targets.