### PR TITLE
GG-163: Don't use actions cache if developer's image is present for 6.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v28
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@GG-162
     with:
       version: 6
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
## Don't use actions cache if developer's image is present for 6.x
- ci (build): retarget to GG-162 branch

Task: [GG-162](https://tracker.yandex.ru/GG-162)