### PR TITLE
Truncate the data on the shrunk segments at ALTER TABLE REBALANCE

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17804,6 +17804,22 @@ ATExecShrinkTable(Relation rel, GpPolicy *policy)
 
 		gp_segment_number_for_table_shrink = 0;
 	}
+	else if (Gp_role == GP_ROLE_EXECUTE && GpPolicyIsPartitioned(policy) &&
+		   GpIdentity.segindex >= policy->numsegments)
+	{
+		/*
+		 * Truncate data on the segments that are not included into the
+		 * table's distribution policy. We need to do it to avoid possible
+		 * issues with table's statistics.
+		 */
+		List *rels = list_make1(rel);
+		List *relids = list_make1_oid(RelationGetRelid(rel));
+		List *relids_logged = NIL;
+		if (RelationIsLogicallyLogged(rel))
+			relids_logged = list_make1_oid(RelationGetRelid(rel));
+		ExecuteTruncateGuts(rels, relids, relids_logged,
+							DROP_RESTRICT, false, NULL);
+	}
 }
 
 /*

--- a/src/test/regress/expected/alter_rebalance.out
+++ b/src/test/regress/expected/alter_rebalance.out
@@ -3618,6 +3618,7 @@ select count(1), gp_segment_id from mv_test_table group by gp_segment_id order b
 drop materialized view mv_test_table;
 drop table test_table;
 -- check ANALYZE after REBALANCE
+drop table if exists test_table_heap;
 create table test_table_heap(a int) distributed by (a);
 insert into test_table_heap select generate_series(1, 50000);
 alter table test_table_heap rebalance 2;
@@ -3643,6 +3644,7 @@ select n_distinct from pg_stats where tablename = 'test_table_heap' and attname 
 (1 row)
 
 drop table test_table_heap;
+drop table if exists test_table_ao_row;
 create table test_table_ao_row(a int) with (appendonly=true, orientation=row) distributed by (a);
 insert into test_table_ao_row select generate_series(1, 50000);
 alter table test_table_ao_row rebalance 2;
@@ -3668,6 +3670,7 @@ select n_distinct from pg_stats where tablename = 'test_table_ao_row' and attnam
 (1 row)
 
 drop table test_table_ao_row;
+drop table if exists test_table_ao_col;
 create table test_table_ao_col(a int) with (appendonly=true, orientation=column) distributed by (a);
 insert into test_table_ao_col select generate_series(1, 50000);
 alter table test_table_ao_col rebalance 2;

--- a/src/test/regress/expected/alter_rebalance.out
+++ b/src/test/regress/expected/alter_rebalance.out
@@ -3617,3 +3617,227 @@ select count(1), gp_segment_id from mv_test_table group by gp_segment_id order b
 
 drop materialized view mv_test_table;
 drop table test_table;
+-- check ANALYZE after REBALANCE
+create table test_table_heap(a int) distributed by (a);
+insert into test_table_heap select generate_series(1, 50000);
+alter table test_table_heap rebalance 2;
+analyze test_table_heap;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_heap group by gp_segment_id order by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+ 25017 |             0
+ 24983 |             1
+(2 rows)
+
+select reltuples from pg_class where oid = 'test_table_heap'::regclass;
+ reltuples 
+-----------
+     50000
+(1 row)
+
+select n_distinct from pg_stats where tablename = 'test_table_heap' and attname = 'a';
+ n_distinct 
+------------
+         -1
+(1 row)
+
+drop table test_table_heap;
+create table test_table_ao_row(a int) with (appendonly=true, orientation=row) distributed by (a);
+insert into test_table_ao_row select generate_series(1, 50000);
+alter table test_table_ao_row rebalance 2;
+analyze test_table_ao_row;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_ao_row group by gp_segment_id order by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+ 25017 |             0
+ 24983 |             1
+(2 rows)
+
+select reltuples from pg_class where oid = 'test_table_ao_row'::regclass;
+ reltuples 
+-----------
+     50000
+(1 row)
+
+select n_distinct from pg_stats where tablename = 'test_table_ao_row' and attname = 'a';
+ n_distinct 
+------------
+         -1
+(1 row)
+
+drop table test_table_ao_row;
+create table test_table_ao_col(a int) with (appendonly=true, orientation=column) distributed by (a);
+insert into test_table_ao_col select generate_series(1, 50000);
+alter table test_table_ao_col rebalance 2;
+analyze test_table_ao_col;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_ao_col group by gp_segment_id order by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+ 25017 |             0
+ 24983 |             1
+(2 rows)
+
+select reltuples from pg_class where oid = 'test_table_ao_col'::regclass;
+ reltuples 
+-----------
+     50000
+(1 row)
+
+select n_distinct from pg_stats where tablename = 'test_table_ao_col' and attname = 'a';
+ n_distinct 
+------------
+         -1
+(1 row)
+
+drop table test_table_ao_col;
+-- Check ANALYZE inside the transaction and after rollback
+create table test_table_heap(a int) distributed by (a);
+insert into test_table_heap select generate_series(1, 50000);
+begin;
+alter table test_table_heap rebalance 2;
+analyze test_table_heap;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_heap group by gp_segment_id order by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+ 25017 |             0
+ 24983 |             1
+(2 rows)
+
+select reltuples from pg_class where oid = 'test_table_heap'::regclass;
+ reltuples 
+-----------
+     50000
+(1 row)
+
+select n_distinct from pg_stats where tablename = 'test_table_heap' and attname = 'a';
+ n_distinct 
+------------
+         -1
+(1 row)
+
+rollback;
+analyze test_table_heap;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_heap group by gp_segment_id order by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+ 16698 |             0
+ 16718 |             1
+ 16584 |             2
+(3 rows)
+
+select reltuples from pg_class where oid = 'test_table_heap'::regclass;
+ reltuples 
+-----------
+     50000
+(1 row)
+
+select n_distinct from pg_stats where tablename = 'test_table_heap' and attname = 'a';
+ n_distinct 
+------------
+         -1
+(1 row)
+
+drop table test_table_heap;
+create table test_table_ao_row(a int) with (appendonly=true, orientation=row) distributed by (a);
+insert into test_table_ao_row select generate_series(1, 50000);
+begin;
+alter table test_table_ao_row rebalance 2;
+analyze test_table_ao_row;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_ao_row group by gp_segment_id order by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+ 25017 |             0
+ 24983 |             1
+(2 rows)
+
+select reltuples from pg_class where oid = 'test_table_ao_row'::regclass;
+ reltuples 
+-----------
+     50000
+(1 row)
+
+select n_distinct from pg_stats where tablename = 'test_table_ao_row' and attname = 'a';
+ n_distinct 
+------------
+         -1
+(1 row)
+
+rollback;
+analyze test_table_ao_row;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_ao_row group by gp_segment_id order by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+ 16698 |             0
+ 16718 |             1
+ 16584 |             2
+(3 rows)
+
+select reltuples from pg_class where oid = 'test_table_ao_row'::regclass;
+ reltuples 
+-----------
+     50000
+(1 row)
+
+select n_distinct from pg_stats where tablename = 'test_table_ao_row' and attname = 'a';
+ n_distinct 
+------------
+         -1
+(1 row)
+
+drop table test_table_ao_row;
+create table test_table_ao_col(a int) with (appendonly=true, orientation=column) distributed by (a);
+insert into test_table_ao_col select generate_series(1, 50000);
+begin;
+alter table test_table_ao_col rebalance 2;
+analyze test_table_ao_col;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_ao_col group by gp_segment_id order by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+ 25017 |             0
+ 24983 |             1
+(2 rows)
+
+select reltuples from pg_class where oid = 'test_table_ao_col'::regclass;
+ reltuples 
+-----------
+     50000
+(1 row)
+
+select n_distinct from pg_stats where tablename = 'test_table_ao_col' and attname = 'a';
+ n_distinct 
+------------
+         -1
+(1 row)
+
+rollback;
+analyze test_table_ao_col;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_ao_col group by gp_segment_id order by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+ 16698 |             0
+ 16718 |             1
+ 16584 |             2
+(3 rows)
+
+select reltuples from pg_class where oid = 'test_table_ao_col'::regclass;
+ reltuples 
+-----------
+     50000
+(1 row)
+
+select n_distinct from pg_stats where tablename = 'test_table_ao_col' and attname = 'a';
+ n_distinct 
+------------
+         -1
+(1 row)
+
+drop table test_table_ao_col;

--- a/src/test/regress/sql/alter_rebalance.sql
+++ b/src/test/regress/sql/alter_rebalance.sql
@@ -489,3 +489,86 @@ select count(1), gp_segment_id from mv_test_table group by gp_segment_id order b
 
 drop materialized view mv_test_table;
 drop table test_table;
+
+-- check ANALYZE after REBALANCE
+create table test_table_heap(a int) distributed by (a);
+insert into test_table_heap select generate_series(1, 50000);
+alter table test_table_heap rebalance 2;
+analyze test_table_heap;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_heap group by gp_segment_id order by gp_segment_id;
+select reltuples from pg_class where oid = 'test_table_heap'::regclass;
+select n_distinct from pg_stats where tablename = 'test_table_heap' and attname = 'a';
+drop table test_table_heap;
+
+create table test_table_ao_row(a int) with (appendonly=true, orientation=row) distributed by (a);
+insert into test_table_ao_row select generate_series(1, 50000);
+alter table test_table_ao_row rebalance 2;
+analyze test_table_ao_row;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_ao_row group by gp_segment_id order by gp_segment_id;
+select reltuples from pg_class where oid = 'test_table_ao_row'::regclass;
+select n_distinct from pg_stats where tablename = 'test_table_ao_row' and attname = 'a';
+drop table test_table_ao_row;
+
+create table test_table_ao_col(a int) with (appendonly=true, orientation=column) distributed by (a);
+insert into test_table_ao_col select generate_series(1, 50000);
+alter table test_table_ao_col rebalance 2;
+analyze test_table_ao_col;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_ao_col group by gp_segment_id order by gp_segment_id;
+select reltuples from pg_class where oid = 'test_table_ao_col'::regclass;
+select n_distinct from pg_stats where tablename = 'test_table_ao_col' and attname = 'a';
+drop table test_table_ao_col;
+
+-- Check ANALYZE inside the transaction and after rollback
+create table test_table_heap(a int) distributed by (a);
+insert into test_table_heap select generate_series(1, 50000);
+begin;
+alter table test_table_heap rebalance 2;
+analyze test_table_heap;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_heap group by gp_segment_id order by gp_segment_id;
+select reltuples from pg_class where oid = 'test_table_heap'::regclass;
+select n_distinct from pg_stats where tablename = 'test_table_heap' and attname = 'a';
+rollback;
+analyze test_table_heap;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_heap group by gp_segment_id order by gp_segment_id;
+select reltuples from pg_class where oid = 'test_table_heap'::regclass;
+select n_distinct from pg_stats where tablename = 'test_table_heap' and attname = 'a';
+drop table test_table_heap;
+
+create table test_table_ao_row(a int) with (appendonly=true, orientation=row) distributed by (a);
+insert into test_table_ao_row select generate_series(1, 50000);
+begin;
+alter table test_table_ao_row rebalance 2;
+analyze test_table_ao_row;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_ao_row group by gp_segment_id order by gp_segment_id;
+select reltuples from pg_class where oid = 'test_table_ao_row'::regclass;
+select n_distinct from pg_stats where tablename = 'test_table_ao_row' and attname = 'a';
+rollback;
+analyze test_table_ao_row;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_ao_row group by gp_segment_id order by gp_segment_id;
+select reltuples from pg_class where oid = 'test_table_ao_row'::regclass;
+select n_distinct from pg_stats where tablename = 'test_table_ao_row' and attname = 'a';
+drop table test_table_ao_row;
+
+create table test_table_ao_col(a int) with (appendonly=true, orientation=column) distributed by (a);
+insert into test_table_ao_col select generate_series(1, 50000);
+begin;
+alter table test_table_ao_col rebalance 2;
+analyze test_table_ao_col;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_ao_col group by gp_segment_id order by gp_segment_id;
+select reltuples from pg_class where oid = 'test_table_ao_col'::regclass;
+select n_distinct from pg_stats where tablename = 'test_table_ao_col' and attname = 'a';
+rollback;
+analyze test_table_ao_col;
+-- validate data and statistics correctness
+select count(*), gp_segment_id from test_table_ao_col group by gp_segment_id order by gp_segment_id;
+select reltuples from pg_class where oid = 'test_table_ao_col'::regclass;
+select n_distinct from pg_stats where tablename = 'test_table_ao_col' and attname = 'a';
+drop table test_table_ao_col;

--- a/src/test/regress/sql/alter_rebalance.sql
+++ b/src/test/regress/sql/alter_rebalance.sql
@@ -491,6 +491,7 @@ drop materialized view mv_test_table;
 drop table test_table;
 
 -- check ANALYZE after REBALANCE
+drop table if exists test_table_heap;
 create table test_table_heap(a int) distributed by (a);
 insert into test_table_heap select generate_series(1, 50000);
 alter table test_table_heap rebalance 2;
@@ -501,6 +502,7 @@ select reltuples from pg_class where oid = 'test_table_heap'::regclass;
 select n_distinct from pg_stats where tablename = 'test_table_heap' and attname = 'a';
 drop table test_table_heap;
 
+drop table if exists test_table_ao_row;
 create table test_table_ao_row(a int) with (appendonly=true, orientation=row) distributed by (a);
 insert into test_table_ao_row select generate_series(1, 50000);
 alter table test_table_ao_row rebalance 2;
@@ -511,6 +513,7 @@ select reltuples from pg_class where oid = 'test_table_ao_row'::regclass;
 select n_distinct from pg_stats where tablename = 'test_table_ao_row' and attname = 'a';
 drop table test_table_ao_row;
 
+drop table if exists test_table_ao_col;
 create table test_table_ao_col(a int) with (appendonly=true, orientation=column) distributed by (a);
 insert into test_table_ao_col select generate_series(1, 50000);
 alter table test_table_ao_col rebalance 2;


### PR DESCRIPTION
Truncate the data on the shrunk segments at ALTER TABLE REBALANCE

Problem description:
ANALYZE on a table that had been shrunk via ALTER TABLE REBALANCE, could end
with: 'ERROR:  too many sample rows received from gp_acquire_sample_rows
(analyze.c:2545)'.

Root cause:
In 'acquire_sample_rows_dispatcher()' we dispatch
'select pg_catalog.gp_acquire_sample_rows(...)' to all segments in the cluster,
even if the table is distributed only on a subset of segments. ALTER TABLE
REBALANCE didn't touch the data on the excessive segments, from which the table
data was copied into the target subset of segments. Therefore, if we performed
ANALYZE after we'd executed the ALTER TABLE REBALANCE command, but before we'd
actually removed the shrunk segments from the cluster,
'acquire_sample_rows_dispatcher()' received the sample data from the target
segments plus the sample data from the excessive segments. The expected amount
of sample data was already on the target segments, and the addition from the
excessive segments led to the reported error.

Fix:
Truncate the data on the excessive segments at ALTER TABLE REBALANCE once we've
completed the data movement.