### PR TITLE
GG-481: Add scripts to test pg_upgrade migration in a demo cluster

### DIFF
--- a/ci/Dockerfile.pg_upgrade
+++ b/ci/Dockerfile.pg_upgrade
@@ -1,0 +1,38 @@
+# Copied from ggupgrade/new/ci/Dockerfile
+
+ARG GGDB6_IMAGE=ghcr.io/greengagedb/greengage/ggdb6_ubuntu:latest
+ARG GGDB7_IMAGE=ghcr.io/greengagedb/greengage/ggdb7_ubuntu:latest
+
+FROM $GGDB6_IMAGE AS ggdb6
+
+RUN set -eux; \
+    source gpdb_src/concourse/scripts/common.bash; \
+    install_and_configure_gpdb
+
+FROM $GGDB7_IMAGE
+
+ENV GREENGAGE6_SRC=/home/gpadmin/ggdb6_src \
+    GREENGAGE7_SRC=/home/gpadmin/gpdb_src \
+    GREENGAGE6_INSTALLATION=/usr/local/greengage-db-6X \
+    GREENGAGE7_INSTALLATION=/usr/local/greengage-db-devel
+
+COPY --from=ggdb6 --chown=1000:1000 /home/gpadmin/gpdb_src $GREENGAGE6_SRC
+COPY --from=ggdb6 --chown=1000:1000 /usr/local/greengage-db-devel $GREENGAGE6_INSTALLATION
+
+RUN set -eux; \
+    . /etc/os-release; \
+    apt update; \
+    if [ "$VERSION_ID" = "22.04" ]; then \
+      apt install python2 python2-dev python-pip -y; \
+      ln -sf /bin/python2 /bin/python; \
+      python -m pip install future==0.16; \
+    else \
+      apt install python-is-python3; \
+      python -m pip install future==1.0.0; \
+    fi
+
+RUN set -eux; \
+    export CONFIGURE_FLAGS=; \
+    source gpdb_src/concourse/scripts/common.bash; \
+    install_and_configure_gpdb; \
+    chown -R 1000:1000 $GREENGAGE7_INSTALLATION

--- a/src/bin/pg_upgrade/Makefile
+++ b/src/bin/pg_upgrade/Makefile
@@ -53,10 +53,10 @@ greengage/aomd_filehandler.c: $(top_srcdir)/src/backend/access/appendonly/aomd_f
 NOTSUBMAKEMAKE=$(MAKE)
 
 check: test_gpdb.sh all
-	bash $< -C -r -s -o $(top_builddir)/gpAux/gpdemo/datadirs/ -b $(DESTDIR)$(bindir)
+	bash $< -C -r -s -O $(top_builddir)/gpAux/gpdemo/datadirs/ -b $(DESTDIR)$(bindir)
 
 perfcheck: test_gpdb.sh all
-	bash $< -p -r -o $(top_builddir)/gpAux/gpdemo/datadirs/ -b $(DESTDIR)$(bindir)
+	bash $< -p -r -O $(top_builddir)/gpAux/gpdemo/datadirs/ -b $(DESTDIR)$(bindir)
 
 # installcheck is not supported because there's no meaningful way to test
 # pg_upgrade against a single already-running server

--- a/src/bin/pg_upgrade/README.gpdb
+++ b/src/bin/pg_upgrade/README.gpdb
@@ -25,8 +25,8 @@ Extensions to upstream pg_upgrade
 Functionality for restoring the append-only catalog relations is in
 aotable.c.
 
-Upgrading from 5.0 to 6.0
--------------------------
+Upgrading from 5.0 to 6.0 (Largely outdated)
+--------------------------------------------
 
 The name_pattern_ops and pattern equality operators were removed in 6.0 and
 text equality is treated like bitwise equality. This will cause internal sort
@@ -50,6 +50,18 @@ intention is for this to be a quick test that all objects are handled by
 pg_upgrade; upgrade testing still requires the full run across all
 segments/mirrors. The smoketest can be invoked by "make check" in the
 contrib/pg_upgrade directory.
