### PR TITLE
ADBDEV-9727: Fix loging the Exceptions in gplog

### DIFF
--- a/gpMgmt/bin/gppylib/gplog.py
+++ b/gpMgmt/bin/gppylib/gplog.py
@@ -320,10 +320,13 @@ class EncodingFileHandler(logging.FileHandler):
         logging.FileHandler.__init__(self, filename, mode, encoding, delay)
 
     def emit(self, record):
+        if not isinstance(record.msg, (string_types, binary_type)):
+            try:
+                record.msg = str(record.msg)
+            except UnicodeEncodeError:
+                record.msg = "Can't decode exception message"
         if isinstance(record.msg, binary_type):
-            record.msg = record.msg.decode('utf-8')
-        elif not isinstance(record.msg, text_type):
-            record.msg = text_type(record.msg)
+            record.msg = record.msg.decode('utf-8', errors='replace')
         logging.FileHandler.emit(self, record)
 
 
@@ -336,8 +339,11 @@ class EncodingStreamHandler(logging.StreamHandler):
         logging.StreamHandler.__init__(self, strm)
 
     def emit(self, record):
+        if not isinstance(record.msg, (string_types, binary_type)):
+            try:
+                record.msg = str(record.msg)
+            except UnicodeEncodeError:
+                record.msg = "Can't decode exception message"
         if isinstance(record.msg, binary_type):
-            record.msg = record.msg.decode('utf-8')
-        elif not isinstance(record.msg, text_type):
-            record.msg = text_type(record.msg)
+            record.msg = record.msg.decode('utf-8', errors='replace')
         logging.StreamHandler.emit(self, record)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gplog.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gplog.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) Greenplum Inc 2008. All Rights Reserved. 
 #
@@ -27,6 +28,23 @@ class GplogTestCase(GpTestCase):
         gplog._LOGGER = None
         gplog.get_unittest_logger()
         gplog.log_to_file_only("should not crash")
+
+    def test_log_exception_with_unicode(self):
+        logger = gplog.get_default_logger()
+        logger.exception(Exception(u"тест".encode('utf-8')))
+        logger.exception(Exception(u"тест"))
+
+    def test_log_unicode(self):
+        logger = gplog.get_default_logger()
+        logger.log(logging.INFO, u"тест")
+
+    def test_log_binary_string(self):
+        logger = gplog.get_default_logger()
+        logger.log(logging.INFO, b"test")
+
+    def test_log_binary_string_with_unicode(self):
+        logger = gplog.get_default_logger()
+        logger.log(logging.INFO, u"тест".encode('utf-8'))
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
In Python 2, if an Exception contains unicode characters, an attempt to convert
it to unicode will result in an error.

This patch restores the old behavior. If we log an Exception, we first cast it
to the str. After that, if it is a byte string, then decode it to the unicode.
If the Exception contains unicode, then catch it and log a fixed message.