### PR TITLE
GG-403: Fix pg_dump for partitioned tables with droped column during pg_upgrade [7X]

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -17539,7 +17539,33 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 					appendStringLiteralAH(q, tbinfo->attnames[j], fout);
 
 					/* GPDB partitioning */
-					if (fout->remoteVersion < GPDB7_MAJOR_PGVERSION)
+					if (dopt->binary_upgrade
+						&& GPDB6_MAJOR_PGVERSION <= fout->remoteVersion
+						&& fout->remoteVersion < GPDB7_MAJOR_PGVERSION)
+					{
+						// binary-upgrade edge-case. Target version (i.e. Greengage 7.x)
+						// uses PostgreSQL partitions, and its catalog doesn't have
+						// 'pg_partition' and 'pg_partition_rule',
+						// but because we are dumping from Greengage 6.x,
+						// the rest of the code expects that we will deal
+						// with partitions here (in 7.x each partition
+						// updates its attributes seperately).
+						//
+						// Gladly, there is a builtin function to traverse partition
+						// hierarchy.
+						//
+						// Also, because non-partitioned tables can also get here,
+						// we can't rely on 'pg_partition_tree' to always report
+						// the table. Therefore, it is hardcoded into the query.
+
+						appendPQExpBufferStr(q, "\n  AND attrelid IN (SELECT ");
+						appendStringLiteralAH(q, qualrelname, fout);
+						appendPQExpBufferStr(q, "::pg_catalog.regclass ");
+						appendPQExpBufferStr(q, "UNION SELECT relid FROM pg_partition_tree(");
+						appendStringLiteralAH(q, qualrelname, fout);
+						appendPQExpBufferStr(q, "::pg_catalog.regclass));\n");
+					}
+					else if (fout->remoteVersion < GPDB7_MAJOR_PGVERSION)
 					{
 						/*
 						 * Do for all descendants of a partition table.

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -17567,14 +17567,11 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 						 * but because we are dumping from Greengage 6.x,
 						 * the rest of the code expects that we will deal
 						 * with partitions here (in 7.x each partition
-						 * updates its attributes seperately).
+						 * updates its attributes separately).
 						 *
-						 * Gladly, there is a builtin function to traverse partition
-						 * hierarchy.
-						 *
-						 * Also, because non-partitioned tables can also get here,
-						 * we can't rely on 'pg_partition_tree' to always report
-						 * the table. Therefore, it is hardcoded into the query.
+						 * Use pg_partition_tree() to find partition children.
+						 * For non-partitioned tables it returns no rows,
+						 * so include the root relation explicitly.
 						 */
 						appendPQExpBufferStr(q, "\n  AND attrelid IN (SELECT ");
 						appendStringLiteralAH(q, qualrelname, fout);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -17539,33 +17539,7 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 					appendStringLiteralAH(q, tbinfo->attnames[j], fout);
 
 					/* GPDB partitioning */
-					if (dopt->binary_upgrade
-						&& GPDB6_MAJOR_PGVERSION <= fout->remoteVersion
-						&& fout->remoteVersion < GPDB7_MAJOR_PGVERSION)
-					{
-						// binary-upgrade edge-case. Target version (i.e. Greengage 7.x)
-						// uses PostgreSQL partitions, and its catalog doesn't have
-						// 'pg_partition' and 'pg_partition_rule',
-						// but because we are dumping from Greengage 6.x,
-						// the rest of the code expects that we will deal
-						// with partitions here (in 7.x each partition
-						// updates its attributes seperately).
-						//
-						// Gladly, there is a builtin function to traverse partition
-						// hierarchy.
-						//
-						// Also, because non-partitioned tables can also get here,
-						// we can't rely on 'pg_partition_tree' to always report
-						// the table. Therefore, it is hardcoded into the query.
-
-						appendPQExpBufferStr(q, "\n  AND attrelid IN (SELECT ");
-						appendStringLiteralAH(q, qualrelname, fout);
-						appendPQExpBufferStr(q, "::pg_catalog.regclass ");
-						appendPQExpBufferStr(q, "UNION SELECT relid FROM pg_partition_tree(");
-						appendStringLiteralAH(q, qualrelname, fout);
-						appendPQExpBufferStr(q, "::pg_catalog.regclass));\n");
-					}
-					else if (fout->remoteVersion < GPDB7_MAJOR_PGVERSION)
+					if (fout->remoteVersion < GPDB6_MAJOR_PGVERSION)
 					{
 						/*
 						 * Do for all descendants of a partition table.
@@ -17581,6 +17555,33 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 										  "pr.paroid = p.oid AND p.parrelid = ");
 						appendStringLiteralAH(q, qualrelname, fout);
 						appendPQExpBufferStr(q, "::pg_catalog.regclass);\n");
+					}
+					else if (fout->remoteVersion < GPDB7_MAJOR_PGVERSION)
+					{
+						/*
+						 * Case for 6.x -> 7.x migration
+						 *
+						 * Target version (i.e. Greengage 7.x)
+						 * uses PostgreSQL partitions, and its catalog doesn't have
+						 * 'pg_partition' and 'pg_partition_rule',
+						 * but because we are dumping from Greengage 6.x,
+						 * the rest of the code expects that we will deal
+						 * with partitions here (in 7.x each partition
+						 * updates its attributes seperately).
+						 *
+						 * Gladly, there is a builtin function to traverse partition
+						 * hierarchy.
+						 *
+						 * Also, because non-partitioned tables can also get here,
+						 * we can't rely on 'pg_partition_tree' to always report
+						 * the table. Therefore, it is hardcoded into the query.
+						 */
+						appendPQExpBufferStr(q, "\n  AND attrelid IN (SELECT ");
+						appendStringLiteralAH(q, qualrelname, fout);
+						appendPQExpBufferStr(q, "::pg_catalog.regclass ");
+						appendPQExpBufferStr(q, "UNION SELECT relid FROM pg_partition_tree(");
+						appendStringLiteralAH(q, qualrelname, fout);
+						appendPQExpBufferStr(q, "::pg_catalog.regclass));\n");
 					}
 					else
 					{


### PR DESCRIPTION
If there is a partitioned table in the database containing 
deleted columns, pg_dump in 7X generates sql that contains 
catalog tables no longer present in 7X, as it uses 
PostgreSQL partitioned tables.

To fix this issue, use a separate query when upgrading 
from 6X.