+
+Also, it is worth mentioning that most of the pg_upgrade tests are performed
+in the ggupgrade repository. This decision was made by the Greenplum team to
+reduce amount of code duplication between ggupgrade and test scripts.
+
+In spite of this, we have added a 6.x to 7.x migration test to the core
+Greengage repository. The reason being that is it simply more convenient
+to test pg_upgrade from the same repository where it is located.
+
+For a more detailed overview of the existing tests, see README.test.md
+and TESTING files
+
 
 GPDB Merge notice:
 ------------------

--- a/src/bin/pg_upgrade/README.gpdb
+++ b/src/bin/pg_upgrade/README.gpdb
@@ -52,8 +52,8 @@ segments/mirrors. The smoketest can be invoked by "make check" in the
 contrib/pg_upgrade directory.
 
 Also, it is worth mentioning that most of the pg_upgrade tests are performed
-in the ggupgrade repository. This decision was made by the Greenplum team to
-reduce amount of code duplication between ggupgrade and test scripts.
+in the ggupgrade repository. This decision was made initially to reduce
+amount of code duplication between ggupgrade and test scripts.
 
 In spite of this, we have added a 6.x to 7.x migration test to the core
 Greengage repository. The reason being that is it simply more convenient

--- a/src/bin/pg_upgrade/README.test.md
+++ b/src/bin/pg_upgrade/README.test.md
@@ -35,8 +35,22 @@ bash   ${GREENGAGE7_SRC}/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh
 Docker image already has all the necessary environment variables set to run the test WITHOUT a schema. The only thing left is to setup gpadmin user:
 ```bash
 docker build -f ci/Dockerfile.pg_upgrade -t gpdb7_pgupgrade:latest .
-docker run --rm gpdb7_pgupgrade bash -c \
-    "gpdb_src/concourse/scripts/setup_gpadmin_user.bash && su gpadmin /home/gpadmin/gpdb_src/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh"
+docker run --rm \
+    gpdb7_pgupgrade bash -c \
+    "gpdb_src/concourse/scripts/setup_gpadmin_user.bash; \
+     su gpadmin /home/gpadmin/gpdb_src/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh"
+```
+
+Note, that the command above will pull the latest Greengage images from the github repository, meaning that they wouldn't have your local changes.
+Therefore, when building the pg_upgrade image, it is possible to provide locally built Greengage images via `GGDB6_IMAGE` and `GGDB7_IMAGE` build arguments. Any combination of images (e.g., none, only Greengage 6, only Greengage 7, or both Greengage 6 and Greengage 7) will work. Here is an example how to specify a local Greengage 7 image:
+```bash
+# Assuming that you at the root of the Greengage 7 source code
+docker build -t gpdb7_u22:latest -f ci/Dockerfile.ubuntu .
+docker build -f ci/Dockerfile.pg_upgrade -t gpdb7_pgupgrade:latest --build-arg GGDB7_IMAGE=gpdb7_u22:latest .
+docker run --rm \
+    gpdb7_pgupgrade bash -c \
+    "gpdb_src/concourse/scripts/setup_gpadmin_user.bash; \
+     su gpadmin /home/gpadmin/gpdb_src/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh"
 ```
 
 To specify a schema, mount a directory with it into the docker image:

