### PR TITLE
Revert gpstart gpsubprocess update

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
@@ -9,7 +9,6 @@ from test.behave_utils import utils
 from test.behave_utils.utils import wait_for_unblocked_transactions
 from gppylib.commands.base import Command
 from gppylib.db import dbconn
-from gppylib import gpsubprocess
 
 def _run_sql(sql, opts=None):
     env = None
@@ -82,17 +81,18 @@ def impl(context, cmd):
     Runs `yes | cmd`.
     """
 
-    p = gpsubprocess.Popen(
+    p = subprocess.Popen(
         ["bash", "-c", "yes | %s" % cmd],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         preexec_fn=_handle_sigpipe,
     )
 
-    # Use communicate2 since communicate from subprocess32 causes an error here.
-    returncode, context.stdout_message, context.stderr_message = p.communicate2()
+    context.stdout_message, context.stderr_message = p.communicate()
+    context.stdout_message = context.stdout_message.decode('utf-8')
+    context.stderr_message = context.stderr_message.decode('utf-8')
 
-    context.ret_code = returncode
+    context.ret_code = p.returncode
 
 @given('the host for the {seg_type} on content {content} is made unreachable')
 def impl(context, seg_type, content):


### PR DESCRIPTION
Revert gpstart gpsubprocess update (#414)

In 37ab4e12ccb793b0f2e0acc2d04589c3613a02da we updated a lot of modules,
replacing `subprocess` with `gpsubprocess`. But the `gpsubprocess` module in
case of python2 relies on `subprocess32` package for managing subprocesses,
which is pretty-much outdated itself (in our project).

So when we try to combine this `subprocesses32` module and coverage utility via
hooking it with site-module, we get following error: 
```
File "test/behave/mgmt_utils/steps/gpstart.py", line 89, in impl
     preexec_fn=_handle_sigpipe,
RuntimeError: not holding the import lock
```

To solve this we should revert changes on `gpstart.py` from mentioned
previously patch, as updating `gpsubprocess` will also solve the problem, but
on the other hand will bring even more errors. 