### PR TITLE
Add final summary to ggrebalance

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v19
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@feat/apt-source
     with:
       version: 7
       target_os: ${{ matrix.target_os }}

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@feat/apt-source
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v19
     with:
       version: 7
       target_os: ${{ matrix.target_os }}

--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -337,6 +337,10 @@ def main(options, args, parser):
         gpenv = GpCoordinatorEnvironment(
             options.coordinator_data_directory, True)
 
+        configurationInterface.registerConfigurationProvider(
+            configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog())
+        configurationInterface.getConfigurationProvider().initializeProvider(gpenv.getCoordinatorPort())
+
         dburl = dbconn.DbURL(dbname=DBNAME, port=gpenv.getCoordinatorPort())
 
         check_down_segments(logger, options, dburl)

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
@@ -20,6 +20,8 @@ except ImportError as e:
 
 class GGRebalanceMainSM:
 
+    summary_separator_str = '================================================================================'
+
     states_not_logged = [
         'STATE_OPTIONS_VALIDATION',
         'STATE_CLEANUP',
@@ -194,9 +196,9 @@ class GGRebalanceMainSM:
             self.logger.info('Skip final shrink summary report (specify "--simple-progress" or "--detailed-progress" to enable it).')
             return
 
-        self.logger.info('================================================================================')
+        self.logger.info(self.summary_separator_str)
         self.logger.info('                                   SHRINK                                   ')
-        self.logger.info('================================================================================')
+        self.logger.info(self.summary_separator_str)
         self.logger.info(f'Tables shrunk:\t\t{summary.tables_shrunk}')
         if self.rebalance_schema.getProgressType() == self.rebalance_schema.ProgressType.PROGRESS_DETAILED:
             self.logger.info(f'Bytes processed:\t{summary.bytes_processed}')
@@ -232,9 +234,9 @@ class GGRebalanceMainSM:
         if self.rebalance_schema.getProgressType() == self.rebalance_schema.ProgressType.PROGRESS_NO:
             self.logger.info('Skip final rebalance summary report (specify "--simple-progress" or "--detailed-progress" to enable it).')
         else:
-            self.logger.info('================================================================================')
+            self.logger.info(self.summary_separator_str)
             self.logger.info('                                   REBALANCE                                   ')
-            self.logger.info('================================================================================')
+            self.logger.info(self.summary_separator_str)
             self.logger.info(f'Segments moved:\t\t{segments_moved}')
             self.logger.info(f'Rolled back moves:\t\t{len(rolled_back_moves)}')
             self.logger.info(f'Cancelled moves:\t\t{len(cancelled_moves)}')
@@ -250,9 +252,9 @@ class GGRebalanceMainSM:
         # we show warnings regardless the progress type set by user
         show_warnings = len(segments_down) > 0 or len(cancelled_moves) > 0 or not balanced
         if show_warnings:
-            self.logger.warning('================================================================================')
+            self.logger.warning(self.summary_separator_str)
             self.logger.warning('                                   WARNINGS                                    ')
-            self.logger.warning('================================================================================')
+            self.logger.warning(self.summary_separator_str)
 
             if len(cancelled_moves) > 0:
                 self.logger.warning('------------------------------- Cancelled moves  -------------------------------')

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
@@ -7,18 +7,20 @@ try:
     from gppylib.commands.gp import *
     from gppylib.gplog import *
     from gppylib.system.environment import *
+    from gppylib.system import configurationInterface
     from ggrebalance_modules.planner import *
-    from ggrebalance_modules.rebalance_schema import RebalanceSchema
+    from ggrebalance_modules.rebalance_schema import RebalanceSchema, RebalanceSummaryInfo
     from gppylib.fault_injection import *
     from ggrebalance_modules.shrink import GGShrink
     from ggrebalance_modules.ggrebalance_sm import RebalanceSM
+    from ggrebalance_modules.rebalance_step import RebalanceStep
+    from ggrebalance_modules.rebalance_commons import is_gparray_balanced
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
 class GGRebalanceMainSM:
 
     states_not_logged = [
-        'STATE_START',
         'STATE_OPTIONS_VALIDATION',
         'STATE_CLEANUP',
         'STATE_ROLLBACK',
@@ -30,6 +32,7 @@ class GGRebalanceMainSM:
     ]
 
     states_logged = [
+        'STATE_START',
         'STATE_SETUP_SCHEMA_STARTED',
         'STATE_SETUP_SCHEMA_DONE',
         'STATE_EXECUTOR_STARTED',
@@ -149,7 +152,7 @@ class GGRebalanceMainSM:
         self.shrink_state_from_prev_run = self.rebalance_schema.getShrinkStateFromPreviousRun()
         self.is_shrink_rollback_in_progress = self.gg_shrink.state_is_from_rollback_flow(self.shrink_state_from_prev_run)
         self.prev_shrink_run_was_complete = self.gg_shrink.state_is_final(self.shrink_state_from_prev_run)
-
+        self.is_summary_output_required = False
 
     def on_every_state(self) -> None:
         if self.state in self.states_logged:
@@ -180,6 +183,104 @@ class GGRebalanceMainSM:
         if need_exit:
             sys.exit(1)
 
+    def is_shrink_planned(self) -> bool:
+        return isinstance(self.plan, ShrinkPlan)
+
+    def print_shrink_summary(self, summary: RebalanceSummaryInfo) -> None:
+        if not self.is_shrink_planned():
+            return
+
+        if self.rebalance_schema.getProgressType() == self.rebalance_schema.ProgressType.PROGRESS_NO:
+            self.logger.info('Skip final shrink summary report (specify "--simple-progress" or "--detailed-progress" to enable it).')
+            return
+
+        self.logger.info('================================================================================')
+        self.logger.info('                                   SHRINK                                   ')
+        self.logger.info('================================================================================')
+        self.logger.info(f'Tables shrunk:\t\t{summary.tables_shrunk}')
+        if self.rebalance_schema.getProgressType() == self.rebalance_schema.ProgressType.PROGRESS_DETAILED:
+            self.logger.info(f'Bytes processed:\t{summary.bytes_processed}')
+            self.logger.info(f'Shrink rate:\t\t{summary.shrink_rate}')
+        self.logger.info(f'Shrink total time:\t\t{summary.shrink_total_time}')
+        if summary.is_rollback:
+            self.logger.info('\n')
+            self.logger.info(f'Tables rolled back:\t\t{summary.tables_rolled_back}')
+            if self.rebalance_schema.getProgressType() == self.rebalance_schema.ProgressType.PROGRESS_DETAILED:
+                self.logger.info(f'Tables rollback rate:\t\t{summary.rollback_rate}')
+            self.logger.info(f'Rollback total time:\t\t{summary.rollback_total_time}')
+
+    def print_rebalance_summary(self, summary: RebalanceSummaryInfo) -> None:
+        if len(summary.executed_rebalance_steps) == 0:
+            return
+
+        segments_moved = 0
+        rolled_back_moves = []
+        cancelled_moves = []
+
+        for step in summary.executed_rebalance_steps:
+            status = step.getStatus()
+            if status == RebalanceStep.Status.CANCELLED:
+                cancelled_moves.append(step.getMove())
+            elif status == RebalanceStep.Status.DONE:
+                if step.isRollback():
+                    rolled_back_moves.append(step.getMove())
+                else:
+                    segments_moved += 1
+            else:
+                raise Exception(f'Unexpected status for executed step: {str(step)}')
+
+        if self.rebalance_schema.getProgressType() == self.rebalance_schema.ProgressType.PROGRESS_NO:
+            self.logger.info('Skip final rebalance summary report (specify "--simple-progress" or "--detailed-progress" to enable it).')
+        else:
+            self.logger.info('================================================================================')
+            self.logger.info('                                   REBALANCE                                   ')
+            self.logger.info('================================================================================')
+            self.logger.info(f'Segments moved:\t\t{segments_moved}')
+            self.logger.info(f'Rolled back moves:\t\t{len(rolled_back_moves)}')
+            self.logger.info(f'Cancelled moves:\t\t{len(cancelled_moves)}')
+
+        segments_down = []
+        gp_array = configurationInterface.getConfigurationProvider().loadSystemConfig(useUtilityMode=False, verbose=False)
+        for segment in gp_array.getSegDbList():
+            if segment.isSegmentDown():
+                segments_down.append(segment)
+
+        balanced = is_gparray_balanced(gp_array)
+
+        # we show warnings regardless the progress type set by user
+        show_warnings = len(segments_down) > 0 or len(cancelled_moves) > 0 or not balanced
+        if show_warnings:
+            self.logger.warning('================================================================================')
+            self.logger.warning('                                   WARNINGS                                    ')
+            self.logger.warning('================================================================================')
+
+            if len(cancelled_moves) > 0:
+                self.logger.warning('------------------------------- Cancelled moves  -------------------------------')
+                for move in cancelled_moves:
+                    self.logger.warning(str(move))
+
+            if len(segments_down) > 0:
+                self.logger.warning('Cluster might be not in fault tolerance mode!')
+                self.logger.warning('These segments should be started manually in order cluster to become fault tolerant:')
+                for segment in segments_down:
+                    self.logger.warning(str(segment))
+
+            if not balanced:
+                self.logger.warning('Cluster is left in unbalanced state')
+                if len(rolled_back_moves) > 0:
+                    self.logger.warning('------------------------------ Rolled back moves ---------------------------------')
+                    for move in rolled_back_moves:
+                        self.logger.warning(str(move))
+                    self.logger.warning('You can review why segments were rolled back and retry rebalance later.')
+
+    def print_full_summary(self) -> None:
+        if not self.is_summary_output_required:
+            return
+        summary = self.rebalance_schema.getProgressSummary()
+        self.logger.info('-----------------------------------SUMMARY--------------------------------------')
+        self.print_shrink_summary(summary)
+        self.print_rebalance_summary(summary)
+
     # state callbacks start here
 
     @wrap_func_with_faults
@@ -198,7 +299,7 @@ class GGRebalanceMainSM:
         else:
             self.plan = self.rebalance_schema.retrieveSavedPlan()
             perform_schema_cleanup = True
-            if isinstance(self.plan, ShrinkPlan):
+            if self.is_shrink_planned():
                 perform_schema_cleanup = self.gg_shrink.cleanup(self.prev_shrink_run_was_complete)
             if perform_schema_cleanup:
                 self.rebalance_schema.dropSchema()
@@ -211,14 +312,16 @@ class GGRebalanceMainSM:
     def on_enter_STATE_ROLLBACK(self) -> None:
         try:
             self.plan = self.rebalance_schema.retrieveSavedPlan()
-            if isinstance(self.plan, ShrinkPlan):
+            if self.is_shrink_planned():
                 if self.is_shrink_rollback_in_progress:
                     self.logger.info("Rollback is already in progress, and was interrupted. Execute 'ggrebalance' without '-r' flag.")
                     return
                 if not self.prev_shrink_run_was_complete:
                     self.gg_shrink.rollback(self.plan)
+                    self.is_summary_output_required = True
                     return
             self.gg_rebalance.rollback()
+            self.is_summary_output_required = True
         finally:
             self.trigger('move_to_STATE_END')
 
@@ -290,7 +393,8 @@ class GGRebalanceMainSM:
 
     @wrap_func_with_faults
     def on_enter_STATE_EXECUTOR_STARTED(self) -> None:
-        if isinstance(self.plan, ShrinkPlan):
+        self.is_summary_output_required = True
+        if self.is_shrink_planned():
             if not self.prev_shrink_run_was_complete:
                 self.trigger('move_to_STATE_SHRINK_STARTED')
                 return
@@ -324,7 +428,7 @@ class GGRebalanceMainSM:
 
     @wrap_func_with_faults
     def on_enter_STATE_END(self) -> None:
-        pass
+        self.print_full_summary()
 
     @wrap_func_with_faults
     def on_enter_STATE_ERROR(self) -> None:

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
@@ -201,7 +201,7 @@ class GGRebalanceMainSM:
         if self.rebalance_schema.getProgressType() == self.rebalance_schema.ProgressType.PROGRESS_DETAILED:
             self.logger.info(f'Bytes processed:\t{summary.bytes_processed}')
             self.logger.info(f'Shrink rate:\t\t{summary.shrink_rate}')
-        self.logger.info(f'Shrink total time:\t\t{summary.shrink_total_time}')
+        self.logger.info(f'Shrink total time:\t{summary.shrink_total_time}')
         if summary.is_rollback:
             self.logger.info('\n')
             self.logger.info(f'Tables rolled back:\t\t{summary.tables_rolled_back}')

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
@@ -317,11 +317,11 @@ class GGRebalanceMainSM:
                     self.logger.info("Rollback is already in progress, and was interrupted. Execute 'ggrebalance' without '-r' flag.")
                     return
                 if not self.prev_shrink_run_was_complete:
+                    self.is_summary_output_required = self.rebalance_schema.schemaExists()
                     self.gg_shrink.rollback(self.plan)
-                    self.is_summary_output_required = True
                     return
+            self.is_summary_output_required = self.rebalance_schema.schemaExists()
             self.gg_rebalance.rollback()
-            self.is_summary_output_required = True
         finally:
             self.trigger('move_to_STATE_END')
 

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_commons.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_commons.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import base64
+from collections import defaultdict
 from dataclasses import dataclass
 import ipaddress
 import os
@@ -743,6 +744,25 @@ class DiskSpaceChecker:
                 raise
         
         return results
+
+def is_gparray_balanced(gparray: GpArray) -> bool:
+    primaries_by_host = defaultdict(int)
+    mirrors_by_host = defaultdict(int)
+    for pair in gparray.getSegmentList():
+        if not pair.mirrorDB or not pair.balanced():
+            return False
+        primaries_by_host[pair.primaryDB.getSegmentHostName()] += 1
+        mirrors_by_host[pair.mirrorDB.getSegmentHostName()] += 1
+        if pair.mirrorDB.getSegmentHostName() == pair.primaryDB.getSegmentHostName():
+            return False
+    load = next(iter(primaries_by_host.values()))
+    for n in primaries_by_host.values():
+        if n != load:
+            return False
+    for n in mirrors_by_host.values():
+        if n != load:
+            return False
+    return True
 
 # Decorator to overwrite the logic of interactive_check_yesno()
 # during tests execution.

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -17,6 +17,20 @@ def get_table_distr_segment_count(conn: dbconn.Connection, schema_name: str, tab
                           WHERE n.nspname='{escape_string(schema_name)}' AND c.relname='{escape_string(table_name)}';''')
     return int(row[0])
 
+@dataclass
+class RebalanceSummaryInfo:
+    executed_rebalance_steps: List[RebalanceStep]
+
+    tables_shrunk: str = '0'
+    bytes_processed: str = '0'
+    shrink_rate: str = '0 MB/s'
+    shrink_total_time: str = '0s'
+
+    is_rollback: bool = False
+    tables_rolled_back: str = '0'
+    rollback_rate: str = '0 MB/s'
+    rollback_total_time: str = '0s'
+
 class RebalanceSchema:
     STATE_CATEGORY_SHRINK = 'SHRINK'
     STATE_CATEGORY_REBALANCE = 'REBALANCE'
@@ -33,10 +47,12 @@ class RebalanceSchema:
         self.rebalance_status = 'rebalance_status'
         self.table_rebalance_status_detail = 'table_rebalance_status_detail'
         self.rebalance_progress_view = 'rebalance_progress'
+        self.rebalance_progress_view_history = 'rebalance_progress_history'
         self.saved_plan = 'saved_plan'
         self.segment_move_steps = 'segment_move_steps'
         self.conn = conn
         self.progress_type = self.ProgressType.PROGRESS_NOT_DEFINED
+        self.progress_summary = None
 
     def createSchema(self, plan: Plan, progress_type: ProgressType, shrink_rollback_states: List[str]) -> None:
         dbconn.execSQL(self.conn, 'BEGIN')
@@ -54,7 +70,7 @@ class RebalanceSchema:
                        rebalance_finished TIMESTAMP WITH TIME ZONE,
                        source_bytes NUMERIC,
                        CONSTRAINT unique_fqn UNIQUE (db_name, schema_name, rel_name))
-                       DISTRIBUTED REPLICATED''')
+                       DISTRIBUTED BY (rel_name)''')
         dbconn.execSQL(self.conn,
                        f'''CREATE TABLE {self.schema_name}.{self.saved_plan}
                        (plan BYTEA)
@@ -270,6 +286,9 @@ SELECT * FROM rebalance_progress_rollback_flow WHERE (SELECT rollback_in_progres
         dbconn.execSQL(self.conn, 'COMMIT')
 
     def dropSchema(self) -> None:
+        # We call getProgressSummary() here in order to memoize the summary
+        # before we drop the schema, as we might need to show summary when the schema is already absent.
+        self.getProgressSummary()
         dbconn.execSQL(self.conn, f'DROP SCHEMA {self.schema_name} CASCADE')
 
     def getSchemaName(self) -> str:
@@ -425,6 +444,17 @@ SELECT * FROM rebalance_progress_rollback_flow WHERE (SELECT rollback_in_progres
 
         return result
 
+    def backupShrinkProgress(self, logger) -> None:
+        if self.getProgressType() != self.ProgressType.PROGRESS_NO:
+            shrink_total_time = self.getShrinkTotalTime()
+            dbconn.execSQL(self.conn,
+                           f'DROP TABLE IF EXISTS {self.schema_name}.{self.rebalance_progress_view_history}')
+            dbconn.execSQL(self.conn,
+                           f'CREATE TABLE {self.schema_name}.{self.rebalance_progress_view_history} AS SELECT * FROM {self.schema_name}.{self.rebalance_progress_view}')
+            # also add to progress history table the shrink total time to show it in the final summary
+            dbconn.execSQL(self.conn,
+                           f"INSERT INTO {self.schema_name}.{self.rebalance_progress_view_history} VALUES ('Shrink total time', '{shrink_total_time}')")
+
     def getProgressType(self) -> ProgressType:
         if self.progress_type != self.ProgressType.PROGRESS_NOT_DEFINED:
             return self.progress_type
@@ -440,3 +470,100 @@ SELECT * FROM rebalance_progress_rollback_flow WHERE (SELECT rollback_in_progres
             else:
                 self.progress_type = self.ProgressType.PROGRESS_DETAILED
         return self.progress_type
+
+    def getShrinkTotalTime(self, is_rollback: bool = False) -> str:
+        target_status = 'done' if not is_rollback else 'none'
+        if not is_rollback:
+            filter_condition = "cte.state != 'STATE_SHRINK_TABLES_STARTED'"
+        else:
+            filter_condition = "cte.state != 'STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START' AND cte.state LIKE 'STATE_SHRINK_ROLLBACK_%'"
+
+        return dbconn.querySingleton(self.conn, f"""
+WITH
+cte_tables_redistribution AS (
+    WITH events AS (
+        SELECT rebalance_started AS ts, 1 AS delta FROM {self.schema_name}.{self.table_rebalance_status_detail}
+        WHERE status = '{target_status}' and rebalance_finished IS NOT NULL
+        UNION ALL
+        SELECT rebalance_finished AS ts, -1 AS delta FROM {self.schema_name}.{self.table_rebalance_status_detail}
+        WHERE status = '{target_status}' and rebalance_finished IS NOT NULL
+    ),
+    ordered AS (
+        SELECT
+            ts,
+            sum(delta) OVER (ORDER BY ts) AS active,
+            LEAD(ts) OVER (ORDER BY ts) AS next_ts
+        FROM events
+    )
+    SELECT
+        sum(next_ts - ts) AS duration
+    FROM ordered
+    WHERE active > 0 AND next_ts IS NOT NULL
+),
+cte_other_states AS (
+    WITH
+    cte AS (
+        SELECT state, state_category, updated, updated - LAG(updated) OVER (ORDER BY updated) AS duration
+        FROM {self.schema_name}.{self.rebalance_status} ORDER BY updated
+    )
+    SELECT sum(cte.duration) as duration FROM cte WHERE cte.state_category = 'SHRINK' AND
+    {filter_condition}
+),
+cte_total AS (
+    SELECT date_trunc('second', cte_tables_redistribution.duration + cte_other_states.duration) AS duration from cte_tables_redistribution, cte_other_states
+)
+SELECT
+EXTRACT(DAY FROM cte_total.duration)::text || 'd ' ||
+EXTRACT(HOUR FROM cte_total.duration)::text || 'h' ||
+EXTRACT(MINUTE FROM cte_total.duration)::text || 'm' ||
+EXTRACT(SECOND FROM cte_total.duration)::text || 's'
+AS total_duration FROM cte_total""")
+
+    def getProgressSummary(self) -> RebalanceSummaryInfo:
+        if self.progress_summary != None:
+            return self.progress_summary
+
+        result = RebalanceSummaryInfo(self.getExecutionSteps([]))
+
+        if self.getProgressType() != self.ProgressType.PROGRESS_NO:
+            result.is_rollback = bool(dbconn.querySingleton(self.conn,
+                f"SELECT CASE WHEN to_regclass('{self.schema_name}.{self.rebalance_progress_view_history}') IS NULL THEN 0 ELSE 1 END AS view_backup_exists"))
+
+            cursor = dbconn.query(self.conn,
+                                f"SELECT stat_name, stat_value FROM {self.schema_name}.{self.rebalance_progress_view}")
+            if not result.is_rollback:
+                for stat_name, stat_value in cursor:
+                    match stat_name:
+                        case '1.1. Tables shrunk':
+                            result.tables_shrunk = stat_value
+                        case '2.1. Bytes processed':
+                            result.bytes_processed = stat_value
+                        case '3.1. Estimated shrink rate':
+                            result.shrink_rate = stat_value
+
+                result.shrink_total_time = self.getShrinkTotalTime()
+            else:
+                for stat_name, stat_value in cursor:
+                    match stat_name:
+                        case '1.1. Tables rolled back':
+                            result.tables_rolled_back = stat_value
+                        case '2.1. Bytes processed':
+                            result.bytes_processed = stat_value
+                        case '3.1. Estimated shrink rate':
+                            result.rollback_rate = stat_value
+
+                cursor = dbconn.query(self.conn,
+                                f"SELECT stat_name, stat_value FROM {self.schema_name}.{self.rebalance_progress_view_history}")
+                for stat_name, stat_value in cursor:
+                    match stat_name:
+                        case '1.1. Tables shrunk':
+                            result.tables_shrunk = stat_value
+                        case '3.1. Estimated shrink rate':
+                            result.shrink_rate = stat_value
+                        case 'Shrink total time':
+                            result.shrink_total_time = stat_value
+
+                result.rollback_total_time = self.getShrinkTotalTime(is_rollback = True)
+
+        self.progress_summary = result
+        return self.progress_summary

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -444,7 +444,7 @@ SELECT * FROM rebalance_progress_rollback_flow WHERE (SELECT rollback_in_progres
 
         return result
 
-    def backupShrinkProgress(self, logger) -> None:
+    def backupShrinkProgress(self) -> None:
         if self.getProgressType() != self.ProgressType.PROGRESS_NO:
             shrink_total_time = self.getShrinkTotalTime()
             dbconn.execSQL(self.conn,
@@ -496,7 +496,7 @@ cte_tables_redistribution AS (
         FROM events
     )
     SELECT
-        sum(next_ts - ts) AS duration
+        COALESCE(sum(next_ts - ts), INTERVAL '0') AS duration
     FROM ordered
     WHERE active > 0 AND next_ts IS NOT NULL
 ),

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -36,6 +36,20 @@ class RebalanceSchema:
     STATE_CATEGORY_REBALANCE = 'REBALANCE'
     STATE_CATEGORY_MAIN = 'MAIN'
 
+    # possible stat names for rebalance_progress_view
+    STAT_NAME_1_1_TABLES_SHRUNK = '1.1. Tables shrunk'
+    STAT_NAME_1_2_TABLES_SHRINK_IN_PROGRESS = '1.2. Tables shrink in progress'
+    STAT_NAME_1_3_TABLES_LEFT_TO_SHRINK = '1.3. Tables left to shrink'
+    STAT_NAME_1_1_TABLES_ROLLED_BACK = '1.1. Tables rolled back'
+    STAT_NAME_1_2_TABLES_ROLLBACK_IN_PROGRESS = '1.2. Tables rollback in progress'
+    STAT_NAME_1_3_TABLES_LEFT_TO_ROLLBACK = '1.3. Tables left to rollback'
+    STAT_NAME_2_1_BYTES_PROCESSED = '2.1. Bytes processed'
+    STAT_NAME_2_2_BYTES_LEFT_TO_PROCESS = '2.2. Bytes left to process'
+    STAT_NAME_2_3_BYTES_IN_PROGRESS = '2.3. Bytes in progress'
+    STAT_NAME_3_1_ESTIMATED_SHRINK_RATE = '3.1. Estimated shrink rate'
+    STAT_NAME_3_2_ESTIMATED_TIME = '3.2. Estimated time'
+    STAT_NAME_SHRINK_TOTAL_TIME = 'Shrink total time'
+
     class ProgressType(Enum):
         PROGRESS_NOT_DEFINED = 0
         PROGRESS_NO = 1
@@ -106,17 +120,17 @@ cond AS (SELECT {self.schema_name}._is_rollback() AS rollback_in_progress),
 rebalance_progress_normal_flow AS
     (
     SELECT
-        '1.1. Tables shrunk' AS stat_name,
+        '{self.STAT_NAME_1_1_TABLES_SHRUNK}' AS stat_name,
         count(1)::text AS stat_value
     FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NOT NULL AND rebalance_finished IS NOT NULL
     UNION
     SELECT
-        '1.3. Tables left to shrink' AS stat_name,
+        '{self.STAT_NAME_1_3_TABLES_LEFT_TO_SHRINK}' AS stat_name,
         count(1)::text AS stat_value
     FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none' AND rebalance_started IS NULL AND rebalance_finished IS NULL
     UNION
     SELECT
-        '1.2. Tables shrink in progress' AS stat_name,
+        '{self.STAT_NAME_1_2_TABLES_SHRINK_IN_PROGRESS}' AS stat_name,
         count(1)::text AS stat_value
     FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none' AND rebalance_started IS NOT NULL
     ORDER BY stat_name ASC
@@ -124,17 +138,17 @@ rebalance_progress_normal_flow AS
 rebalance_progress_rollback_flow AS
     (
     SELECT
-        '1.1. Tables rolled back' AS stat_name,
+        '{self.STAT_NAME_1_1_TABLES_ROLLED_BACK}' AS stat_name,
         count(1)::text AS stat_value
     FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none' AND rebalance_started IS NOT NULL AND rebalance_finished IS NOT NULL
     UNION
     SELECT
-        '1.2. Tables rollback in progress' AS stat_name,
+        '{self.STAT_NAME_1_2_TABLES_ROLLBACK_IN_PROGRESS}' AS stat_name,
         count(1)::text AS stat_value
     FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NOT NULL AND rebalance_finished IS NULL
     UNION
     SELECT
-        '1.3. Tables left to rollback' AS stat_name,
+        '{self.STAT_NAME_1_3_TABLES_LEFT_TO_ROLLBACK}' AS stat_name,
         count(1)::text AS stat_value
     FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NULL
     ORDER BY stat_name ASC
@@ -171,42 +185,42 @@ rebalance_progress_normal_flow AS
         FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none'
         )
     SELECT
-        '1.1. Tables shrunk' AS stat_name,
+        '{self.STAT_NAME_1_1_TABLES_SHRUNK}' AS stat_name,
         tables_processed::text AS stat_value
     FROM stat_processed
     UNION
     SELECT
-        '1.3. Tables left to shrink' AS stat_name,
+        '{self.STAT_NAME_1_3_TABLES_LEFT_TO_SHRINK}' AS stat_name,
         count(1)::text AS stat_value
     FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none' AND rebalance_started IS NULL AND rebalance_finished IS NULL
     UNION
     SELECT
-        '1.2. Tables shrink in progress' AS stat_name,
+        '{self.STAT_NAME_1_2_TABLES_SHRINK_IN_PROGRESS}' AS stat_name,
         tables_in_processing::text AS stat_value
     FROM stat_in_processing
     UNION
     SELECT
-        '2.1. Bytes processed' AS stat_name,
+        '{self.STAT_NAME_2_1_BYTES_PROCESSED}' AS stat_name,
         bytes_processed::text AS stat_value
     FROM stat_processed
     UNION
     SELECT
-        '2.2. Bytes left to process' AS stat_name,
+        '{self.STAT_NAME_2_2_BYTES_LEFT_TO_PROCESS}' AS stat_name,
         bytes_left_to_process::text AS stat_value
     FROM stat_left_to_process
     UNION
     SELECT
-        '2.3. Bytes in progress' AS stat_name,
+        '{self.STAT_NAME_2_3_BYTES_IN_PROGRESS}' AS stat_name,
         bytes_in_processing::text AS stat_value
     FROM stat_in_processing
     UNION
     SELECT
-        '3.1. Estimated shrink rate' AS stat_name,
+        '{self.STAT_NAME_3_1_ESTIMATED_SHRINK_RATE}' AS stat_name,
         (est_processing_rate / (1024*1024))::text || ' MB/s' AS stat_value
     FROM stat_processed
     UNION
     SELECT
-        '3.2. Estimated time' AS stat_name,
+        '{self.STAT_NAME_3_2_ESTIMATED_TIME}' AS stat_name,
         CASE
             WHEN p.est_processing_rate = 0 THEN 'not defined'
             ELSE (l.bytes_left_to_process / p.est_processing_rate)::text || ' s'
@@ -236,42 +250,42 @@ rebalance_progress_rollback_flow AS
         FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done'
         )
     SELECT
-        '1.1. Tables rolled back' AS stat_name,
+        '{self.STAT_NAME_1_1_TABLES_ROLLED_BACK}' AS stat_name,
         tables_processed::text AS stat_value
     FROM stat_processed
     UNION
     SELECT
-        '1.2. Tables rollback in progress' AS stat_name,
+        '{self.STAT_NAME_1_2_TABLES_ROLLBACK_IN_PROGRESS}' AS stat_name,
         count(1)::text AS stat_value
     FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NOT NULL AND rebalance_finished IS NULL
     UNION
     SELECT
-        '1.3. Tables left to rollback' AS stat_name,
+        '{self.STAT_NAME_1_3_TABLES_LEFT_TO_ROLLBACK}' AS stat_name,
         count(1)::text AS stat_value
     FROM {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = 'done' AND rebalance_started IS NULL
     UNION
     SELECT
-        '2.1. Bytes processed' AS stat_name,
+        '{self.STAT_NAME_2_1_BYTES_PROCESSED}' AS stat_name,
         bytes_processed::text AS stat_value
     FROM stat_processed
     UNION
     SELECT
-        '2.2. Bytes left to process' AS stat_name,
+        '{self.STAT_NAME_2_2_BYTES_LEFT_TO_PROCESS}' AS stat_name,
         bytes_left_to_process::text AS stat_value
     FROM stat_left_to_process
     UNION
     SELECT
-        '2.3. Bytes in progress' AS stat_name,
+        '{self.STAT_NAME_2_3_BYTES_IN_PROGRESS}' AS stat_name,
         bytes_in_processing::text AS stat_value
     FROM stat_in_processing
     UNION
     SELECT
-        '3.1. Estimated shrink rate' AS stat_name,
+        '{self.STAT_NAME_3_1_ESTIMATED_SHRINK_RATE}' AS stat_name,
         (est_processing_rate / (1024*1024))::text || ' MB/s' AS stat_value
     FROM stat_processed
     UNION
     SELECT
-        '3.2. Estimated time' AS stat_name,
+        '{self.STAT_NAME_3_2_ESTIMATED_TIME}' AS stat_name,
         CASE
             WHEN p.est_processing_rate = 0 THEN 'not defined'
             ELSE (l.bytes_left_to_process / p.est_processing_rate)::text || ' s'
@@ -453,7 +467,7 @@ SELECT * FROM rebalance_progress_rollback_flow WHERE (SELECT rollback_in_progres
                            f'CREATE TABLE {self.schema_name}.{self.rebalance_progress_view_history} AS SELECT * FROM {self.schema_name}.{self.rebalance_progress_view}')
             # also add to progress history table the shrink total time to show it in the final summary
             dbconn.execSQL(self.conn,
-                           f"INSERT INTO {self.schema_name}.{self.rebalance_progress_view_history} VALUES ('Shrink total time', '{shrink_total_time}')")
+                           f"INSERT INTO {self.schema_name}.{self.rebalance_progress_view_history} VALUES ('{self.STAT_NAME_SHRINK_TOTAL_TIME}', '{shrink_total_time}')")
 
     def getProgressType(self) -> ProgressType:
         if self.progress_type != self.ProgressType.PROGRESS_NOT_DEFINED:
@@ -478,7 +492,7 @@ SELECT * FROM rebalance_progress_rollback_flow WHERE (SELECT rollback_in_progres
         else:
             filter_condition = "cte.state != 'STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START' AND cte.state LIKE 'STATE_SHRINK_ROLLBACK_%'"
 
-        # In order to get total shrink (or shrink rollback time), we need to consider several items:
+        # In order to get total shrink (or shrink rollback) time, we need to consider several items:
         # 1. the execution can be interrupted, so we can't just take the 'updated' column of last state and subtract the first state from it.
         # So we calculate the duration for each shrink state separately by subtracting the time of the preceeding state,
         # and then summarize them (refer to cte_other_states.duration). But! Here is another consideration:
@@ -542,33 +556,33 @@ AS total_duration FROM cte_total""")
             if not result.is_rollback:
                 for stat_name, stat_value in cursor:
                     match stat_name:
-                        case '1.1. Tables shrunk':
+                        case self.STAT_NAME_1_1_TABLES_SHRUNK:
                             result.tables_shrunk = stat_value
-                        case '2.1. Bytes processed':
+                        case self.STAT_NAME_2_1_BYTES_PROCESSED:
                             result.bytes_processed = stat_value
-                        case '3.1. Estimated shrink rate':
+                        case self.STAT_NAME_3_1_ESTIMATED_SHRINK_RATE:
                             result.shrink_rate = stat_value
 
                 result.shrink_total_time = self.getShrinkTotalTime()
             else:
                 for stat_name, stat_value in cursor:
                     match stat_name:
-                        case '1.1. Tables rolled back':
+                        case self.STAT_NAME_1_1_TABLES_ROLLED_BACK:
                             result.tables_rolled_back = stat_value
-                        case '2.1. Bytes processed':
+                        case self.STAT_NAME_2_1_BYTES_PROCESSED:
                             result.bytes_processed = stat_value
-                        case '3.1. Estimated shrink rate':
+                        case self.STAT_NAME_3_1_ESTIMATED_SHRINK_RATE:
                             result.rollback_rate = stat_value
 
                 cursor = dbconn.query(self.conn,
                                 f"SELECT stat_name, stat_value FROM {self.schema_name}.{self.rebalance_progress_view_history}")
                 for stat_name, stat_value in cursor:
                     match stat_name:
-                        case '1.1. Tables shrunk':
+                        case self.STAT_NAME_1_1_TABLES_SHRUNK:
                             result.tables_shrunk = stat_value
-                        case '3.1. Estimated shrink rate':
+                        case self.STAT_NAME_3_1_ESTIMATED_SHRINK_RATE:
                             result.shrink_rate = stat_value
-                        case 'Shrink total time':
+                        case self.STAT_NAME_SHRINK_TOTAL_TIME:
                             result.shrink_total_time = stat_value
 
                 result.rollback_total_time = self.getShrinkTotalTime(is_rollback = True)

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -478,6 +478,14 @@ SELECT * FROM rebalance_progress_rollback_flow WHERE (SELECT rollback_in_progres
         else:
             filter_condition = "cte.state != 'STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START' AND cte.state LIKE 'STATE_SHRINK_ROLLBACK_%'"
 
+        # In order to get total shrink (or shrink rollback time), we need to consider several items:
+        # 1. the execution can be interrupted, so we can't just take the 'updated' column of last state and subtract the first state from it.
+        # So we calculate the duration for each shrink state separately by subtracting the time of the preceeding state,
+        # and then summarize them (refer to cte_other_states.duration). But! Here is another consideration:
+        # 2. We can't do it for the state where the tables redistribution is done - as on each re-enter of this state
+        # we process only the remaining amount of tables, and we will capture only the last re-enter duration.
+        # Therefore we process table redistribution time separately - we get it from actual table rebalance_started and rebalance_finished
+        # (taking into account their parallel execution). Refer to cte_tables_redistribution.duration.
         return dbconn.querySingleton(self.conn, f"""
 WITH
 cte_tables_redistribution AS (

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -488,6 +488,7 @@ class GGShrink:
 
     @wrap_func_with_faults
     def on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START(self) -> None:
+        self.rebalance_schema.backupShrinkProgress(self.logger)
         dbconn.execSQL(self.conn, 'BEGIN')
         dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
         dbconn.execSQL(self.conn, 'SELECT gp_toolkit.gp_reset_rebalance_numsegments()')

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -488,7 +488,7 @@ class GGShrink:
 
     @wrap_func_with_faults
     def on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START(self) -> None:
-        self.rebalance_schema.backupShrinkProgress(self.logger)
+        self.rebalance_schema.backupShrinkProgress()
         dbconn.execSQL(self.conn, 'BEGIN')
         dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
         dbconn.execSQL(self.conn, 'SELECT gp_toolkit.gp_reset_rebalance_numsegments()')

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -563,6 +563,18 @@ Feature: ggrebalance behave tests (misc options scenarios)
         When the user runs "ggrebalance -r -n 1 --non-interactive-mode"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rollback is complete" to logfile with latest timestamp
+         And ggrebalance should print "Skip final shrink summary report" to logfile with latest timestamp
+         And ggrebalance should not print "Tables shrunk:" to logfile with latest timestamp
+         And ggrebalance should not print "Bytes processed:" to logfile with latest timestamp
+         And ggrebalance should not print "Shrink rate:" to logfile with latest timestamp
+         And ggrebalance should not print "Shrink total time:" to logfile with latest timestamp
+         And ggrebalance should not print "Tables rolled back:" to logfile with latest timestamp
+         And ggrebalance should not print "Tables rollback rate:" to logfile with latest timestamp
+         And ggrebalance should not print "Rollback total time:" to logfile with latest timestamp
+         And ggrebalance should not print "Segments moved:" to logfile with latest timestamp
+         And ggrebalance should not print "Rolled back moves:" to logfile with latest timestamp
+         And ggrebalance should not print "Cancelled moves:" to logfile with latest timestamp
+         And ggrebalance should not print " WARNINGS " to logfile with latest timestamp
          And all files in gpAdminLogs directory are deleted
 
          # Checks for '--simple-progress'
@@ -733,6 +745,18 @@ Feature: ggrebalance behave tests (misc options scenarios)
         When the user runs "ggrebalance -n 1 --non-interactive-mode"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rollback is complete" to logfile with latest timestamp
+         And ggrebalance should print "Tables shrunk:\s*10" regex to logfile
+         And ggrebalance should not print "Bytes processed:" to logfile with latest timestamp
+         And ggrebalance should not print "Shrink rate:" to logfile with latest timestamp
+         And ggrebalance should print "Shrink total time:" to logfile with latest timestamp
+         And ggrebalance should print "Tables rolled back:\s*10" regex to logfile
+         And ggrebalance should not print "Tables rollback rate:" to logfile with latest timestamp
+         And ggrebalance should print "Rollback total time:" to logfile with latest timestamp
+         And ggrebalance should not print "Segments moved:" to logfile with latest timestamp
+         And ggrebalance should not print "Rolled back moves:" to logfile with latest timestamp
+         And ggrebalance should not print "Cancelled moves:" to logfile with latest timestamp
+         And ggrebalance should not print " WARNINGS " to logfile with latest timestamp
+         And all files in gpAdminLogs directory are deleted
 
          # Checks for '--detailed-progress'
          # Check progress report before any table is redistributed
@@ -1048,3 +1072,18 @@ Feature: ggrebalance behave tests (misc options scenarios)
           |  2.3. Bytes in progress           | 0           |
           |  3.1. Estimated shrink rate       | > 0 MB/s    |
           |  3.2. Estimated time              | 0 s         |
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rollback is complete" to logfile with latest timestamp
+         And ggrebalance should print "Tables shrunk:\s*10" regex to logfile
+         And ggrebalance should print "Bytes processed:\s*\d+" regex to logfile
+         And ggrebalance should print "Shrink rate:" to logfile with latest timestamp
+         And ggrebalance should print "Shrink total time:" to logfile with latest timestamp
+         And ggrebalance should print "Tables rolled back:\s*10" regex to logfile
+         And ggrebalance should print "Tables rollback rate:" to logfile with latest timestamp
+         And ggrebalance should print "Rollback total time:" to logfile with latest timestamp
+         And ggrebalance should not print "Segments moved:" to logfile with latest timestamp
+         And ggrebalance should not print "Rolled back moves:" to logfile with latest timestamp
+         And ggrebalance should not print "Cancelled moves:" to logfile with latest timestamp
+         And ggrebalance should not print " WARNINGS " to logfile with latest timestamp

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -91,9 +91,20 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance --non-interactive-mode -x 3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --simple-progress --non-interactive-mode -x 3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And ggrebalance should print "Tables shrunk:\s*4" regex to logfile
+         And ggrebalance should not print "Bytes processed:" to logfile with latest timestamp
+         And ggrebalance should not print "Shrink rate:" to logfile with latest timestamp
+         And ggrebalance should print "Shrink total time:" to logfile with latest timestamp
+         And ggrebalance should not print "Tables rolled back:" to logfile with latest timestamp
+         And ggrebalance should not print "Tables rollback rate:" to logfile with latest timestamp
+         And ggrebalance should not print "Rollback total time:" to logfile with latest timestamp
+         And ggrebalance should print "Segments moved:\s*\d+" regex to logfile
+         And ggrebalance should print "Rolled back moves:\s*0" regex to logfile
+         And ggrebalance should print "Cancelled moves:\s*0" regex to logfile
+         And ggrebalance should not print " WARNINGS " to logfile with latest timestamp
          And the cluster configuration has 1 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
          And the cluster configuration has 1 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
          And the cluster configuration has 1 segments where "hostname='sdw2' and content > -1 and role = 'p' and status = 'u'"
@@ -128,7 +139,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance --non-interactive-mode -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --simple-progress --non-interactive-mode -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
@@ -137,6 +148,17 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When the user runs "ggrebalance --non-interactive-mode"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And ggrebalance should not print "Tables shrunk:" to logfile with latest timestamp
+         And ggrebalance should not print "Bytes processed:" to logfile with latest timestamp
+         And ggrebalance should not print "Shrink rate:" to logfile with latest timestamp
+         And ggrebalance should not print "Shrink total time:" to logfile with latest timestamp
+         And ggrebalance should not print "Tables rolled back:" to logfile with latest timestamp
+         And ggrebalance should not print "Tables rollback rate:" to logfile with latest timestamp
+         And ggrebalance should not print "Rollback total time:" to logfile with latest timestamp
+         And ggrebalance should print "Segments moved:\s*\d+" regex to logfile
+         And ggrebalance should print "Rolled back moves:\s*0" regex to logfile
+         And ggrebalance should print "Cancelled moves:\s*0" regex to logfile
+         And ggrebalance should not print " WARNINGS " to logfile with latest timestamp
          And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
          And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
          And the cluster configuration has 3 segments where "hostname='sdw2' and content > -1 and role = 'p' and status = 'u'"
@@ -436,7 +458,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --simple-progress --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
@@ -453,6 +475,14 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should print "Port is updated: False" to logfile with latest timestamp
          And ggrebalance should print "Plan to rollback step" to logfile with latest timestamp
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And ggrebalance should print "Segments moved:\s*\d+" regex to logfile
+         And ggrebalance should print "Rolled back moves:\s*\d+" regex to logfile
+         And ggrebalance should print "Cancelled moves:\s*0" regex to logfile
+         And ggrebalance should print " WARNINGS " to logfile with latest timestamp
+         And ggrebalance should not print " Cancelled moves " to logfile with latest timestamp
+         And ggrebalance should not print "Cluster might be not in fault tolerance mode!" to logfile with latest timestamp
+         And ggrebalance should print "Cluster is left in unbalanced state" to logfile with latest timestamp
+         And ggrebalance should print " Rolled back moves " to logfile with latest timestamp
          And clear user's answers
          And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
          And the cluster configuration has 1 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
@@ -487,7 +517,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --simple-progress --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
@@ -504,6 +534,13 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should print "Port is updated: False" to logfile with latest timestamp
          And ggrebalance should print "Cancel step" to logfile with latest timestamp
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And ggrebalance should print "Segments moved:\s*\d+" regex to logfile
+         And ggrebalance should print "Rolled back moves:\s*0" regex to logfile
+         And ggrebalance should print "Cancelled moves:\s*\d+" regex to logfile
+         And ggrebalance should print " WARNINGS " to logfile with latest timestamp
+         And ggrebalance should print " Cancelled moves " to logfile with latest timestamp
+         And ggrebalance should print "Cluster might be not in fault tolerance mode!" to logfile with latest timestamp
+         And ggrebalance should print "These segments should be started manually in order cluster to become fault tolerant:" to logfile with latest timestamp
          And clear user's answers
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
@@ -588,7 +625,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --no-progress --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
@@ -603,6 +640,14 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should print "Processing error status for switchover step" to logfile with latest timestamp
          And ggrebalance should print "Plan to rollback step" to logfile with latest timestamp
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And ggrebalance should not print "Segments moved:" to logfile with latest timestamp
+         And ggrebalance should not print "Rolled back moves:" to logfile with latest timestamp
+         And ggrebalance should not print "Cancelled moves:" to logfile with latest timestamp
+         And ggrebalance should print " WARNINGS " to logfile with latest timestamp
+         And ggrebalance should not print " Cancelled moves " to logfile with latest timestamp
+         And ggrebalance should not print "Cluster might be not in fault tolerance mode!" to logfile with latest timestamp
+         And ggrebalance should print "Cluster is left in unbalanced state" to logfile with latest timestamp
+         And ggrebalance should print " Rolled back moves " to logfile with latest timestamp
          And clear user's answers
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
          And the cluster configuration has 4 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
@@ -687,7 +732,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --no-progress --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
@@ -702,6 +747,14 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should print "Processing error status for switchover step" to logfile with latest timestamp
          And ggrebalance should print "Cancel step" to logfile with latest timestamp
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And ggrebalance should not print "Segments moved:" to logfile with latest timestamp
+         And ggrebalance should not print "Rolled back moves:" to logfile with latest timestamp
+         And ggrebalance should not print "Cancelled moves:" to logfile with latest timestamp
+         And ggrebalance should print " WARNINGS " to logfile with latest timestamp
+         And ggrebalance should print " Cancelled moves " to logfile with latest timestamp
+         And ggrebalance should not print "Cluster might be not in fault tolerance mode!" to logfile with latest timestamp
+         And ggrebalance should print "Cluster is left in unbalanced state" to logfile with latest timestamp
+         And ggrebalance should not print " Rolled back moves " to logfile with latest timestamp
          And clear user's answers
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
          And the cluster configuration has 4 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
@@ -736,7 +789,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
-        When the user runs "ggrebalance --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --no-progress --non-interactive-mode -n 1 -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
@@ -753,6 +806,15 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should print "Port is updated: False" to logfile with latest timestamp
          And ggrebalance should print "Cancel step" to logfile with latest timestamp
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And ggrebalance should not print "Segments moved:" to logfile with latest timestamp
+         And ggrebalance should not print "Rolled back moves:" to logfile with latest timestamp
+         And ggrebalance should not print "Cancelled moves:" to logfile with latest timestamp
+         And ggrebalance should print " WARNINGS " to logfile with latest timestamp
+         And ggrebalance should print " Cancelled moves " to logfile with latest timestamp
+         And ggrebalance should print "Cluster might be not in fault tolerance mode!" to logfile with latest timestamp
+         And ggrebalance should print "These segments should be started manually in order cluster to become fault tolerant:" to logfile with latest timestamp
+         And ggrebalance should print "Cluster is left in unbalanced state" to logfile with latest timestamp
+         And ggrebalance should not print " Rolled back moves " to logfile with latest timestamp
          And clear user's answers
          # some mirrors are definitely down, so do not check them
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
@@ -1200,7 +1262,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
          And all files in gpAdminLogs directory are deleted
-         And set fault inject "on_enter_STATE_SHRINK_TABLES_STARTED_begin"
+         And set fault inject "on_enter_STATE_SHRINK_TABLES_DONE_begin"
          And the gp_segment_configuration have been saved
          And database "test_db_1" exists
          And schema "test_schema_1" exists in "test_db_1"
@@ -1216,7 +1278,6 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And unset fault inject
         When the user runs "ggrebalance --non-interactive-mode -r"
         Then ggrebalance should return a return code of 0
-         And ggrebalance should print "Rollback is complete" to logfile with latest timestamp
          And verify the gp_segment_configuration has been restored
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 6, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 6, row count = 100
@@ -1348,13 +1409,24 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance --non-interactive-mode -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --simple-progress --non-interactive-mode -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And all files in gpAdminLogs directory are deleted
         When the user runs "ggrebalance --non-interactive-mode -r"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance rollback is complete" to logfile with latest timestamp
+         And ggrebalance should not print "Tables shrunk:" to logfile with latest timestamp
+         And ggrebalance should not print "Bytes processed:" to logfile with latest timestamp
+         And ggrebalance should not print "Shrink rate:" to logfile with latest timestamp
+         And ggrebalance should not print "Shrink total time:" to logfile with latest timestamp
+         And ggrebalance should not print "Tables rolled back:" to logfile with latest timestamp
+         And ggrebalance should not print "Tables rollback rate:" to logfile with latest timestamp
+         And ggrebalance should not print "Rollback total time:" to logfile with latest timestamp
+         And ggrebalance should print "Segments moved:\s*0" regex to logfile
+         And ggrebalance should print "Rolled back moves:\s*\d+" regex to logfile
+         And ggrebalance should print "Cancelled moves:\s*0" regex to logfile
+         And ggrebalance should not print " WARNINGS " to logfile with latest timestamp
          And verify the gp_segment_configuration has been restored
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 6, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 6, row count = 100


### PR DESCRIPTION
Add final summary to ggrebalance

This patch adds final summary output to ggrebalance tool. Final summary consists
from shrink and rebalance statistics plus warnings section. Shrink and rebalance
statistics are not output in case '--no-progress' options is used. Warnings
sections is output always (if any warnings exist).

Some details about the change:
 - 'configurationInterface' is added back, as now it is used when checking for
warnings.
 - In order to show correct shrink statistics in case of shrink rollback,
we save 'rebalance_progress' view into the 'rebalance_progress_history' table.
And add the information about shrink duration into the table, as it will be
lost as well during rollback. We do it in 'backupShrinkProgress()'.
 - Distribution of rebalance internal 'table_rebalance_status_detail' is
changed from 'replicated' to hash-distributed. There are 2 reasons: A) On a 
real cluster the table can be pretty large, so no need to make it replicated.
B) There is some strange issue that hits with ~50% reproduction rate (and only
via psycopg; not reproduced in psql) when performing CTAS from a view over the
replicated table - the result table has wrong data (as if the source table was
empty). It is a separate issue, out of scope of this PR. So far it is not
reproduced with non-replicated table.

New tests are not added. Some old tests are modified instead:
 - rebalance_test 8.1.3 - check final summary with '--simple-progress' plus 
 warnings due to cancelled moves that caused segments down;
 - rebalance_test 8.1.2 - check final summary with '--simple-progress' plus 
 warnings due to rolled back moves that caused unbalanced cluster;
 - rebalance_test 8.2.2 - check final summary with '--no-progress' plus 
 warnings due to rolled back moves that caused unbalanced cluster;
 - rebalance_test 8.2.4 - check final summary with '--simple-progress' plus 
 warnings due to cancelled back moves that caused unbalanced cluster;
 - rebalance_test 8.3.1 - check final summary with '--simple-progress' plus 
 warnings due to cancelled back moves that caused unbalanced cluster
 and segments down;
 - rebalance_test 2 - check final summary with '--simple-progress' with 
 shrink and rebalance;
 - misc_options_test 21 - check final summary with '--simple-progress' 
 with shrink and shrink rollback;
 - rebalance_test 3 - check final summary with '--simple-progress' with 
 no shrink and rebalance;
 - rebalance_test 10 - check final summary with '--simple-progress' with 
 no shrink and rebalance and full rebalance rollback;
 - misc_options_test 21 - check final summary with '--no-progress' with 
 shrink and shrink rollback;
 - misc_options_test 21 - check final summary with '--detailed-progress' 
 with shrink and shrink rollback;