--- a/src/bin/pg_upgrade/README.test.md
+++ b/src/bin/pg_upgrade/README.test.md
@@ -44,7 +44,7 @@ docker run --rm \
 Note, that the command above will pull the latest Greengage images from the github repository, meaning that they wouldn't have your local changes.
 Therefore, when building the pg_upgrade image, it is possible to provide locally built Greengage images via `GGDB6_IMAGE` and `GGDB7_IMAGE` build arguments. Any combination of images (e.g., none, only Greengage 6, only Greengage 7, or both Greengage 6 and Greengage 7) will work. Here is an example how to specify a local Greengage 7 image:
 ```bash
-# Assuming that you at the root of the Greengage 7 source code
+# Assuming that the current directory is the root of the Greengage 7 source code
 docker build -t gpdb7_u22:latest -f ci/Dockerfile.ubuntu .
 docker build -f ci/Dockerfile.pg_upgrade -t gpdb7_pgupgrade:latest --build-arg GGDB7_IMAGE=gpdb7_u22:latest .
 docker run --rm \

--- a/src/bin/pg_upgrade/README.test.md
+++ b/src/bin/pg_upgrade/README.test.md
@@ -1,0 +1,67 @@
+# How to run tests
+
+## Overview
+
+pg_upgrade has several greengage-specific testing files. These include:
+
+- `test_gpdb.sh` - the core script to perform and test the upgrade, which does all the heavy lifting. It is directly run from the regression test suite via `make check` recipe, but only between the same version (e.g from Greengage7 to Greengage7).
+- `pg_upgrade_run_6X_to_7X_migration.sh` - small wrapper to run the above test between Greengage6 and Greengage7.
+- `Dockerfile.pg_upgrade` - creates an image intended to run the above tests on the CI.
+
+Here it is shown how to run pg_upgrade tests using `pg_upgrade_run_6X_to_7X_migration.sh`. `test_gpdb.sh` can be run by manually following steps in the `pg_upgrade_run_6X_to_7X_migration.sh`.
+
+## Running tests locally
+
+To run `pg_upgrade_run_6X_to_7X_migration.sh` locally, it is necessary to specify the following environment variables:
+- GREENGAGE6_SRC - directory of the Greengage6 source code.
+- GREENGAGE7_SRC - directory of the Greengage7 source code.
+- GREENGAGE6_INSTALLATION - directory where the Greengage6 installation is located (i.e., after make install).
+- GREENGAGE7_INSTALLATION - directory where the Greengage7 installation is located (i.e., after make install).
+- SQL_SCHEMA - optional path to an sql file that will be loaded before performing the upgrade. If it is not specified,
+  the upgrade will be performed on an empty cluster.
+
+For example:
+```bash
+export GREENGAGE6_SRC=/home/gpadmin/ggdb6_src
+export GREENGAGE7_SRC=/home/gpadmin/gpdb7_src
+export GREENGAGE6_INSTALLATION=/usr/local/greengage-db-6X
+export GREENGAGE7_INSTALLATION=/usr/local/greengage-db-7X
+export SQL_SCHEMA=/home/gpadmin/dump.sql
+bash   ${GREENGAGE7_SRC}/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh
+```
+
+## Running test from the image
+
+All the necessary environment variables are already present inside the docker image, so the only thing left is to setup gpadmin user:
+```bash
+docker build -f ci/Dockerfile.pg_upgrade -t gpdb7_pgupgrade:latest .
+docker run --rm gpdb7_pgupgrade bash -c \
+    "gpdb_src/concourse/scripts/setup_gpadmin_user.bash && su gpadmin /home/gpadmin/gpdb_src/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh"
+```
+
+Note, that SQL_SCHEMA is empty by default. To specify a schema, mount a directory with it into the docker image:
+```bash
+mkdir dump_dir
+echo "create database test2;" > dump_dir/dump.sql
+docker run --rm \
+	-v $(pwd)/dump_dir:/dump_dir \
+	gpdb7_pgupgrade bash -c \
+	"export SQL_SCHEMA=/dump_dir/dump.sql; \
+	 gpdb_src/concourse/scripts/setup_gpadmin_user.bash; \
+	 su gpadmin /home/gpadmin/gpdb_src/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh;"
+```
+
+To collect execution logs, mount an additional volume:
+```bash
+mkdir logs
+docker run --rm \
+	-v $(pwd)/dump_dir:/dump_dir \
+	-v $(pwd)/logs:/logs \
+	gpdb7_pgupgrade bash -c \
+	"export SQL_SCHEMA=/dump_dir/dump.sql; \
+	 gpdb_src/concourse/scripts/setup_gpadmin_user.bash; \
+	 su gpadmin /home/gpadmin/gpdb_src/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh; \
+	 cp /home/gpadmin/gpdb_src/src/bin/pg_upgrade/tmp_check/dump1.sql /logs/dump1.sql; \
+	 cp /home/gpadmin/gpdb_src/src/bin/pg_upgrade/tmp_check/dump2.sql /logs/dump2.sql; \
+	 cp /home/gpadmin/gpdb_src/src/bin/pg_upgrade/regression.diffs /logs/regression.diffs;"
+```

--- a/src/bin/pg_upgrade/README.test.md
+++ b/src/bin/pg_upgrade/README.test.md
@@ -30,7 +30,7 @@ export SQL_SCHEMA=/home/gpadmin/dump.sql
 bash   ${GREENGAGE7_SRC}/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh
 ```
 
