### PR TITLE
Optimize ALTER TABLE REBALANCE

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -404,6 +404,10 @@ cdbllize_adjust_top_path(PlannerInfo *root, Path *best_path,
 		Assert(rte->rtekind == RTE_RELATION);
 
 		targetPolicy = GpPolicyFetch(rte->relid);
+		if (targetPolicy->ptype == POLICYTYPE_PARTITIONED &&
+			gp_segment_number_for_table_shrink > 0)
+			targetPolicy->numsegments =
+					Min(targetPolicy->numsegments, gp_segment_number_for_table_shrink);
 	}
 
 	if (query->commandType == CMD_SELECT && query->parentStmtType == PARENTSTMTTYPE_CTAS)

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17753,16 +17753,10 @@ ATExecShrinkTable(Relation rel, GpPolicy *policy)
 		StringInfoData shrunk_segments_condition;
 		initStringInfo(&shrunk_segments_condition);
 		appendStringInfo(&shrunk_segments_condition, "gp_segment_id in (");
-		for (int shrunk_segment = policy->numsegments;
-			shrunk_segment < getgpsegmentCount();
-			shrunk_segment++)
-			if (shrunk_segment == getgpsegmentCount() - 1)
-				appendStringInfo(&shrunk_segments_condition,
-								 "%d", shrunk_segment);
-			else
-				appendStringInfo(&shrunk_segments_condition,
-								 "%d, ", shrunk_segment);
-		appendStringInfo(&shrunk_segments_condition, ")");
+		int shrunk_segment = policy->numsegments;
+		for (;shrunk_segment < getgpsegmentCount() - 1; shrunk_segment++)
+			appendStringInfo(&shrunk_segments_condition, "%d, ", shrunk_segment);
+		appendStringInfo(&shrunk_segments_condition, "%d)", shrunk_segment);
 
 		appendStringInfo(&sqlstmtInsert,
 						 "insert into %s select * from %s where %s",

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17738,6 +17738,7 @@ ATExecShrinkTable(Relation rel, GpPolicy *policy)
 	if (Gp_role == GP_ROLE_DISPATCH && GpPolicyIsPartitioned(policy))
 	{
 		volatile bool connected = false;
+		bool saveOptimizerGucValue;
 		StringInfoData sqlstmtInsert;
 		initStringInfo(&sqlstmtInsert);
 		const char *nsp = quote_identifier(
@@ -17749,21 +17750,37 @@ ATExecShrinkTable(Relation rel, GpPolicy *policy)
 		initStringInfo(&qualified_table_name);
 		appendStringInfo(&qualified_table_name, "%s.%s", nsp, relname);
 
-		/*
-		 * 'gp_dist_random' will cause fallback to Postgres planner,
-		 * so no need to tweak 'optimizer' value.
-		 */
+		StringInfoData shrunk_segments_condition;
+		initStringInfo(&shrunk_segments_condition);
+		appendStringInfo(&shrunk_segments_condition, "gp_segment_id in (");
+		for (int shrunk_segment = policy->numsegments;
+			shrunk_segment < getgpsegmentCount();
+			shrunk_segment++)
+			if (shrunk_segment == getgpsegmentCount() - 1)
+				appendStringInfo(&shrunk_segments_condition,
+								 "%d", shrunk_segment);
+			else
+				appendStringInfo(&shrunk_segments_condition,
+								 "%d, ", shrunk_segment);
+		appendStringInfo(&shrunk_segments_condition, ")");
+
 		appendStringInfo(&sqlstmtInsert,
-						 "insert into %s select * "
-						 "from gp_dist_random(%s) "
-						 "where gp_segment_id >= %d",
+						 "insert into %s select * from %s where %s",
 						 qualified_table_name.data,
-						 quote_literal_cstr(qualified_table_name.data),
-						 policy->numsegments);
+						 qualified_table_name.data,
+						 shrunk_segments_condition.data);
 
 		pfree(qualified_table_name.data);
+		pfree(shrunk_segments_condition.data);
 
 		gp_segment_number_for_table_shrink = policy->numsegments;
+
+		/*
+		 * Force the use of Postgres based planner, since Orca will not
+		 * redistribute the tuples.
+		 */
+		saveOptimizerGucValue = optimizer;
+		optimizer = false;
 
 		PG_TRY();
 		{
@@ -17794,6 +17811,7 @@ ATExecShrinkTable(Relation rel, GpPolicy *policy)
 			pfree(sqlstmtInsert.data);
 
 			gp_segment_number_for_table_shrink = 0;
+			optimizer = saveOptimizerGucValue;
 
 			/* Carry on with error handling. */
 			PG_RE_THROW();
@@ -17803,6 +17821,7 @@ ATExecShrinkTable(Relation rel, GpPolicy *policy)
 		pfree(sqlstmtInsert.data);
 
 		gp_segment_number_for_table_shrink = 0;
+		optimizer = saveOptimizerGucValue;
 	}
 	else if (Gp_role == GP_ROLE_EXECUTE && GpPolicyIsPartitioned(policy) &&
 		   GpIdentity.segindex >= policy->numsegments)

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17754,7 +17754,7 @@ ATExecShrinkTable(Relation rel, GpPolicy *policy)
 		initStringInfo(&shrunk_segments_condition);
 		appendStringInfo(&shrunk_segments_condition, "gp_segment_id in (");
 		int shrunk_segment = policy->numsegments;
-		for (;shrunk_segment < getgpsegmentCount() - 1; shrunk_segment++)
+		for (;shrunk_segment < rel->rd_cdbpolicy->numsegments - 1; shrunk_segment++)
 			appendStringInfo(&shrunk_segments_condition, "%d, ", shrunk_segment);
 		appendStringInfo(&shrunk_segments_condition, "%d)", shrunk_segment);
 

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -3003,6 +3003,12 @@ create_modifytable_plan(PlannerInfo *root, ModifyTablePath *best_path)
 				if (isfirst)
 				{
 					root->curSlice->gangType = GANGTYPE_PRIMARY_WRITER;
+					/*
+					 * Do not update numsegments of the slice in case
+					 * gp_segment_number_for_table_shrink is set, as we are
+					 * going to insert data into a reduced set of segments in
+					 * this case.
+					 */
 					if (gp_segment_number_for_table_shrink == 0)
 						root->curSlice->numsegments = policy->numsegments;
 				}

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -3003,7 +3003,8 @@ create_modifytable_plan(PlannerInfo *root, ModifyTablePath *best_path)
 				if (isfirst)
 				{
 					root->curSlice->gangType = GANGTYPE_PRIMARY_WRITER;
-					root->curSlice->numsegments = policy->numsegments;
+					if (gp_segment_number_for_table_shrink == 0)
+						root->curSlice->numsegments = policy->numsegments;
 				}
 				else
 				{


### PR DESCRIPTION
Optimize ALTER TABLE REBALANCE command

ALTER TABLE REBALANCE, in order to shrink a table, uses the approach with
selecting data from the shrunk segments and inserting the data into the
remaining segments.
Before this patch, the plan for the insert query had 'redistribute' motion from
all segments into all segments. That means that the root slice was executed on
all segments, either the scan slice. Scan execution on not-shrunk segments led
to performance overhead since tuples were retrieved first, and only then the
filter (which checks gp_segment_id) was applied.

This patch optimizes the ALTER TABLE REBALANCE command in a way that the insert
plan now has 'redistribute' motion from only shrunk segments to the reduced set
of segments that are left after shrinking. That is achieved by
1. enabling direct dispatch by reworking the condition from
'where gp_segment_id >= N' to 'where gp_segment_id in (N, N+1, ...)';
2. removing 'gp_dist_random' (as forcing random distribution disables
direct dispatch - refer to code in 'GetContentIdsFromPlanForSingleRelation()'
function);
3. limiting the 'numsegments' in the target result relation of the insert.

As 'gp_dist_random' is removed, now we need to disable Orca explicitly during
planning of the insert query.

New tests are not added; passing the current tests set is enough.

Co-authored-by: Alexander Kondakov <a.kondakov@arenadata.io>