### PR TITLE
Support interruption of table redistribution by the SIGINT

### DIFF
--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -622,6 +622,18 @@ class GGShrink:
                 fun(self, attempt)
             return func_with_faults
 
+        # decorator to help with interruption of potentially long queries
+        def long_object_method(func):
+            def long_func(*args, **kwargs):
+                try:
+                    self = args[0]
+                    self.long_operation_in_progress = True
+                    self.check_cancel()
+                    return func(*args, **kwargs)
+                finally:
+                    self.long_operation_in_progress = False
+            return long_func
+
         def table_exists(self, conn: dbconn.Connection) -> bool:
             if dbconn.querySingleton(conn, f"""
                 SELECT count(1)
@@ -641,10 +653,16 @@ class GGShrink:
                 return False
             return True
 
+        @long_object_method
         def rebalance_table(self, conn: dbconn.Connection) -> None:
             dbconn.execSQL(conn,
                            f'''ALTER TABLE {escapeDoubleQuoteInSQLString(self.schema_name, True)}.{escapeDoubleQuoteInSQLString(self.rel_name, True)}
                            REBALANCE {self.target_segment_count}''')
+
+        @long_object_method
+        def analyze_table(self, conn: dbconn.Connection) -> None:
+            dbconn.execSQL(conn,
+                           f'''ANALYZE {escapeDoubleQuoteInSQLString(self.schema_name, True)}.{escapeDoubleQuoteInSQLString(self.rel_name, True)}''')
 
         def check_cancel(self):
             if self.cancel_flag:
@@ -653,7 +671,7 @@ class GGShrink:
         @wrap_table_rebalance_with_faults
         def process_table(self, attempt: int) -> None:
             self.shrink.logger.info(f'Start table rebalance for "{self.db_name}"."{self.schema_name}"."{self.rel_name}" to {self.target_segment_count} segments (attempt {attempt})')
-            # check for cancel_flag at the beginning and before each long operation
+            # check for cancel_flag at the beginning and before each long operation (refer to long_object_method decorator)
             self.check_cancel()
             self.shrink.rebalance_schema.setTableRebalanceStartTime(self.db_name, self.schema_name, self.rel_name)
             if self.db_exists(self.shrink.rebalance_schema.conn):
@@ -665,18 +683,11 @@ class GGShrink:
 
                     if self.table_exists(conn):
                         if not self.table_is_rebalanced(conn):
-                            self.long_operation_in_progress = True
-                            self.check_cancel()
                             self.rebalance_table(conn)
-                            self.long_operation_in_progress = False
                         else:
                             self.shrink.logger.info(f'''Table "{self.db_name}"."{self.schema_name}"."{self.rel_name}" is already rebalanced''')
                         if self.shrink.options.analyze:
-                            self.long_operation_in_progress = True
-                            self.check_cancel()
-                            dbconn.execSQL(conn,
-                                           f'''ANALYZE {escapeDoubleQuoteInSQLString(self.schema_name, True)}.{escapeDoubleQuoteInSQLString(self.rel_name, True)}''')
-                            self.long_operation_in_progress = False
+                            self.analyze_table(conn)
                     else:
                         self.shrink.logger.info(f'''Table "{self.db_name}"."{self.schema_name}"."{self.rel_name}" doesn't exist, skipping actual rebalance''')
 
@@ -709,8 +720,6 @@ class GGShrink:
                             self.shrink.tables_rebalance_failed = True
                             self.shrink.workers_for_tables_rebalance.haltWork()
                     continue
-                finally:
-                    self.long_operation_in_progress = False
                 break
 
         def cancel(self):

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -612,6 +612,7 @@ class GGShrink:
             self.rel_name = rel_name
             self.target_segment_count = target_segment_count
             self.table_status_after_rebalance = table_status_after_rebalance
+            self.long_operation_in_progress = False
             SQLCommand.__init__(self, f'task rebalance for {self.db_name}.{self.schema_name}.{self.rel_name}')
 
         # decorator to inject a fault before running TableRebalanceTask for a specific {db_name, schema_name, rel_name}
@@ -652,6 +653,8 @@ class GGShrink:
         @wrap_table_rebalance_with_faults
         def process_table(self, attempt: int) -> None:
             self.shrink.logger.info(f'Start table rebalance for "{self.db_name}"."{self.schema_name}"."{self.rel_name}" to {self.target_segment_count} segments (attempt {attempt})')
+            # check for cancel_flag at the beginning and before each long operation
+            self.check_cancel()
             self.shrink.rebalance_schema.setTableRebalanceStartTime(self.db_name, self.schema_name, self.rel_name)
             if self.db_exists(self.shrink.rebalance_schema.conn):
                 dburl = dbconn.DbURL(dbname=self.db_name, port=self.shrink.gpEnv.getCoordinatorPort())
@@ -662,14 +665,18 @@ class GGShrink:
 
                     if self.table_exists(conn):
                         if not self.table_is_rebalanced(conn):
+                            self.long_operation_in_progress = True
                             self.check_cancel()
                             self.rebalance_table(conn)
+                            self.long_operation_in_progress = False
                         else:
                             self.shrink.logger.info(f'''Table "{self.db_name}"."{self.schema_name}"."{self.rel_name}" is already rebalanced''')
                         if self.shrink.options.analyze:
+                            self.long_operation_in_progress = True
                             self.check_cancel()
                             dbconn.execSQL(conn,
                                            f'''ANALYZE {escapeDoubleQuoteInSQLString(self.schema_name, True)}.{escapeDoubleQuoteInSQLString(self.rel_name, True)}''')
+                            self.long_operation_in_progress = False
                     else:
                         self.shrink.logger.info(f'''Table "{self.db_name}"."{self.schema_name}"."{self.rel_name}" doesn't exist, skipping actual rebalance''')
 
@@ -677,7 +684,6 @@ class GGShrink:
 
                     inject_fault(f'before_set_status_{self.db_name}.{self.schema_name}.{self.rel_name}')
                     self.shrink.rebalance_schema.setStatusForTableToRebalance(self.db_name, self.schema_name, self.rel_name, self.table_status_after_rebalance)
-                    self.cancel_conn = None
             else:
                 self.shrink.logger.info(f'''DB "{self.db_name}" doesn't exist, skipping actual rebalance for "{self.schema_name}"."{self.rel_name}"''')
             self.shrink.logger.info(f'Complete table rebalance for "{self.db_name}"."{self.schema_name}"."{self.rel_name}"')
@@ -695,15 +701,38 @@ class GGShrink:
                     self.process_table(attempt)
                 except Exception as e:
                     if attempt < attempt_max_cnt:
-                        logger.warning(f"{str(e)}")
+                        self.shrink.logger.warning(f"{str(e)}")
                     else:
-                        logger.error(f"{str(e)}")
-                        logger.error(f'Failed to process the db object "{self.db_name}"."{self.schema_name}"."{self.rel_name}" for {attempt_max_cnt} attempts')
+                        self.shrink.logger.error(f"{str(e)}")
+                        self.shrink.logger.error(f'Failed to process the db object "{self.db_name}"."{self.schema_name}"."{self.rel_name}" for {attempt_max_cnt} attempts')
                         if not self.cancel_flag:
                             self.shrink.tables_rebalance_failed = True
                             self.shrink.workers_for_tables_rebalance.haltWork()
                     continue
+                finally:
+                    self.long_operation_in_progress = False
                 break
+
+        def cancel(self):
+            super().cancel()
+            # there is a very small (but not 0) chance that 'SQLCommand.cancel()' is issued in
+            # a tiny time window when we've already checked the flag, but the query hasn't
+            # started to execute, so connection.cancel() will fire out without any effect.
+            # To handle it, we add the logic below to re-try 'cancel_conn.cancel()' till
+            # the flag 'self.long_operation_in_progress' is reset.
+            try:
+                cnt = 0
+                while (self.cancel_conn and
+                    not self.cancel_conn.closed and
+                    self.long_operation_in_progress):
+                    self.cancel_conn.cancel()
+                    time.sleep(0.01)
+                    cnt += 1
+                    if (cnt > 1000):
+                        self.shrink.logger.info('TableRebalanceTask cancel timed out')
+                        break
+            finally:
+                pass
 
     def prepare_shrink_schema(self, is_rollback: bool) -> None:
         status = 'done' if is_rollback else 'none'

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -645,6 +645,10 @@ class GGShrink:
                            f'''ALTER TABLE {escapeDoubleQuoteInSQLString(self.schema_name, True)}.{escapeDoubleQuoteInSQLString(self.rel_name, True)}
                            REBALANCE {self.target_segment_count}''')
 
+        def check_cancel(self):
+            if self.cancel_flag:
+                raise Exception(f'Cancelled table rebalance for "{self.db_name}"."{self.schema_name}"."{self.rel_name}"')
+
         @wrap_table_rebalance_with_faults
         def process_table(self, attempt: int) -> None:
             self.shrink.logger.info(f'Start table rebalance for "{self.db_name}"."{self.schema_name}"."{self.rel_name}" to {self.target_segment_count} segments (attempt {attempt})')
@@ -652,14 +656,18 @@ class GGShrink:
             if self.db_exists(self.shrink.rebalance_schema.conn):
                 dburl = dbconn.DbURL(dbname=self.db_name, port=self.shrink.gpEnv.getCoordinatorPort())
                 with closing(dbconn.connect(dburl, encoding='UTF8')) as conn:
+                    self.cancel_conn = conn
+
                     dbconn.execSQL(conn, 'BEGIN')
 
                     if self.table_exists(conn):
                         if not self.table_is_rebalanced(conn):
+                            self.check_cancel()
                             self.rebalance_table(conn)
                         else:
                             self.shrink.logger.info(f'''Table "{self.db_name}"."{self.schema_name}"."{self.rel_name}" is already rebalanced''')
                         if self.shrink.options.analyze:
+                            self.check_cancel()
                             dbconn.execSQL(conn,
                                            f'''ANALYZE {escapeDoubleQuoteInSQLString(self.schema_name, True)}.{escapeDoubleQuoteInSQLString(self.rel_name, True)}''')
                     else:
@@ -669,6 +677,7 @@ class GGShrink:
 
                     inject_fault(f'before_set_status_{self.db_name}.{self.schema_name}.{self.rel_name}')
                     self.shrink.rebalance_schema.setStatusForTableToRebalance(self.db_name, self.schema_name, self.rel_name, self.table_status_after_rebalance)
+                    self.cancel_conn = None
             else:
                 self.shrink.logger.info(f'''DB "{self.db_name}" doesn't exist, skipping actual rebalance for "{self.schema_name}"."{self.rel_name}"''')
             self.shrink.logger.info(f'Complete table rebalance for "{self.db_name}"."{self.schema_name}"."{self.rel_name}"')
@@ -690,8 +699,9 @@ class GGShrink:
                     else:
                         logger.error(f"{str(e)}")
                         logger.error(f'Failed to process the db object "{self.db_name}"."{self.schema_name}"."{self.rel_name}" for {attempt_max_cnt} attempts')
-                        self.shrink.tables_rebalance_failed = True
-                        self.shrink.workers_for_tables_rebalance.haltWork()
+                        if not self.cancel_flag:
+                            self.shrink.tables_rebalance_failed = True
+                            self.shrink.workers_for_tables_rebalance.haltWork()
                     continue
                 break
 

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
@@ -120,16 +120,22 @@ Feature: ggrebalance behave tests
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
          And all files in gpAdminLogs directory are deleted
-         And set fault inject "on_enter_STATE_REBALANCE_DONE_begin"
          And database "test_db_1" exists
          And schema "test_schema_1" exists in "test_db_1"
-         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "10000000" rows
          And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
          And database "test_db_2" exists
          And schema "test_schema_2" exists in "test_db_2"
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
-        When the user runs "ggrebalance -x 4 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user asynchronously runs "ggrebalance -x 4 -n 1 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'" and the process is saved
+        Then the user asynchronously sets up to end ggrebalance process when "Start table rebalance for \"test_db_1\".\"test_schema_1\".\"test_table_1\" to 4 segments" is printed in the ggrebalance logs
+         And the async process finished with a return code of 1
+         And ggrebalance should print "Failed to process the db object "test_db_1"."test_schema_1"."test_table_1" for 2 attempts" to logfile with latest timestamp
+         And ggrebalance should print "Shrink was interrupted" to logfile with latest timestamp
+         And set fault inject "on_enter_STATE_REBALANCE_DONE_begin"
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance --non-interactive-mode"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
@@ -140,7 +146,7 @@ Feature: ggrebalance behave tests
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
          And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'p' and status = 'u'"
          And the cluster configuration has 0 segments where "hostname='sdw3' and content > -1 and role = 'p' and status = 'u'"
-         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 4, row count = 10000000
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 4, row count = 100
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 4, row count = 100
          And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 4, row count = 100

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
@@ -122,17 +122,21 @@ Feature: ggrebalance behave tests
          And all files in gpAdminLogs directory are deleted
          And database "test_db_1" exists
          And schema "test_schema_1" exists in "test_db_1"
-         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "10000000" rows
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
          And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
          And database "test_db_2" exists
          And schema "test_schema_2" exists in "test_db_2"
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And the user connects to "test_db_1" with named connection "test_connection"
+         And the user executes "BEGIN; LOCK TABLE test_schema_1.test_table_1 IN ACCESS EXCLUSIVE MODE;" with named connection "test_connection"
         When the user asynchronously runs "ggrebalance -x 4 -n 1 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'" and the process is saved
         Then the user asynchronously sets up to end ggrebalance process when "Start table rebalance for \"test_db_1\".\"test_schema_1\".\"test_table_1\" to 4 segments" is printed in the ggrebalance logs
          And the async process finished with a return code of 1
          And ggrebalance should print "Failed to process the db object "test_db_1"."test_schema_1"."test_table_1" for 2 attempts" to logfile with latest timestamp
          And ggrebalance should print "Shrink was interrupted" to logfile with latest timestamp
+         And the user executes "ROLLBACK;" with named connection "test_connection"
+         And the user drops the named connection "test_connection"
          And set fault inject "on_enter_STATE_REBALANCE_DONE_begin"
          And all files in gpAdminLogs directory are deleted
         When the user runs "ggrebalance --non-interactive-mode"
@@ -146,7 +150,7 @@ Feature: ggrebalance behave tests
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
          And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'p' and status = 'u'"
          And the cluster configuration has 0 segments where "hostname='sdw3' and content > -1 and role = 'p' and status = 'u'"
-         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 4, row count = 10000000
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 4, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 4, row count = 100
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 4, row count = 100
          And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 4, row count = 100


### PR DESCRIPTION
Support interruption of table redistribution by the SIGINT

Problem description:
Workers that execute table redistribution ('ALTER TABLE ... REBALANCE') were
not interrupted by the SIGINT. If during the shrink of a large table, SIGINT was
issued, ggrebalance waited till the table processing had been complete, and only
after the completion it terminated the execution.
It also affected the interruption by the '--end' and '--duration' flags.

Root cause:
Worker for the table redistribution (TableRebalanceTask) is inherited from the
SQLCommand class. Child classes of SQLCommand should set 'self.cancel_conn' to
the psycopg connection they wish to cancel and check 'self.cancel_flag' in
order to properly handle cancellation of the worker's current operation. It was
not done.

Fix:
Set 'self.cancel_conn' to the connection used for table redistribution. It will
invoke 'cancel()' method on the psycopg connection (refer to
'SQLCommand.cancel()' for details). But the 'cancel()' works only if there is
an active query being executed, otherwise is does nothing. So, we also check
the 'self.cancel_flag' flag in the beginning and before every potentially long
operation (which is 'ALTER TABLE ... REBALANCE' and 'ANALYZE'), and bail out if
it is set. For other queries, we allow them to finish without interruption,
as they should not take much time.

Note: there is a very small chance that 'SQLCommand.cancel()' is issued in
a tiny time window when we've already checked the flag, but the query hasn't
started to execute, so connection.cancel() will fire out without any effect.
To handle it, TableRebalanceTask defines its own 'cancel()' method
implementation, which calls the superclass's method() and then retries to
cancel the query till the flag 'long_operation_in_progress' (which signals that
a long query may still be running) is on.

Plus, this patch fixes logger instance usage in TableRebalanceTask.