-## Running test from the image
+## Running tests from the image
 
 All the necessary environment variables are already present inside the docker image, so the only thing left is to setup gpadmin user:
 ```bash

--- a/src/bin/pg_upgrade/README.test.md
+++ b/src/bin/pg_upgrade/README.test.md
@@ -32,14 +32,14 @@ bash   ${GREENGAGE7_SRC}/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh
 
 ## Running tests from the image
 
-All the necessary environment variables are already present inside the docker image, so the only thing left is to setup gpadmin user:
+Docker image already has all the necessary environment variables set to run the test WITHOUT a schema. The only thing left is to setup gpadmin user:
 ```bash
 docker build -f ci/Dockerfile.pg_upgrade -t gpdb7_pgupgrade:latest .
 docker run --rm gpdb7_pgupgrade bash -c \
     "gpdb_src/concourse/scripts/setup_gpadmin_user.bash && su gpadmin /home/gpadmin/gpdb_src/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh"
 ```
 
-Note, that SQL_SCHEMA is empty by default. To specify a schema, mount a directory with it into the docker image:
+To specify a schema, mount a directory with it into the docker image:
 ```bash
 mkdir dump_dir
 echo "create database test2;" > dump_dir/dump.sql

--- a/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh
+++ b/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh
@@ -1,0 +1,57 @@
+# Helper script for running src/bin/pg_upgrade/test_gpdb.sh to
+# upgrade between Greengage6 and Greengage7
+
+set -euo pipefail
+
+# We could accept command line arguments instead of relying on environment variables,
+# but it seems too much for a 50-line script. In any case, perform some redundant
+# checks before running the script.
+
+if [ -z "${GREENGAGE7_INSTALLATION:-}" ] || \
+   [ -z "${GREENGAGE6_INSTALLATION:-}" ] || \
+   [ -z "${GREENGAGE7_SRC:-}" ] || \
+   [ -z "${GREENGAGE6_SRC:-}" ]; then
+	echo "This scrips expects the following environment variables to be set:"
+    echo "  GREENGAGE7_INSTALLATION"
+    echo "  GREENGAGE6_INSTALLATION"
+    echo "  GREENGAGE7_SRC"
+    echo "  GREENGAGE6_SRC"
+    exit 1
+fi
+
+SQL_SCHEMA=${SQL_SCHEMA:-}
+if [ -z "${SQL_SCHEMA}" ]; then
+    echo "SQL_SCHEMA environment variable is not set. This test will be performed on an empty cluster."
+else
+    echo "SQL_SCHEMA is set. This test will load \"${SQL_SCHEMA}\" before performing upgrade."
+fi
+
+set -x
+
+# Create demo cluster
+export PORT_BASE=7000
+cd     ${GREENGAGE6_SRC}/gpAux/gpdemo
+source ${GREENGAGE6_INSTALLATION}/greengage_path.sh
+make   create-demo-cluster
+
+# Setup environment
+export PGPORT=7000
+export MASTER_DATA_DIRECTORY=${GREENGAGE6_SRC}/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+
+# Load the schema
+if [ -n "${SQL_SCHEMA}" ]; then
+    psql template1 -f ${SQL_SCHEMA}
+fi
+
+# Create regression database if it doesn't exist.
+# psql can report an error if it does,
+# but the returned exit code is 0 either way.
+echo 'CREATE DATABASE regression;' | psql template1 -f-
+
+# And finally, run the test
+pushd ${GREENGAGE7_SRC}/src/bin/pg_upgrade
+./test_gpdb.sh \
+    -b ${GREENGAGE7_INSTALLATION}/bin \
+    -B ${GREENGAGE6_INSTALLATION}/bin \
+    -O ${GREENGAGE6_SRC}/gpAux/gpdemo/datadirs/
+popd

