### PR TITLE
Add check ggrebalance isn't running into gpcheckcat and gpconfig

### DIFF
--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -598,16 +598,22 @@ AS total_duration FROM cte_total""")
     def checkOperationInProgress(cls, gpEnv: GpCoordinatorEnvironment) -> bool:
         """Checks if there is ggrebalance operation in progress (possibly interrupted)"""
         dburl = dbconn.DbURL(dbname=DBNAME, port=gpEnv.getCoordinatorPort())
-        with closing(dbconn.connect(dburl, encoding='UTF8')) as conn:
-            # if there is no schema existing, we are not performing shrink or rebalance
-            if 0 == (dbconn.querySingleton(conn, f"SELECT COUNT(1) FROM pg_namespace WHERE nspname = '{cls.schema_name}'")):
-                return False
-            # if there is schema existing, check the last state - if it is final one - then we've complete all operations
-            latest_main_state = ''
-            cursor = dbconn.query(conn, f"SELECT state FROM {cls.schema_name}.{cls.rebalance_status} WHERE state_category = '{cls.STATE_CATEGORY_MAIN}' ORDER BY updated DESC LIMIT 1")
-            if cursor.rowcount > 0:
-                latest_main_state = str(cursor.fetchone()[0])
-            if latest_main_state == 'STATE_EXECUTOR_DONE':
-                return False
+        try:
+            with closing(dbconn.connect(dburl, encoding='UTF8')) as conn:
+                # if there is no schema existing, we are not performing shrink or rebalance
+                if 0 == (dbconn.querySingleton(conn, f"SELECT COUNT(1) FROM pg_namespace WHERE nspname = '{cls.schema_name}'")):
+                    return False
+                # if there is schema existing, check the last state - if it is final one - then we've complete all operations
+                latest_main_state = ''
+                cursor = dbconn.query(conn, f"SELECT state FROM {cls.schema_name}.{cls.rebalance_status} WHERE state_category = '{cls.STATE_CATEGORY_MAIN}' ORDER BY updated DESC LIMIT 1")
+                if cursor.rowcount > 0:
+                    latest_main_state = str(cursor.fetchone()[0])
+                if latest_main_state == 'STATE_EXECUTOR_DONE':
+                    return False
+        except:
+            # In case we didn't succeed to probe the schema,
+            # we assume that the cluster is not in a state that allows rebalance
+            # (for ex., the cluster is in single node mode). So return false here.
+            return False
 
         return True

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -3677,7 +3677,7 @@ def is_ggrebalance_running():
     if check_pid_file(coordinator_data_directory, 'ggrebalance.pid'):
         return True
     """Checks if ggrebalance was interrupted and didn't finish its work"""
-    gpEnv = GpCoordinatorEnvironment(coordinator_data_directory, True)
+    gpEnv = GpCoordinatorEnvironment(coordinator_data_directory, False, verbose=False)
     return RebalanceSchema.checkOperationInProgress(gpEnv)
 
 def check_test_subset_parameter_count():

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -3668,15 +3668,15 @@ def check_gpexpand():
 
 def check_ggrebalance():
     if is_ggrebalance_running():
-        myprint("ERROR: Usage of gpcheckcat is not supported while the cluster is being rebalanced")
+        myprint("ERROR: Using gpcheckcat is not supported during cluster rebalancing")
         sys.exit(1)
 
 def is_ggrebalance_running():
     coordinator_data_directory = get_coordinatordatadir()
-    """Checks if there is an instance of ggrebalance running"""
+    # Checks if there is an instance of ggrebalance running
     if check_pid_file(coordinator_data_directory, 'ggrebalance.pid'):
         return True
-    """Checks if ggrebalance was interrupted and didn't finish its work"""
+    # Checks if ggrebalance was interrupted and didn't finish its work
     gpEnv = GpCoordinatorEnvironment(coordinator_data_directory, False, verbose=False)
     return RebalanceSchema.checkOperationInProgress(gpEnv)
 

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -37,11 +37,14 @@ try:
     from gppylib.commands.unix import *
     from gppylib.commands.gp import conflict_with_gpexpand
     from gppylib.system.info import *
