### PR TITLE
GG-391 Bump resgroup workflow version (7.x)

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -95,7 +95,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v29
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v31
     with:
       version: 7
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
### Bump resgroup workflow version (7.x) (#412)

Reduced default timeout for resgroup tests.

Currently, resgroup tests use the default timeout of 360 minutes. 
If the tests hang and reach this limit, the GitHub workflow hits its
maximum timeout and cancels all jobs immediately, preventing
logs from being collected (even with `always()` conditions).

This change sets the resgroup test timeout to 3 hours, leaving
an additional 30 minutes for log collection and uploading
results.

Tests:
- timeout: https://github.com/arenadata/greengage/actions/runs/24984222740/job/73156164487