--- a/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh
+++ b/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh
@@ -35,7 +35,9 @@ fi
 
 set -x
 
-# Create demo cluster
+# Create Greengage 6 demo cluster.
+# Its default PORT_BASE is 6000, which is inconsistent with Greengage 7 and PGPORT
+# environment variable below.
 export PORT_BASE=7000
 cd     ${GREENGAGE6_SRC}/gpAux/gpdemo
 source ${GREENGAGE6_INSTALLATION}/greengage_path.sh

--- a/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh
+++ b/src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh
@@ -7,15 +7,22 @@ set -euo pipefail
 # but it seems too much for a 50-line script. In any case, perform some redundant
 # checks before running the script.
 
-if [ -z "${GREENGAGE7_INSTALLATION:-}" ] || \
-   [ -z "${GREENGAGE6_INSTALLATION:-}" ] || \
-   [ -z "${GREENGAGE7_SRC:-}" ] || \
-   [ -z "${GREENGAGE6_SRC:-}" ]; then
-	echo "This scrips expects the following environment variables to be set:"
-    echo "  GREENGAGE7_INSTALLATION"
-    echo "  GREENGAGE6_INSTALLATION"
-    echo "  GREENGAGE7_SRC"
-    echo "  GREENGAGE6_SRC"
+
+all_paths_are_set=true
+
+for path in GREENGAGE7_INSTALLATION \
+            GREENGAGE6_INSTALLATION \
+            GREENGAGE7_SRC \
+            GREENGAGE6_SRC;
+do
+    if [ -z ${!path:-} ]; then
+        echo "This test expects the following environment variable: ${path}"
+        all_paths_are_set=false
+    fi
+done
+
+if [ ${all_paths_are_set} = false ]; then
+    echo "Not all required enviroment variable are set. Exiting."
     exit 1
 fi
 

--- a/src/bin/pg_upgrade/test_gpdb.sh
+++ b/src/bin/pg_upgrade/test_gpdb.sh
@@ -211,7 +211,7 @@ usage()
 {
 	local appname=`basename $0`
 	echo "usage: $appname -o <dir> -b <dir> [options]"
-	echo " -o <dir>     old cluster data directory"
+	echo " -O <dir>     old cluster data directory"
 	echo " -b <dir>     new cluster executable directory"
 	echo " -B <dir>     old cluster executable directory (defaults to new binaries)"
 	echo " -s           Run smoketest only"
@@ -312,9 +312,9 @@ main() {
 	local temp_root=`pwd`/tmp_check
 	local base_dir=`pwd`
 	
-	while getopts ":o:b:B:sCkKmrp" opt; do
+	while getopts ":O:b:B:sCkKmrp" opt; do
 		case ${opt} in
-			o )
+			O )
 				realpath OLD_DATADIR "${OPTARG}"
 				;;
 			b )
