### PR TITLE
Quit ggrebalance if '--show-plan' is used

### DIFF
--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
@@ -113,7 +113,7 @@ class GGRebalanceMainSM:
         },
         {
             'trigger': 'move_to_STATE_END',
-            'source': ['STATE_EXECUTOR_DONE', 'STATE_CHECK_PREVIOUS_RUN', 'STATE_CLEANUP', 'STATE_ROLLBACK'],
+            'source': ['STATE_EXECUTOR_DONE', 'STATE_CHECK_PREVIOUS_RUN', 'STATE_CLEANUP', 'STATE_ROLLBACK', 'STATE_PLANNING_STARTED'],
             'dest': 'STATE_END'
         },
         {
@@ -226,9 +226,11 @@ class GGRebalanceMainSM:
     def on_enter_STATE_PLANNING_STARTED(self) -> None:
         if self.options.target_segment_count != None:
             self.plan = Planner(self.logger, self.dburl, self.gparray, self.options).plan()
-
-        if self.options.target_segment_count != None and self.options.show_plan:
             self.logger.info(f"Final plan:\n{self.plan}")
+
+            if self.options.show_plan:
+                self.trigger('move_to_STATE_END')
+                return
 
         self.trigger('move_to_STATE_PLANNING_DONE')
 

--- a/gpMgmt/doc/ggrebalance_help
+++ b/gpMgmt/doc/ggrebalance_help
@@ -123,7 +123,8 @@ OPTIONS
  Set the type of mirroring to be used after rebalance is complete.
 
 -p, --show-plan
- Show the segment movement plan.
+ Only show the segment movement plan and halt the tool's work without changing
+ the cluster.
 
 -c, --clean
  Delete the ggrebalance schema and all previously created ggrebalance

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -197,7 +197,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 3, row count = 100
          And the temporary file "/tmp/ggrebalance_add_hosts" is removed
 
-    Scenario: test 9. Check rebalance with '--remove-hosts-file'.
+    Scenario: test 9. Check rebalance with '--remove-hosts-file' (plus check '--show-plan').
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3", with 2 segments on each
@@ -211,6 +211,14 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And there is a file "/tmp/ggrebalance_remove_hosts" with hosts "sdw3"
+        When the user runs "ggrebalance --show-plan --non-interactive-mode -x 4 --remove-hosts-file /tmp/ggrebalance_remove_hosts -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+         Then ggrebalance should return a return code of 0
+         And ggrebalance should not print "Rebalance is complete" to logfile with latest timestamp
+         And ggrebalance should not print "Shrink is complete" to logfile with latest timestamp
+         And ggrebalance should print "SHRINK PLAN" to logfile with latest timestamp
+         And ggrebalance should print "-SEGMENTS TO REMOVE-" to logfile with latest timestamp
+         And ggrebalance should print "-BALANCE MOVES-" to logfile with latest timestamp
+         And all files in gpAdminLogs directory are deleted
         When the user runs "ggrebalance --non-interactive-mode -x 4 --remove-hosts-file /tmp/ggrebalance_remove_hosts -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp


### PR DESCRIPTION
Quit ggrebalance if '--show-plan' is used

Problem description:
ggrebalance didn't quit if '--show-plan' option was specified. According to the
current requirements, expected behaviour is following: show plan always, and
don't perform any other actions (shrink/rebalance) if '--show-plan' is used.

This patch aligns the tool behaviour with the requirements.