### PR TITLE
Check for running ggrebalance in the gpexpand

### DIFF
--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -10,7 +10,7 @@ try:
     from gppylib.userinput import *
     from gppylib.system.environment import GpCoordinatorEnvironment
     from gppylib.system import configurationInterface, configurationImplGpdb
-    from ggrebalance_modules.shrink import GGShrink, DBNAME
+    from ggrebalance_modules.rebalance_schema import DBNAME
     from ggrebalance_modules.ggrebalance_main_sm import GGRebalanceMainSM
     from ggrebalance_modules.planner import *
     from gppylib.programs.clsRecoverSegment_triples import get_segments_with_running_basebackup

--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -2,10 +2,13 @@
 
 from psycopg2.extensions import cursor
 from gppylib.db import dbconn
+from gppylib.system.environment import GpCoordinatorEnvironment
 from gppylib.utils import escape_string
 from typing import List
 from ggrebalance_modules.planner import Plan, deserializePlan
 from ggrebalance_modules.rebalance_step import *
+
+DBNAME = 'postgres'
 
 STATE_NOT_DEFINED = 'not defined'
 
@@ -22,6 +25,13 @@ class RebalanceSchema:
     STATE_CATEGORY_REBALANCE = 'REBALANCE'
     STATE_CATEGORY_MAIN = 'MAIN'
 
+    schema_name = 'ggrebalance'
+    rebalance_status = 'rebalance_status'
+    table_rebalance_status_detail = 'table_rebalance_status_detail'
+    rebalance_progress_view = 'rebalance_progress'
+    saved_plan = 'saved_plan'
+    segment_move_steps = 'segment_move_steps'
+
     class ProgressType(Enum):
         PROGRESS_NOT_DEFINED = 0
         PROGRESS_NO = 1
@@ -29,12 +39,6 @@ class RebalanceSchema:
         PROGRESS_DETAILED = 3
 
     def __init__(self, conn: dbconn.Connection):
-        self.schema_name = 'ggrebalance'
-        self.rebalance_status = 'rebalance_status'
-        self.table_rebalance_status_detail = 'table_rebalance_status_detail'
-        self.rebalance_progress_view = 'rebalance_progress'
-        self.saved_plan = 'saved_plan'
-        self.segment_move_steps = 'segment_move_steps'
         self.conn = conn
         self.progress_type = self.ProgressType.PROGRESS_NOT_DEFINED
 
