### PR TITLE
GG-474: Use Azure Ubuntu mirror in docker build 7.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v30
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v33
     with:
       version: 7
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
## Use Azure Ubuntu mirror in docker build 7.x (#431)

- [ci (build): bump version to v33](https://github.com/GreengageDB/greengage/commit/350147fe50a95b1245966e268d474f2eceb7a82e)

## New in CI `v33` version:

Fix: drop buildx, redirect apt to Azure mirror when available

- Remove unused `docker/setup-buildx-action` step
- Resolve `azure.archive.ubuntu.com` IP at build time and
  inject via `--add-host` for `archive.ubuntu.com` and
  `security.ubuntu.com`
- Fall back to default mirrors if Azure mirror is unreachable
- Update README to reflect removed Buildx step and new mirror behaviour

Task: [CI-5617](https://tracker.yandex.ru/CI-5617)