+    from gppylib.system.environment import GpCoordinatorEnvironment
+    from gppylib.commands.gp import check_pid_file, get_coordinatordatadir
     from gpcheckcat_modules.unique_index_violation_check import UniqueIndexViolationCheck
     from gpcheckcat_modules.leaked_schema_dropper import LeakedSchemaDropper
     from gpcheckcat_modules.repair import Repair
     from gpcheckcat_modules.foreign_key_check import ForeignKeyCheck
     from gpcheckcat_modules.orphaned_toast_tables_check import OrphanedToastTablesCheck
+    from ggrebalance_modules.rebalance_schema import RebalanceSchema
 except ImportError as e:
     sys.exit('Error: unable to import module: ' + str(e))
 
@@ -3663,6 +3666,20 @@ def check_gpexpand():
         myprint(msg)
         sys.exit(1)
 
+def check_ggrebalance():
+    if is_ggrebalance_running():
+        myprint("ERROR: Usage of gpcheckcat is not supported while the cluster is being rebalanced")
+        sys.exit(1)
+
+def is_ggrebalance_running():
+    coordinator_data_directory = get_coordinatordatadir()
+    """Checks if there is an instance of ggrebalance running"""
+    if check_pid_file(coordinator_data_directory, 'ggrebalance.pid'):
+        return True
+    """Checks if ggrebalance was interrupted and didn't finish its work"""
+    gpEnv = GpCoordinatorEnvironment(coordinator_data_directory, True)
+    return RebalanceSchema.checkOperationInProgress(gpEnv)
+
 def check_test_subset_parameter_count():
     test_option_count = 0
     if GV.opt['-R']:
@@ -3702,6 +3719,8 @@ def main():
 
     # gpcheckcat should check gpexpand running status
     check_gpexpand()
+    # gpcheckcat should check ggrebalance running status
+    check_ggrebalance()
 
     GV.cfg = getGPConfiguration()
     truncate_batch_size(len(GV.cfg.keys()))

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -562,7 +562,7 @@ def is_ggrebalance_running():
     if check_pid_file(coordinator_data_directory, 'ggrebalance.pid'):
         return True
     """Checks if ggrebalance was interrupted and didn't finish its work"""
-    gpEnv = GpCoordinatorEnvironment(coordinator_data_directory, True)
+    gpEnv = GpCoordinatorEnvironment(coordinator_data_directory, False, verbose=False)
     return RebalanceSchema.checkOperationInProgress(gpEnv)
 
 def do_main():

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -26,12 +26,14 @@ try:
     from gppylib.commands.gp import *
     from gppylib.db import dbconn
     from gppylib.userinput import *
+    from gppylib.system.environment import GpCoordinatorEnvironment
     from gpconfig_modules.segment_guc import SegmentGuc
     from gpconfig_modules.database_segment_guc import DatabaseSegmentGuc
     from gpconfig_modules.file_segment_guc import FileSegmentGuc
     from gpconfig_modules.guc_collection import GucCollection
     from gppylib.gpresgroup import GpResGroup
     from gpconfig_modules.parse_guc_metadata import ParseGuc
+    from ggrebalance_modules.rebalance_schema import RebalanceSchema
 except ImportError as err:
     sys.exit('Cannot import modules.  Please check that you have sourced '
              'greengage_path.sh.  Detail: ' + str(err))
@@ -549,6 +551,20 @@ def check_gpexpand():
         LOGGER.error(msg)
         sys.exit(1)
 
+def check_ggrebalance():
+    if is_ggrebalance_running():
+        LOGGER.error("ERROR: Usage of gpconfig is not supported while the cluster is being rebalanced")
+        sys.exit(1)
+
+def is_ggrebalance_running():
+    coordinator_data_directory = get_coordinatordatadir()
+    """Checks if there is an instance of ggrebalance running"""
+    if check_pid_file(coordinator_data_directory, 'ggrebalance.pid'):
+        return True
+    """Checks if ggrebalance was interrupted and didn't finish its work"""
+    gpEnv = GpCoordinatorEnvironment(coordinator_data_directory, True)
+    return RebalanceSchema.checkOperationInProgress(gpEnv)
+
 def do_main():
     options = parseargs()
     _set_gparray()
@@ -562,6 +578,8 @@ def do_main():
         # gpconfig should check gpexpand running status when
         # it wants to modify configurations
         check_gpexpand()
+
+        check_ggrebalance()
 
         do_change(options)
 

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -553,15 +553,15 @@ def check_gpexpand():
 
 def check_ggrebalance():
     if is_ggrebalance_running():