@@ -440,3 +444,21 @@ SELECT * FROM rebalance_progress_rollback_flow WHERE (SELECT rollback_in_progres
             else:
                 self.progress_type = self.ProgressType.PROGRESS_DETAILED
         return self.progress_type
+
+    @classmethod
+    def checkOperationInProgress(cls, gpEnv: GpCoordinatorEnvironment) -> bool:
+        """Checks if there is ggrebalance operation in progress (possibly interrupted)"""
+        dburl = dbconn.DbURL(dbname=DBNAME, port=gpEnv.getCoordinatorPort())
+        with closing(dbconn.connect(dburl, encoding='UTF8')) as conn:
+            # if there is no schema existing, we are not performing shrink or rebalance
+            if 0 == (dbconn.querySingleton(conn, f"SELECT COUNT(1) FROM pg_namespace WHERE nspname = '{cls.schema_name}'")):
+                return False
+            # if there is schema existing, check the last state - if it is final one - then we've complete all operations
+            latest_main_state = ''
+            cursor = dbconn.query(conn, f"SELECT state FROM {cls.schema_name}.{cls.rebalance_status} WHERE state_category = '{cls.STATE_CATEGORY_MAIN}' ORDER BY updated DESC LIMIT 1")
+            if cursor.rowcount > 0:
+                latest_main_state = str(cursor.fetchone()[0])
+            if latest_main_state == 'STATE_EXECUTOR_DONE':
+                return False
+
+        return True

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -22,9 +22,6 @@ try:
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
-
-DBNAME = 'postgres'
-
 class GGShrink:
     timeout = SEGMENT_STOP_TIMEOUT_DEFAULT
 

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -246,7 +246,7 @@ def remove_pid_file(coordinator_data_directory):
 def check_pid_file(coordinator_data_directory, pid_filename):
     is_running = False
     try:
-        fp = open(coordinator_data_directory + f'/{pid_filename}', 'r')
+        fp = open(os.path.join(coordinator_data_directory, pid_filename), 'r')
         pid = int(fp.readline().strip())
         fp.close()
         is_running = check_pid(pid)

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -42,6 +42,7 @@ try:
     from gppylib.commands.pg import PgBaseBackup
     from gppylib.mainUtils import ExceptionNoStackTraceNeeded
     from gppylib.operations.update_pg_hba_on_segments import update_pg_hba_on_segments
+    from ggrebalance_modules.rebalance_schema import RebalanceSchema
 
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greengage_path.sh.  Detail: ' + str(e))
@@ -242,11 +243,10 @@ def remove_pid_file(coordinator_data_directory):
         pass
 
 
-def is_gpexpand_running(coordinator_data_directory):
-    """Checks if there is another instance of gpexpand running"""
+def check_pid_file(coordinator_data_directory, pid_filename):
     is_running = False
     try:
-        fp = open(coordinator_data_directory + '/gpexpand.pid', 'r')
+        fp = open(coordinator_data_directory + f'/{pid_filename}', 'r')
         pid = int(fp.readline().strip())
         fp.close()
         is_running = check_pid(pid)
@@ -256,6 +256,19 @@ def is_gpexpand_running(coordinator_data_directory):
         raise
 
     return is_running
+
+
+def is_gpexpand_running(coordinator_data_directory):
+    """Checks if there is another instance of gpexpand running"""
+    return check_pid_file(coordinator_data_directory, 'gpexpand.pid')
+
+
+def is_ggrebalance_running(gpEnv, coordinator_data_directory):
+    """Checks if there is an instance of ggrebalance running"""
+    if check_pid_file(coordinator_data_directory, 'ggrebalance.pid'):
+        return True
+    """Checks if ggrebalance was interrupted and didn't finish its work"""
+    return RebalanceSchema.checkOperationInProgress(gpEnv)
 
 
 def gpexpand_status_file_exists(coordinator_data_directory):
@@ -2524,16 +2537,21 @@ def main(options, args, parser):
         if options.verbose:
             enable_verbose_logging()
 
+        gpEnv = GpCoordinatorEnvironment(options.coordinator_data_directory, True)
+
         if is_gpexpand_running(options.coordinator_data_directory):
             logger.error('gpexpand is already running.  Only one instance')
             logger.error('of gpexpand is allowed at a time.')
+            remove_pid = False
+            sys.exit(1)
+        elif is_ggrebalance_running(gpEnv, options.coordinator_data_directory):
+            logger.error("ggrebalance is already running. gpexpand is not allowed to run in parallel.")
             remove_pid = False
             sys.exit(1)
         else:
             create_pid_file(options.coordinator_data_directory)
 
         # prepare provider for updateSystemConfig
-        gpEnv = GpCoordinatorEnvironment(options.coordinator_data_directory, True)
         configurationInterface.registerConfigurationProvider(
             configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog())
         configurationInterface.getConfigurationProvider().initializeProvider(gpEnv.getCoordinatorPort())

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -341,6 +341,40 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And the gprecoverseg lock directory is removed
          And all files in gpAdminLogs directory are deleted
 
+    Scenario: test 13.2. Check other tools launch (gpexpand) when ggrebalance operation hasn't finished.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "10000" rows
+         And there is a "heap" table "test_schema_1.test_table_2" in "test_db_1" with "10000" rows
+         And there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "10000" rows
+         And there is a "heap" table "test_schema_1.test_table_4" in "test_db_1" with "10000" rows
+         And there is a "heap" table "test_schema_1.test_table_5" in "test_db_1" with "10000" rows
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_begin"
+         And set fault inject type to suspend
+        When the user asynchronously runs "ggrebalance -n 1 -x 2 --skip-rebalance" and the process is saved
+         And the user waits till ggrebalance prints "Updated target segment count to 2" in the logs (with timeout of "60" sec)
+        When the user runs "gpexpand"
+        Then gpexpand should return a return code of 1
+         And gpexpand should print "ggrebalance is already running. gpexpand is not allowed to run in parallel" to logfile with latest timestamp
+         And unset fault inject
+         And the user asynchronously sets up to end ggrebalance process with SIGINT
+        Then the async process finished with a return code of 1
+         And ggrebalance should print "Shrink was interrupted" to logfile with latest timestamp
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "gpexpand"
+        Then gpexpand should return a return code of 1
+         And gpexpand should print "ggrebalance is already running. gpexpand is not allowed to run in parallel" to logfile with latest timestamp
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -n 1 --non-interactive-mode"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+        When the user runs "gpexpand"
+         Then gpexpand should not print "ggrebalance is already running. gpexpand is not allowed to run in parallel" to logfile with latest timestamp
+
     Scenario: test 14.  Check ggrebalance if pg_basebackup is already running
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'


### PR DESCRIPTION
Check for running ggrebalance in the gpexpand

This patch adds checking into the gpexpand that will throw an error: 
 - if there is a running instance of ggrebalance detected via pid file check;
 - or if there is a ggrebalance schema existing and
latest rebalance state isn't equal to STATE_EXECUTOR_DONE.

Schema check are encapsulated into the RebalanceSchema class and are available
with the help of the 'checkOperationInProgress()' class method.
