### PR TITLE
Add '--approve-swap-roles' option

### DIFF
--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -49,6 +49,8 @@ def parseargs():
                       help='show this help message and exit.')
     parser.add_option('--non-interactive-mode', dest="interactive", action='store_false', default=True,
                          help="non-interactive mode, do not require user input for confirmations, use defaults.")
+    parser.add_option('-y', '--approve-swap-roles', dest="approve_swap_roles", action='store_true', default=False,
+                      help="In interactive mode don't ask a user for permission to switch role.")
     parser.add_option('-H', '--target-hosts', dest='target_hosts', metavar='<target_hosts>',
                       help='Set of hostnames where rebalance will distribute segments to')
     parser.add_option('-A', '--add-hosts', dest='add_hosts', metavar='<hosts_to_add>', 

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_sm.py
@@ -748,7 +748,8 @@ class RebalanceSM:
         for step in steps_to_approve:
             msg += str(step)
             msg += '\n'
-        if not interactive_check_yesno(self.options.interactive, msg, 'Approve switchovers?', default = 'Y'):
+        if not interactive_check_yesno(self.options.interactive and not self.options.approve_swap_roles,
+                                       msg, 'Approve switchovers?', default = 'Y'):
             raise Exception('Switchovers were not approved, interrupting execution')
 
         for step in steps_to_approve:

--- a/gpMgmt/doc/ggrebalance_help
+++ b/gpMgmt/doc/ggrebalance_help
@@ -17,7 +17,7 @@ ggrebalance -x <segment_count>
     [{-T hh:mm:ss | -E 'YYYY-MM-DD hh:mm:ss'}]
     [{-D | -S | --no-progress}]
     [--hba-hostnames] [--replay-lag <replay_lag>] [-a]
-    [--non-interactive-mode] [-l <log_dir>] [-q] [-v]
+    [--non-interactive-mode] [--approve-swap-roles] [-l <log_dir>] [-q] [-v]
     [--seed <planner_seed>]
 
 ggrebalance
@@ -25,14 +25,14 @@ ggrebalance
     [{-T hh:mm:ss | -E 'YYYY-MM-DD hh:mm:ss'}]
     [{-D | -S | --no-progress}]
     [--hba-hostnames] [--replay-lag <replay_lag>] [-a]
-    [--non-interactive-mode] [-l <log_dir>] [-q] [-v]
+    [--non-interactive-mode] [--approve-swap-roles] [-l <log_dir>] [-q] [-v]
 
 ggrebalance -r
     [-n <parallel_processes>] [-B <batch_size>]
     [{-T hh:mm:ss | -E 'YYYY-MM-DD hh:mm:ss'}]
     [{-D | -S | --no-progress}]
     [--hba-hostnames] [--replay-lag <replay_lag>] [-a]
-    [--non-interactive-mode] [-l <log_dir>] [-q] [-v]
+    [--non-interactive-mode] [--approve-swap-roles] [-l <log_dir>] [-q] [-v]
 
 ggrebalance -c
 
@@ -190,6 +190,11 @@ OPTIONS
  At the cluster shrink operation, in the interactive mode the shrunken segments
  are stopped via 'smart' mode, and in non-interactive mode they are stopped via
  'fast' mode.
+
+-y, --approve-swap-roles
+ If this option is set, in the interactive mode, the tool does not ask the user
+ to acknowledge role swap ('primary' to 'mirror' and vice versa) for a segment
+ during cluster rebalance.
 
 --inplace-swap-roles
  If this option is set, it is permitted to temporarily place primary and

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -44,7 +44,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 6, row count = 100
          And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 6, row count = 100
 
-    Scenario: test 4. Check rebalance with 'spread' mirror configuration.
+    Scenario: test 4. Check rebalance with 'spread' mirror configuration (plus check '--approve-swap-roles').
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3", with 3 segments on each
@@ -57,7 +57,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance --non-interactive-mode -x 6 --mirror-mode spread -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --approve-swap-roles -x 6 --mirror-mode spread -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And verify that mirror segments are in "spread" configuration


### PR DESCRIPTION
Add the '--approve-swap-roles' option

This patch adds the '--approve-swap-roles' option. If it is set, do not ask
the user in the interactive mode for permission to switch segment's role.
