### PR TITLE
Add test cases to check that no gpbackup/restore session is in progress

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -348,6 +348,19 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And the background pid is killed on "coordinator" segment
          And the gprecoverseg lock directory is removed
          And all files in gpAdminLogs directory are deleted
+        When the user connects to "postgres" with named connection "test_connection"
+         And the user executes "SET application_name TO 'gpbackup_20260424085425'" with named connection "test_connection"
+         And the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "gpbackup/gprestore utility is already running." to logfile with latest timestamp
+         And the user drops the named connection "test_connection"
+         And all files in gpAdminLogs directory are deleted
+        When the user connects to "postgres" with named connection "test_connection"
+         And the user executes "SET application_name TO 'gprestore_20260424085425'" with named connection "test_connection"
+         And the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "gpbackup/gprestore utility is already running." to logfile with latest timestamp
+         And the user drops the named connection "test_connection"
 
     Scenario: test 13.2. Check other tools launch (gpexpand) when ggrebalance operation hasn't finished.
         Given the database is not running


### PR DESCRIPTION
Add test cases to check that no gpbackup/restore session is in progress

ggrebalance shouldn't allow execution in parallel with gpbackup/restore tools.
gpbackup/restore tools set GUC 'application_name' to
'gpbackup_<timestamp>'/'gprestore_<timestamp>' respectively at their operation
start when creating the connection pool (refer to functions
'initializeConnectionPool()' in their code), and the connection pool is kept
alive till the tool's operation ends. Therefore, during operation of
gpbackup/restore there are respective entries in 'pg_stat_activities'.

ggrebalance already has a check for running gpbackup/restore based on the info
from 'pg_stat_activities'. But it was not covered in tests.

This patch adds a couple of test cases to simulate running gpbackup/restore and
check that ggrebalance will not allow its operation in this case.