-        LOGGER.error("ERROR: Usage of gpconfig is not supported while the cluster is being rebalanced")
+        LOGGER.error("ERROR: Using gpconfig is not supported during cluster rebalancing")
         sys.exit(1)
 
 def is_ggrebalance_running():
     coordinator_data_directory = get_coordinatordatadir()
-    """Checks if there is an instance of ggrebalance running"""
+    # Checks if there is an instance of ggrebalance running
     if check_pid_file(coordinator_data_directory, 'ggrebalance.pid'):
         return True
-    """Checks if ggrebalance was interrupted and didn't finish its work"""
+    # Checks if ggrebalance was interrupted and didn't finish its work
     gpEnv = GpCoordinatorEnvironment(coordinator_data_directory, False, verbose=False)
     return RebalanceSchema.checkOperationInProgress(gpEnv)
 
@@ -578,7 +578,7 @@ def do_main():
         # gpconfig should check gpexpand running status when
         # it wants to modify configurations
         check_gpexpand()
-
+        # and gpconfig also should check ggrebalance running status
         check_ggrebalance()
 
         do_change(options)

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -243,21 +243,6 @@ def remove_pid_file(coordinator_data_directory):
         pass
 
 
-def check_pid_file(coordinator_data_directory, pid_filename):
-    is_running = False
-    try:
-        fp = open(os.path.join(coordinator_data_directory, pid_filename), 'r')
-        pid = int(fp.readline().strip())
-        fp.close()
-        is_running = check_pid(pid)
-    except IOError:
-        pass
-    except Exception:
-        raise
-
-    return is_running
-
-
 def is_gpexpand_running(coordinator_data_directory):
     """Checks if there is another instance of gpexpand running"""
     return check_pid_file(coordinator_data_directory, 'gpexpand.pid')

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1435,6 +1435,21 @@ def conflict_with_gpexpand(utility, refuse_phase1=True, refuse_phase2=False):
 
     return (True, "")
 
