### PR TITLE
CI-5691 Upload latest docker image to docker hub for ubuntu 24.04

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -122,7 +122,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target_os: [ubuntu]
+        include:
+          - target_os: ubuntu
+          - target_os: ubuntu
+            target_os_version: "24.04"
     permissions:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access


### PR DESCRIPTION
## Upload latest docker image to docker hub for ubuntu 24.04 (6.x) (#443)

Add matrix to upload workflow. Matrix needed to upload latest
docker image for ubuntu 24.04.

Task: CI-5691