### PR TITLE
Fix gpcheckcat test after switching to SCRAM password hashing (#410)

### DIFF
--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -356,6 +356,12 @@ class GPCatalog():
         # transaction state, hence it can be different so skip it from checks.
         self._tables['pg_index']._setKnownDifferences("indpred indcheckxmin")
 
+        # GG-424 : Inconsistent rolpassword
+        # rolpassword is inconsistent if scram-sha-256 encryption is used.
+        # Salt is generated locally on each segment, so the hashes are
+        # inconsistent between segments.
+        self._tables['pg_authid']._setKnownDifferences("rolpassword")
+
     def _validate(self):
         """
         Check that all tables defined in the catalog have either been marked

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -725,8 +725,22 @@ Feature: gpcheckcat tests
         And gpcheckcat should print "Found no catalog issue" to stdout
         And the user runs "psql -d check_dependency_error -c "DROP SUBSCRIPTION foo""
         And the user runs "psql -d check_dependency_error -c "DROP TRANSFORM FOR int LANGUAGE SQL""
+        And the user runs "psql -d check_dependency_error -c "DROP OWNED BY foo; DROP ROLE foo""
+        Then psql should return a return code of 0
         And the user runs "dropdb check_dependency_error"
-        And the user runs "psql -d postgres -c "DROP ROLE foo""
+
+    Scenario: gpcheckcat should not report inconsistency because of scram-sha-256 passwords
+        Given database "check_scram_passwords" is dropped and recreated
+        And the user runs "psql -d check_scram_passwords -c "SET password_encryption = 'scram-sha-256'; CREATE ROLE foo PASSWORD 'bar';""
+        Then psql should return a return code of 0
+        When the user runs "gpcheckcat check_scram_passwords"
+        Then gpcheckcat should return a return code of 0
+        And gpcheckcat should not print "SUMMARY REPORT: FAILED" to stdout
+        And gpcheckcat should not print "inconsistent_pg_authid" to stdout
+        And gpcheckcat should print "Found no catalog issue" to stdout
+        And the user runs "psql -d check_scram_passwords -c "DROP ROLE foo""
+        Then psql should return a return code of 0
+        And the user runs "dropdb check_scram_passwords"
 
     Scenario Outline: gpcheckcat should discover missing attributes for external tables
         Given database "miss_attr_db3" is dropped and recreated


### PR DESCRIPTION
SCRAM hashing for passwords uses salted hashes that are locally generated on segments, so hashes are not consistent between segments. So inconsistency in rolpassword field in pg_authid catalog table is not an issue and should not be checked by gpcheckcat. Also fix cleanup in the previous behave test.

(cherry picked from commit arenadata/gpdb@fe08e036e01bf5f29f39d2806e1127297fbb0540)

Ticket: GG-437

---

Note: do not squash to preserve authorship