@@ -418,7 +418,7 @@ main() {
 	
 	########################## START: NEW cluster creation
 	
-	echo "Switching to gpdb-6 env..."
+	echo "Switching to gpdb-7 env..."
 	. ${NEW_BINDIR}/../greengage_path.sh
 	
 	# Create a new gpdemo cluster in the NEW_DATADIR. Using the new datadir for the
@@ -426,7 +426,7 @@ main() {
 	# using a demo cluster anyway, this is acceptable.
 	export DEMO_PORT_BASE=17432
 	export NUM_PRIMARY_MIRROR_PAIRS=3
-	export COORDINATOR_DATADIR=${temp_root}
+	export COORDINATOR_DATADIR=${temp_root} # Assuming that $NEW_DATADIR is $temp_root
 	cp ${OLD_DATADIR}/../lalshell .
 	
 	LANG=en_US.utf8 BLDWRAP_POSTGRES_CONF_ADDONS=fsync=off ${temp_root}/../../../../gpAux/gpdemo/demo_cluster.sh ${DEMOCLUSTER_OPTS}

--- a/src/bin/pg_upgrade/test_gpdb.sh
+++ b/src/bin/pg_upgrade/test_gpdb.sh
@@ -5,7 +5,7 @@
 # Test driver for upgrading a Greengage cluster with pg_upgrade.
 # The upgraded cluster will be a newly created gpdemo
 # cluster created by this script.  This test assumes that all pre-upgrade 
-# clusters, whether for 5 or 6, have been created as standard gpdemo clusters.
+# clusters, whether for 6 or 7, have been created as standard gpdemo clusters.
 # This test is independent of the user data contents of the pre-upgrade 
 # database, though of course you can run ICW into the gpdemo cluster before
 # upgrading to get some coverage of object types.
@@ -15,16 +15,17 @@
 # upgrade it performs another pg_dumpall, if the two dumps match then the 
 # upgrade created a new identical copy of the cluster.
 
-# Here are two example runs, one for a 6 cluster and then one for a 5 cluster:
-# bash test_gpdb.sh -b /usr/local/gpdb/bin -o ~/workspace/gpdb/gpAux/gpdemo/datadirs
-# bash test_gpdb.sh -b /usr/local/gpdb/bin -o ~/workspace/gpdb5/gpAux/gpdemo/datadirs
-#                   -B /usr/local/gpdb5/bin
+# Here are two example runs, one for a 7 cluster and then one for a 6 cluster:
+# bash test_gpdb.sh -b /usr/local/gpdb/bin -O ~/workspace/gpdb/gpAux/gpdemo/datadirs
+# bash test_gpdb.sh -b /usr/local/gpdb/bin -O ~/workspace/gpdb6/gpAux/gpdemo/datadirs
+#                   -B /usr/local/gpdb6/bin
 #
 # Keep in mind this script is relatively fragile since it depends on specific
 # paths and locations relative to the standard gpdemo cluster.
 #
-# It has been tested on demo clusters transitioning from (6 to 6)
-# or from (5 to 6; on a private branch).
+# It has been tested on demo clusters transitioning from (7 to 7).
+# Details on how to run transition from 6 to 7 are described in
+# src/bin/pg_upgrade/README.test.md
 
 OLD_BINDIR=
 OLD_DATADIR=
@@ -210,7 +211,7 @@ upgrade_segment()
 usage()
 {
 	local appname=`basename $0`
-	echo "usage: $appname -o <dir> -b <dir> [options]"
+	echo "usage: $appname -O <dir> -b <dir> [options]"
 	echo " -O <dir>     old cluster data directory"
 	echo " -b <dir>     new cluster executable directory"
 	echo " -B <dir>     old cluster executable directory (defaults to new binaries)"


### PR DESCRIPTION
This patch adds infrastructure to run src/bin/pg_upgrade/test_gpdb.sh
test between Greengage 6 and Greengage 7.

The list of changes is as follows:
- src/bin/pg_upgrade/test_gpdb.sh is slightly modified to make
  flags a bit more consistent. This change also affects
  src/bin/pg_upgrade/Makefile.
- src/bin/pg_upgrade/pg_upgrade_run_6X_to_7X_migration.sh is added.
  It is the main script to run the test between different versions.
- ci/Dockerfile.pg_upgrade file is added to run the new test on the
  CI. The CI action itself should be added in the future.
- src/bin/pg_upgrade/README.test.md file is added. It explains how
  to run the newly added test.
- src/bin/pg_upgrade/README.gpdb is updated to contain more 
  information about pg_upgrade testing.