+
+def check_pid_file(coordinator_data_directory, pid_filename):
+    is_running = False
+    try:
+        fp = open(os.path.join(coordinator_data_directory, pid_filename), 'r')
+        pid = int(fp.readline().strip())
+        fp.close()
+        is_running = check_pid(pid)
+    except IOError:
+        pass
+    except Exception:
+        raise
+
+    return is_running
+
 #=-=-=-=-=-=-=-=-=-= Bash Migration Helper Functions =-=-=-=-=-=-=-=-
 
 def start_standbycoordinator(host, datadir, port, era=None,

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1439,9 +1439,8 @@ def conflict_with_gpexpand(utility, refuse_phase1=True, refuse_phase2=False):
 def check_pid_file(coordinator_data_directory, pid_filename):
     is_running = False
     try:
-        fp = open(os.path.join(coordinator_data_directory, pid_filename), 'r')
-        pid = int(fp.readline().strip())
-        fp.close()
+        with open(os.path.join(coordinator_data_directory, pid_filename), 'r') as fp:
+            pid = int(fp.readline().strip())
         is_running = check_pid(pid)
     except IOError:
         pass

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -349,7 +349,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And the gprecoverseg lock directory is removed
          And all files in gpAdminLogs directory are deleted
 
-    Scenario: test 13.2. Check other tools launch (gpexpand) when ggrebalance operation hasn't finished.
+    Scenario: test 13.2. Check other tools launch when ggrebalance operation hasn't finished.
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2"

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -370,10 +370,10 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And gpexpand should print "ggrebalance is already running. gpexpand is not allowed to run in parallel" to logfile with latest timestamp
         When the user runs "gpcheckcat"
         Then gpcheckcat should return a return code of 1
-         And gpcheckcat should print "ERROR: Usage of gpcheckcat is not supported while the cluster is being rebalanced" to logfile with latest timestamp
+         And gpcheckcat should print "ERROR: Using gpcheckcat is not supported during cluster rebalancing" to logfile with latest timestamp
         When the user runs "gpconfig -c application_name -v 'gpconfig_test'"
         Then gpconfig should return a return code of 1
-         And gpconfig should print "ERROR: Usage of gpconfig is not supported while the cluster is being rebalanced" to logfile with latest timestamp
+         And gpconfig should print "ERROR: Using gpconfig is not supported during cluster rebalancing" to logfile with latest timestamp
          And unset fault inject
          And the user asynchronously sets up to end ggrebalance process with SIGINT
         Then the async process finished with a return code of 1
@@ -384,10 +384,10 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And gpexpand should print "ggrebalance is already running. gpexpand is not allowed to run in parallel" to logfile with latest timestamp
         When the user runs "gpcheckcat"
         Then gpcheckcat should return a return code of 1
-         And gpcheckcat should print "ERROR: Usage of gpcheckcat is not supported while the cluster is being rebalanced" to logfile with latest timestamp
+         And gpcheckcat should print "ERROR: Using gpcheckcat is not supported during cluster rebalancing" to logfile with latest timestamp
         When the user runs "gpconfig -c application_name -v 'gpconfig_test'"
         Then gpconfig should return a return code of 1
-         And gpconfig should print "ERROR: Usage of gpconfig is not supported while the cluster is being rebalanced" to logfile with latest timestamp
+         And gpconfig should print "ERROR: Using gpconfig is not supported during cluster rebalancing" to logfile with latest timestamp
          And all files in gpAdminLogs directory are deleted
         When the user runs "ggrebalance -n 1 --non-interactive-mode"
         Then ggrebalance should return a return code of 0

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -368,6 +368,12 @@ Feature: ggrebalance behave tests (misc options scenarios)
         When the user runs "gpexpand"
         Then gpexpand should return a return code of 1
          And gpexpand should print "ggrebalance is already running. gpexpand is not allowed to run in parallel" to logfile with latest timestamp
+        When the user runs "gpcheckcat"
+        Then gpcheckcat should return a return code of 1
+         And gpcheckcat should print "ERROR: Usage of gpcheckcat is not supported while the cluster is being rebalanced" to logfile with latest timestamp
+        When the user runs "gpconfig -c application_name -v 'gpconfig_test'"
+        Then gpconfig should return a return code of 1
+         And gpconfig should print "ERROR: Usage of gpconfig is not supported while the cluster is being rebalanced" to logfile with latest timestamp
          And unset fault inject
          And the user asynchronously sets up to end ggrebalance process with SIGINT
         Then the async process finished with a return code of 1
@@ -376,12 +382,22 @@ Feature: ggrebalance behave tests (misc options scenarios)
         When the user runs "gpexpand"
         Then gpexpand should return a return code of 1
          And gpexpand should print "ggrebalance is already running. gpexpand is not allowed to run in parallel" to logfile with latest timestamp
+        When the user runs "gpcheckcat"
+        Then gpcheckcat should return a return code of 1
+         And gpcheckcat should print "ERROR: Usage of gpcheckcat is not supported while the cluster is being rebalanced" to logfile with latest timestamp
+        When the user runs "gpconfig -c application_name -v 'gpconfig_test'"
+        Then gpconfig should return a return code of 1
+         And gpconfig should print "ERROR: Usage of gpconfig is not supported while the cluster is being rebalanced" to logfile with latest timestamp
          And all files in gpAdminLogs directory are deleted
         When the user runs "ggrebalance -n 1 --non-interactive-mode"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
         When the user runs "gpexpand"
          Then gpexpand should not print "ggrebalance is already running. gpexpand is not allowed to run in parallel" to logfile with latest timestamp
+        When the user runs "gpcheckcat"
+         Then gpcheckcat should not print "ERROR: Usage of gpcheckcat is not supported while the cluster is being rebalanced" to logfile with latest timestamp
+        When the user runs "gpconfig -c application_name -v 'gpconfig_test'"
+         Then gpconfig should not print "ERROR: Usage of gpconfig is not supported while the cluster is being rebalanced" to logfile with latest timestamp
 
     Scenario: test 14.  Check ggrebalance if pg_basebackup is already running
         Given the database is not running


### PR DESCRIPTION
Add check ggrebalance isn't running into gpcheckcat and gpconfig

According to current requirements, gpcheckcat and gpconfig should not allow
their execution if ggrebalance session is in progress. This patch adds such
capability.

Function 'check_pid_file()' is moved from 'gpexpand' into common 'gp.py' as it
is now used across several tools.

RebalanceSchema.checkOperationInProgress() is updated to handle
cases when the cluster is in one node mode (which is tested in the gpcheckcat
test suite).
