### PR TITLE
GG-472: Fix pg_dump inconsistencies between 6.x and 7.x

### DIFF
--- a/src/bin/pg_dump/pg_backup_archiver.c
+++ b/src/bin/pg_dump/pg_backup_archiver.c
@@ -3248,8 +3248,13 @@ _doSetFixedOutputState(ArchiveHandle *AH)
 	/*
 	 * Ensure that the setting is on, so that we don't error out while trying
 	 * to restore TRIGGERS from GP6 to GP7.
+	 *
+	 * This is done for the pg_restore connection itself, meaning that this
+	 * setting is set implicitly and it wouldn't appear in sql dumps
+	 * or archives. This is not ideal, but changing this code means
+	 * breaking already existing dumps/archives from GP6.
 	 */
-	if (AH->public.remoteVersion >= GPDB7_MAJOR_PGVERSION)
+	if (RestoringToDB(AH) && AH->public.remoteVersion >= GPDB7_MAJOR_PGVERSION)
 		ahprintf(AH, "SET gp_enable_statement_trigger = on;\n");
 
 	ahprintf(AH, "\n");

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -1320,6 +1320,14 @@ dumpRoles(PGconn *conn)
 			else
 				appendPQExpBufferStr(buf, " NOBYPASSRLS");
 		}
+		else
+		{
+			/*
+			 * Default to NOBYPASSRLS for dumps from Greengage 6 to make
+			 * them consistent with dumps from Greenage 7.
+			 */
+			appendPQExpBufferStr(buf, " NOBYPASSRLS");
+		}
 
 		if (strcmp(PQgetvalue(res, i, i_rolconnlimit), "-1") != 0)
 			appendPQExpBuffer(buf, " CONNECTION LIMIT %s",

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -1313,21 +1313,10 @@ dumpRoles(PGconn *conn)
 		else
 			appendPQExpBufferStr(buf, " NOREPLICATION");
 
-		if (server_version >= 90600)
-		{
-			if (strcmp(PQgetvalue(res, i, i_rolbypassrls), "t") == 0)
-				appendPQExpBufferStr(buf, " BYPASSRLS");
-			else
-				appendPQExpBufferStr(buf, " NOBYPASSRLS");
-		}
+		if (strcmp(PQgetvalue(res, i, i_rolbypassrls), "t") == 0)
+			appendPQExpBufferStr(buf, " BYPASSRLS");
 		else
-		{
-			/*
-			 * Default to NOBYPASSRLS for dumps from Greengage 6 to make
-			 * them consistent with dumps from Greenage 7.
-			 */
 			appendPQExpBufferStr(buf, " NOBYPASSRLS");
-		}
 
 		if (strcmp(PQgetvalue(res, i, i_rolconnlimit), "-1") != 0)
 			appendPQExpBuffer(buf, " CONNECTION LIMIT %s",

--- a/src/bin/pg_upgrade/test_gpdb.sh
+++ b/src/bin/pg_upgrade/test_gpdb.sh
@@ -276,7 +276,7 @@ diff_and_exit() {
 	# Mask database versions, as they will certainly not match during cross-version testing.
 	# There is already a vanilla PostgreSQL script that does this:
 	# src/test/perl/PostgreSQL/Test/AdjustUpgrade.pm
-	# But it performs many other subsititions, and because cross-version testing is currently
+	# But it performs many other substitutions, and because cross-version testing is currently
 	# broken for other reasons, it is hard to judge whether we need all of them.
 	sed -i "s/Dumped from database version [0-9.]*$/Dumped from database version XXX/g" $temp_root/dump1.sql $temp_root/dump2.sql
 	

--- a/src/bin/pg_upgrade/test_gpdb.sh
+++ b/src/bin/pg_upgrade/test_gpdb.sh
@@ -271,6 +271,13 @@ diff_and_exit() {
 	${NEW_BINDIR}/gpstop -a ${args}
 	COORDINATOR_DATA_DIRECTORY=""; unset COORDINATOR_DATA_DIRECTORY
 	PGPORT=""; unset PGPORT
+
+	# Mask database versions, as they will certainly not match during cross-version testing.
+	# There is already a vanilla PostgreSQL script that does this:
+	# src/test/perl/PostgreSQL/Test/AdjustUpgrade.pm
+	# But it performs many other subsititions, and because cross-version testing is currently
+	# broken for other reasons, it is hard to judge whether we need all of them.
+	sed -i "s/Dumped from database version [0-9.]*$/Dumped from database version XXX/g" $temp_root/dump1.sql $temp_root/dump2.sql
 	
 	# Since we've used the same pg_dumpall binary to create both dumps, whitespace
 	# shouldn't be a cause of difference in the files but it is. Partitioning info

--- a/src/test/regress/expected/foreign_data.out
+++ b/src/test/regress/expected/foreign_data.out
@@ -2109,7 +2109,6 @@ SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
-SET gp_enable_statement_trigger = on;
 
 SET default_tablespace = '';
 
@@ -2153,7 +2152,6 @@ SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
-SET gp_enable_statement_trigger = on;
 
 SET default_tablespace = '';
 


### PR DESCRIPTION
This is the first round of fixing pg_dump inconsistencies
between 6.x and 7.x versions.

This patch makes sure that src/bin/gp_upgrade/test_gpdb.sh
test doesn't produce any errors on an empty cluster.

There might be more similar errors, but to find most of
them we need to make pg_upgrade being able to handle
SQL dump from the regression test suite.
And since it can take quite a while, let's fix these
simple errors right away.

The list of changes is as follows:
- Mask source cluster versions during cross-version testing.
- Explicitly default to NOBYPASSRLS when dumping from 6.x.
  This reverts 1a33ccf96ea199eabcb891ae6e66259d0913ff7c
- Make sure that gp_enable_statement_trigger GUC doesn't
  appear in the dumps. It is set for the restore connection anyway.