### PR TITLE
CI-5691 Upload latest docker image to docker hub for ubuntu 24.04

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -134,6 +134,7 @@ jobs:
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
+      target_os_version: ${{ matrix.target_os_version }}
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Upload latest docker image to docker hub for ubuntu 24.04 (6.x) (#444)

Add target_os_version to upload latest docker image
for ubuntu 24.04.

Task: CI-5691