### PR TITLE
GG-396: Fix assert trigger when vacuum AO table after ggupgrade

### DIFF
--- a/src/bin/pg_upgrade/pg_upgrade.c
+++ b/src/bin/pg_upgrade/pg_upgrade.c
@@ -241,26 +241,15 @@ main(int argc, char **argv)
 		 * however. So we still need to restore those separately on each
 		 * server.
 		 *
-		 * Because we are concerned with 6.x -> 7.x migration here, this
-		 * step should be done only for segments, because starting from
+		 * Because we are concerned with 6.x -> 7.x (or further) migration here,
+		 * this step should be done only for segments, because starting from
 		 * Greengage 7, pg_aoseg table entries are almost never created
-		 * on the coordinator. With a notable exception:
-		 *
-		 * 'ALTER TABLE ... REPACK BY COLUMNS (...)' and 'CLUSTER ...'
-		 * queries do create an oddly specific entry for RESERVED_SEGNO
-		 * segfile of the AO table with zero tuples. It looks like a flaw
-		 * in the logic, moreover, these commands are absent in 6.x.
-		 *
-		 * If any other pg_aoseg entry (that is, not similar to the one
-		 * created by the aforementioned queries) is present in the target
-		 * cluser, it would cause a failure to 'VACUUM' corresponding
-		 * AO table (see vacuum_ao.c , line 378).
+		 * on the coordinator.
 		 *
 		 * 'restore_aosegment_tables' function also deals with other tables,
 		 * so, in total, when upgrading the coordinator:
 		 *
-		 * Don't copy pg_aoseg tables. Coordinator can always recreate
-		 * necessary entries in the above edge case.
+		 * Don't copy pg_aoseg tables.
 		 *
 		 * Don't copy pg_aoblkdir and pg_aovisimap tables, because they should
 		 * be empty too.

--- a/src/bin/pg_upgrade/pg_upgrade.c
+++ b/src/bin/pg_upgrade/pg_upgrade.c
@@ -243,9 +243,33 @@ main(int argc, char **argv)
 		 *
 		 * Because we are concerned with 6.x -> 7.x migration here, this
 		 * step should be done only for segments, because starting from
-		 * Greengage 7, pg_aoseg tables on the coordinator are expected
-		 * to remain empty. Don't copy pg_aoblkdir and pg_aovisimap tables
-		 * either, they should be empty too.
+		 * Greengage 7, pg_aoseg table entries are almost never created
+		 * on the coordinator. With a notable exception:
+		 *
+		 * 'ALTER TABLE ... REPACK BY COLUMNS (...)' and 'CLUSTER ...'
+		 * queries do create an oddly specific entry for RESERVED_SEGNO
+		 * segfile of the AO table with zero tuples. It looks like a flaw
+		 * in the logic, moreover, these commands are absent in 6.x.
+		 *
+		 * If any other pg_aoseg entry (that is, not similar to the one
+		 * created by the aforementioned queries) is present in the target
+		 * cluser, it would cause a failure to 'VACUUM' corresponding
+		 * AO table (see vacuum_ao.c , line 378).
+		 *
+		 * 'restore_aosegment_tables' function also deals with other tables,
+		 * so, in total, when upgrading the coordinator:
+		 *
+		 * Don't copy pg_aoseg tables. Coordinator can always recreate
+		 * necessary entries in the above edge-case.
+		 *
+		 * Don't copy pg_aoblkdir and pg_aovisimap tabes, because they should
+		 * be empty too.
+		 *
+		 * Don't copy gp_fastsequence table, it will be filled when recreating
+		 * AO tables.
+		 *
+		 * (the difference between versions comes mainly from
+		 *  the commit 5778f31124d5737e18d76f8d06f07f96c31c8be7)
 		 */
 		restore_aosegment_tables();
 	}

--- a/src/bin/pg_upgrade/pg_upgrade.c
+++ b/src/bin/pg_upgrade/pg_upgrade.c
@@ -260,9 +260,9 @@ main(int argc, char **argv)
 		 * so, in total, when upgrading the coordinator:
 		 *
 		 * Don't copy pg_aoseg tables. Coordinator can always recreate
-		 * necessary entries in the above edge-case.
+		 * necessary entries in the above edge case.
 		 *
-		 * Don't copy pg_aoblkdir and pg_aovisimap tabes, because they should
+		 * Don't copy pg_aoblkdir and pg_aovisimap tables, because they should
 		 * be empty too.
 		 *
 		 * Don't copy gp_fastsequence table, it will be filled when recreating

--- a/src/bin/pg_upgrade/pg_upgrade.c
+++ b/src/bin/pg_upgrade/pg_upgrade.c
@@ -231,15 +231,24 @@ main(int argc, char **argv)
 		create_new_objects();
 	}
 
-	/*
-	 * In a segment, the data directory already contains all the objects,
-	 * because the segment is initialized by taking a physical copy of the
-	 * upgraded QD data directory. The auxiliary AO tables - containing
-	 * information about the segment files, are different in each server,
-	 * however. So we still need to restore those separately on each
-	 * server.
-	 */
-	restore_aosegment_tables();
+	if (!is_greengage_dispatcher_mode())
+	{
+		/*
+		 * In a segment, the data directory already contains all the objects,
+		 * because the segment is initialized by taking a physical copy of the
+		 * upgraded QD data directory. The auxiliary AO tables - containing
+		 * information about the segment files, are different in each server,
+		 * however. So we still need to restore those separately on each
+		 * server.
+		 *
+		 * Because we are concerned with 6.x -> 7.x migration here, this
+		 * step should be done only for primary segments, because starting
+		 * from Greengage 7, pg_aoseg tables on the coordinator are expected
+		 * to remain empty. Don't copy pg_aoblkdir and pg_aovisimap tables
+		 * either, they should be empty too.
+		 */
+		restore_aosegment_tables();
+	}
 
 	if (is_greengage_dispatcher_mode())
 	{

--- a/src/bin/pg_upgrade/pg_upgrade.c
+++ b/src/bin/pg_upgrade/pg_upgrade.c
@@ -242,8 +242,8 @@ main(int argc, char **argv)
 		 * server.
 		 *
 		 * Because we are concerned with 6.x -> 7.x migration here, this
-		 * step should be done only for primary segments, because starting
-		 * from Greengage 7, pg_aoseg tables on the coordinator are expected
+		 * step should be done only for segments, because starting from
+		 * Greengage 7, pg_aoseg tables on the coordinator are expected
 		 * to remain empty. Don't copy pg_aoblkdir and pg_aovisimap tables
 		 * either, they should be empty too.
 		 */


### PR DESCRIPTION
Vacuuming AO table after pg_upgrade from 6.x to 7.x triggered 
an assertion inside AppendOnlyCompact function. 
 
It was caused by the difference in the handling of the pg_aoseg 
tables on the coordinator:

- in 6.x, these tables contain the totals of the whole distributed 
  table
- in 7.x, the code expects them to remain empty. Otherwise it 
  is possible to reach executor-only code.
 
Note that there is an exception to this rule in 7.x:
`ALTER TABLE ... REPACK BY COLUMNS (...)` and `CLUSTER ...`
queries do create an oddly specific entry for RESERVED_SEGNO
segfile of the AO table with zero tuples. But these commands are 
absent in 6.x, so pg_upgrade code can ignore this edge case.
 
Therefore the most simple fix is to skip copying these tables on 
the coordinator during upgrade. Also, don't copy pg_aoblkdir, 
pg_aovisimap and gp_fastsequence tables.

This patch is done as a part of gguprade migration.
Specifically, it fixes vacuum_freeze_tables test.

Ticket: GG-396