### PR TITLE
GG-426: Port a check from upstream repo [7X]

### DIFF
--- a/src/bin/pg_upgrade/greengage/check_gp.c
+++ b/src/bin/pg_upgrade/greengage/check_gp.c
@@ -15,6 +15,7 @@
  */
 
 #include "pg_upgrade_greengage.h"
+#include "catalog/pg_magic_oid.h"
 #include "catalog/pg_class_d.h"
 
 #define RELSTORAGE_EXTERNAL	'x'
@@ -31,6 +32,7 @@ static void check_views_with_removed_operators(void);
 static void check_views_with_removed_functions(void);
 static void check_views_with_removed_types(void);
 static void check_for_disallowed_pg_operator(void);
+static void check_views_with_changed_function_signatures(void);
 
 /*
  *	check_greengage
@@ -55,6 +57,7 @@ check_greengage(void)
 	check_views_with_removed_functions();
 	check_views_with_removed_types();
 	check_for_disallowed_pg_operator();
+	check_views_with_changed_function_signatures();
 }
 
 /*
@@ -1147,6 +1150,99 @@ check_for_disallowed_pg_operator(void)
 					 "| You will need to remove the disallowed OPERATOR =>\n"
 					 "| from the list of databases in the file:\n"
 					 "|    %s\n\n", output_path);
+	}
+	else
+		check_ok();
+}
+
+static void
+check_views_with_changed_function_signatures()
+{
+	if (GET_MAJOR_VERSION(old_cluster.major_version) > 904)
+		return;
+
+	char  output_path[MAXPGPATH];
+	FILE *script = NULL;
+	bool  found = false;
+	int   dbnum;
+	int   i_viewname;
+
+	prep_status("Checking for views with functions having changed signatures");
+
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir, "views_with_changed_function_signatures.txt");
+
+	for (dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
+	{
+		PGresult   *res;
+		int			ntups;
+		int			rowno;
+		DbInfo	   *active_db = &old_cluster.dbarr.dbs[dbnum];
+		PGconn	   *conn;
+		bool		db_used = false;
+
+		conn = connectToServer(&old_cluster, active_db->db_name);
+
+		/*
+		 * Disabling track_counts results in a large performance improvement of
+		 * several orders of magnitude when walking the views. This is because
+		 * calling try_relation_open to get a handle of the view calls
+		 * pgstat_initstats which has been profiled to be very expensive. For
+		 * our purposes, this is not needed and disabled for performance.
+		 */
+		PQclear(executeQueryOrDie(conn, "SET track_counts TO off;"));
+
+		/* Install check support function */
+		PQclear(executeQueryOrDie(conn,
+								  "CREATE OR REPLACE FUNCTION "
+								  "public.view_has_changed_function_signatures(OID) "
+								  "RETURNS BOOL "
+								  "AS '$libdir/pg_upgrade_support' "
+								  "LANGUAGE C STRICT;"));
+		res = executeQueryOrDie(conn,
+								"SELECT pg_catalog.quote_ident(n.nspname) "
+								"|| '.' || pg_catalog.quote_ident(c.relname) AS badviewname "
+								"FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n on c.relnamespace=n.oid "
+								"WHERE c.relkind = 'v' "
+								"AND c.oid >= %d "
+								"AND public.view_has_changed_function_signatures(c.oid) = TRUE;", FirstNormalObjectId);
+
+		PQclear(executeQueryOrDie(conn, "DROP FUNCTION public.view_has_changed_function_signatures(OID);"));
+		PQclear(executeQueryOrDie(conn, "RESET track_counts;"));
+
+		ntups = PQntuples(res);
+		i_viewname = PQfnumber(res, "badviewname");
+		for (rowno = 0; rowno < ntups; rowno++)
+		{
+			found = true;
+			if (script == NULL && (script = fopen(output_path, "w")) == NULL)
+				pg_fatal("Could not create necessary file:  %s\n", output_path);
+			if (!db_used)
+			{
+				fprintf(script, "Database: %s\n", active_db->db_name);
+				db_used = true;
+			}
+			fprintf(script, "  %s\n", PQgetvalue(res, rowno, i_viewname));
+		}
+
+		PQclear(res);
+		PQfinish(conn);
+	}
+
+	if (script)
+		fclose(script);
+
+	if (found)
+	{
+		pg_log(PG_REPORT, "fatal\n");
+		gp_fatal_log(
+			"| Your installation contains views that use\n"
+			"| functions with changed signatures.\n"
+			"| These functions are present on the target version but with\n"
+			"| different arguments and/or return values.\n"
+			"| These views must be updated to use functions supported in the\n"
+			"| target version or removed before upgrade can continue. A list\n"
+			"| of the problem views is in the file:\n\t%s\n\n", output_path);
 	}
 	else
 		check_ok();


### PR DESCRIPTION
Views that use functions with changed signatures will cause upgrade to fail. This happens during metadata restore on the target cluster because pg_restore will error trying to create a view using functions with changed arguments and/or return types. This is not ideal as we could be many hours into upgrade before a view using a function with changed signature causes pg_upgrade to fail This check calls a support function on the source cluster to check if views using such functions with changed signature exist.

(cherry picked from commit 3c0ffffc651fbbe9febd005eee4cd4022fff2bb2)

Changes compared to the original commit:
- Use fully qualified names, and remove queries that change schemas.
- Properly format error message.
- Close created file.
- Unhardcode FirstNormalObjectId.

---

MERGE WITH REBASE