### PR TITLE
GG-425: Make temp_tablespaces test stable

### DIFF
--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -112,7 +112,8 @@ FunctionNext_guts(FunctionScanState *node)
 				MemoryContextSwitchTo(CurTransactionContext);
 			function_scan_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix), node->initplanId);
 
-			node->ts_state = tuplestore_open_shared(rwfile_prefix);
+			node->ts_state = tuplestore_open_shared(NULL,
+													rwfile_prefix);
 			MemoryContextSwitchTo(old_context);
 		}
 

--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -112,8 +112,7 @@ FunctionNext_guts(FunctionScanState *node)
 				MemoryContextSwitchTo(CurTransactionContext);
 			function_scan_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix), node->initplanId);
 
-			node->ts_state = tuplestore_open_shared(get_shareinput_fileset(),
-													rwfile_prefix);
+			node->ts_state = tuplestore_open_shared(rwfile_prefix);
 			MemoryContextSwitchTo(old_context);
 		}
 

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -150,7 +150,6 @@ init_tuplestore_state(ShareInputScanState *node, bool skip_waiting)
 
 				shareinput_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix), sisc->share_id);
 				tuplestore_make_shared_many(ts,
-											get_shareinput_fileset(),
 											rwfile_prefix,
 											sisc->nconsumers + 1);
 
@@ -231,7 +230,7 @@ init_tuplestore_state(ShareInputScanState *node, bool skip_waiting)
 			Assert(sisc->cross_slice);
 
 			shareinput_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix), sisc->share_id);
-			ts = tuplestore_open_shared_extended(get_shareinput_fileset(), rwfile_prefix, skip_waiting);
+			ts = tuplestore_open_shared_extended(rwfile_prefix, skip_waiting);
 
 			MemoryContextSwitchTo(old_context);
 		}

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -83,7 +83,7 @@
  * individual ShareInputScan whenever its reference count reaches zero.
  */
 static dsm_handle *shareinput_Xslice_dsm_handle_ptr;
-static SharedFileSet *shareinput_Xslice_fileset;
+/* static SharedFileSet *shareinput_Xslice_fileset; */
 
 /*
  * For local (i.e. intra-slice) variants, we use a 'shareinput_local_state'

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -81,6 +81,7 @@
  * individual ShareInputScan whenever its reference count reaches zero.
  */
 static dsm_handle *shareinput_Xslice_dsm_handle_ptr;
+static SharedFileSet *shareinput_Xslice_fileset;
 
 /*
  * For local (i.e. intra-slice) variants, we use a 'shareinput_local_state'
@@ -613,6 +614,55 @@ ShareInputShmemInit(void)
 
 	shareinput_Xslice_dsm_handle_ptr =
 		ShmemInitStruct("ShareInputScan DSM handle", sizeof(dsm_handle), &found);
+}
+
+/*
+ * Get reference to the SharedFileSet used to hold all the tuplestore files.
+ *
+ * This is exported so that it can also be used by the INITPLAN function
+ * tuplestores.
+ */
+SharedFileSet *
+get_shareinput_fileset(void)
+{
+	dsm_handle		handle;
+
+	if (shareinput_Xslice_fileset == NULL)
+	{
+		dsm_segment *seg;
+
+		LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
+
+		handle = *shareinput_Xslice_dsm_handle_ptr;
+
+		if (handle)
+		{
+			seg = dsm_attach(handle);
+			if (seg == NULL)
+				elog(ERROR, "could not attach to ShareInputScan DSM segment");
+			dsm_pin_mapping(seg);
+
+			shareinput_Xslice_fileset = dsm_segment_address(seg);
+		}
+		else
+		{
+			seg = dsm_create(sizeof(SharedFileSet), 0);
+			dsm_pin_segment(seg);
+			*shareinput_Xslice_dsm_handle_ptr = dsm_segment_handle(seg);
+			dsm_pin_mapping(seg);
+
+			shareinput_Xslice_fileset = dsm_segment_address(seg);
+		}
+
+		if (shareinput_Xslice_fileset->refcnt == 0)
+			SharedFileSetInit(shareinput_Xslice_fileset, seg);
+		else
+			SharedFileSetAttach(shareinput_Xslice_fileset, seg);
+
+		LWLockRelease(ShareInputScanLock);
+	}
+
+	return shareinput_Xslice_fileset;
 }
 
 void

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -66,26 +66,6 @@
 #include "port/atomics.h"
 
 /*
- * UNUSED VARIABLES. WE KEEP TO REDUCE CONFLICTS ON FUTURE POSTGRES UPDASTE.
- *
- * The tuplestore files for all share input scans are held in one SharedFileSet.
- * The SharedFileSet is attached to a single DSM segment that persists until
- * postmaster shutdown. When the reference count of the SharedFileSet reaches
- * zero, the SharedFileSet is automatically destroyed, but it is re-initialized
- * the next time it's needed.
- *
- * The SharedFileSet deletes any remaining files when the reference count
- * reaches zero, but we don't rely on that mechanism. All the files are
- * held in the same SharedFileSet, so it cannot be recycled until all
- * ShareInputScans in the system have finished, which might never happen if
- * new queries are started continuously. The shared tuplestore entries
- * are reference counted separately, and we clean up the files backing each
- * individual ShareInputScan whenever its reference count reaches zero.
- */
-static dsm_handle *shareinput_Xslice_dsm_handle_ptr;
-/* static SharedFileSet *shareinput_Xslice_fileset; */
-
-/*
  * For local (i.e. intra-slice) variants, we use a 'shareinput_local_state'
  * to track the status. It is analogous to 'shareinput_share_state' used for
  * cross-slice scans, but we don't need to keep it in shared memory. These
@@ -607,31 +587,30 @@ shareinput_create_bufname_prefix(char* p, int size, int share_id)
 /*
  * Legacy ABI entry point. Is not supported.
  *
- * Kept to reduce conflicts on future postgres updaste.
+ * Kept for ABI support.
  */
 Size
 ShareInputShmemSize(void)
 {
-	return sizeof(dsm_handle);
+	ereport(ERROR, errmsg("Unsupported sharefileset shared memory initializer."));
 }
 
 /*
  * Legacy ABI entry point. Is not supported.
  *
- * Kept to reduce conflicts on future postgres updaste.
+ * Kept for ABI support.
  */
 void
 ShareInputShmemInit(void)
 {
-	bool		found;
-
-	shareinput_Xslice_dsm_handle_ptr =
-		ShmemInitStruct("ShareInputScan DSM handle", sizeof(dsm_handle), &found);
+	ereport(ERROR, errmsg("Unsupported sharefileset shared memory initializer."));
 }
 
 /*
  * Legacy ABI entry point. Is not supported.
  *
+ * Kept for ABI support.
+ * 
  * Get reference to the SharedFileSet used to hold all the tuplestore files.
  *
  * This is exported so that it can also be used by the INITPLAN function

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -81,7 +81,6 @@
  * individual ShareInputScan whenever its reference count reaches zero.
  */
 static dsm_handle *shareinput_Xslice_dsm_handle_ptr;
-static SharedFileSet *shareinput_Xslice_fileset;
 
 /*
  * For local (i.e. intra-slice) variants, we use a 'shareinput_local_state'
@@ -614,55 +613,6 @@ ShareInputShmemInit(void)
 
 	shareinput_Xslice_dsm_handle_ptr =
 		ShmemInitStruct("ShareInputScan DSM handle", sizeof(dsm_handle), &found);
-}
-
-/*
- * Get reference to the SharedFileSet used to hold all the tuplestore files.
- *
- * This is exported so that it can also be used by the INITPLAN function
- * tuplestores.
- */
-SharedFileSet *
-get_shareinput_fileset(void)
-{
-	dsm_handle		handle;
-
-	if (shareinput_Xslice_fileset == NULL)
-	{
-		dsm_segment *seg;
-
-		LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
-
-		handle = *shareinput_Xslice_dsm_handle_ptr;
-
-		if (handle)
-		{
-			seg = dsm_attach(handle);
-			if (seg == NULL)
-				elog(ERROR, "could not attach to ShareInputScan DSM segment");
-			dsm_pin_mapping(seg);
-
-			shareinput_Xslice_fileset = dsm_segment_address(seg);
-		}
-		else
-		{
-			seg = dsm_create(sizeof(SharedFileSet), 0);
-			dsm_pin_segment(seg);
-			*shareinput_Xslice_dsm_handle_ptr = dsm_segment_handle(seg);
-			dsm_pin_mapping(seg);
-
-			shareinput_Xslice_fileset = dsm_segment_address(seg);
-		}
-
-		if (shareinput_Xslice_fileset->refcnt == 0)
-			SharedFileSetInit(shareinput_Xslice_fileset, seg);
-		else
-			SharedFileSetAttach(shareinput_Xslice_fileset, seg);
-
-		LWLockRelease(ShareInputScanLock);
-	}
-
-	return shareinput_Xslice_fileset;
 }
 
 void

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -150,6 +150,7 @@ init_tuplestore_state(ShareInputScanState *node, bool skip_waiting)
 
 				shareinput_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix), sisc->share_id);
 				tuplestore_make_shared_many(ts,
+											NULL,
 											rwfile_prefix,
 											sisc->nconsumers + 1);
 
@@ -230,7 +231,7 @@ init_tuplestore_state(ShareInputScanState *node, bool skip_waiting)
 			Assert(sisc->cross_slice);
 
 			shareinput_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix), sisc->share_id);
-			ts = tuplestore_open_shared_extended(rwfile_prefix, skip_waiting);
+			ts = tuplestore_open_shared_extended(NULL, rwfile_prefix, skip_waiting);
 
 			MemoryContextSwitchTo(old_context);
 		}
@@ -617,6 +618,8 @@ ShareInputShmemInit(void)
 }
 
 /*
+ * Legacy ABI entry point. Is not supported.
+ *
  * Get reference to the SharedFileSet used to hold all the tuplestore files.
  *
  * This is exported so that it can also be used by the INITPLAN function
@@ -625,44 +628,7 @@ ShareInputShmemInit(void)
 SharedFileSet *
 get_shareinput_fileset(void)
 {
-	dsm_handle		handle;
-
-	if (shareinput_Xslice_fileset == NULL)
-	{
-		dsm_segment *seg;
-
-		LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
-
-		handle = *shareinput_Xslice_dsm_handle_ptr;
-
-		if (handle)
-		{
-			seg = dsm_attach(handle);
-			if (seg == NULL)
-				elog(ERROR, "could not attach to ShareInputScan DSM segment");
-			dsm_pin_mapping(seg);
-
-			shareinput_Xslice_fileset = dsm_segment_address(seg);
-		}
-		else
-		{
-			seg = dsm_create(sizeof(SharedFileSet), 0);
-			dsm_pin_segment(seg);
-			*shareinput_Xslice_dsm_handle_ptr = dsm_segment_handle(seg);
-			dsm_pin_mapping(seg);
-
-			shareinput_Xslice_fileset = dsm_segment_address(seg);
-		}
-
-		if (shareinput_Xslice_fileset->refcnt == 0)
-			SharedFileSetInit(shareinput_Xslice_fileset, seg);
-		else
-			SharedFileSetAttach(shareinput_Xslice_fileset, seg);
-
-		LWLockRelease(ShareInputScanLock);
-	}
-
-	return shareinput_Xslice_fileset;
+	ereport(ERROR, errmsg("Unsupported sharefileset getter."));
 }
 
 void

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -66,6 +66,8 @@
 #include "port/atomics.h"
 
 /*
+ * UNUSED VARIABLES. WE KEEP TO REDUCE CONFLICTS ON FUTURE POSTGRES UPDASTE.
+ *
  * The tuplestore files for all share input scans are held in one SharedFileSet.
  * The SharedFileSet is attached to a single DSM segment that persists until
  * postmaster shutdown. When the reference count of the SharedFileSet reaches
@@ -602,12 +604,22 @@ shareinput_create_bufname_prefix(char* p, int size, int share_id)
 			 gp_session_id, MyProc->queryCommandId, share_id);
 }
 
+/*
+ * Legacy ABI entry point. Is not supported.
+ *
+ * Kept to reduce conflicts on future postgres updaste.
+ */
 Size
 ShareInputShmemSize(void)
 {
 	return sizeof(dsm_handle);
 }
 
+/*
+ * Legacy ABI entry point. Is not supported.
+ *
+ * Kept to reduce conflicts on future postgres updaste.
+ */
 void
 ShareInputShmemInit(void)
 {

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1250,6 +1250,7 @@ PG_TRY();
 											  false, /* interXact */
 											  PlanStateOperatorMemKB((PlanState *)(node->planstate)));
 		tuplestore_make_shared(node->ts_state,
+							   NULL,
 							   rwfile_prefix);
 		MemoryContextSwitchTo(old_context);
 		CurrentResourceOwner = old_resowner;

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1250,7 +1250,6 @@ PG_TRY();
 											  false, /* interXact */
 											  PlanStateOperatorMemKB((PlanState *)(node->planstate)));
 		tuplestore_make_shared(node->ts_state,
-							   get_shareinput_fileset(),
 							   rwfile_prefix);
 		MemoryContextSwitchTo(old_context);
 		CurrentResourceOwner = old_resowner;

--- a/src/backend/storage/file/sharedfileset.c
+++ b/src/backend/storage/file/sharedfileset.c
@@ -260,3 +260,43 @@ SharedFilePath(char *path, SharedFileSet *fileset, const char *name)
 	SharedFileSetPath(dirpath, fileset, ChooseTablespace(fileset, name));
 	snprintf(path, MAXPGPATH, "%s/%s", dirpath, name);
 }
+
+void
+SharedFileSetUnpin(SharedFileSet *fileset)
+{
+	bool delete_all = false;
+
+	SpinLockAcquire(&fileset->mutex);
+
+	if (fileset->refcnt == 0)
+	{
+		SpinLockRelease(&fileset->mutex);
+		elog(ERROR, "could not unpin a SharedFileSet that is already destroyed");
+	}
+
+	fileset->refcnt--;
+
+	if (fileset->refcnt == 0)
+		delete_all = true;
+
+	SpinLockRelease(&fileset->mutex);
+
+	if (delete_all)
+		SharedFileSetDeleteAll(fileset);
+}
+
+void
+SharedFileSetPin(SharedFileSet *fileset)
+{
+	SpinLockAcquire(&fileset->mutex);
+
+	if (fileset->refcnt == 0)
+	{
+		SpinLockRelease(&fileset->mutex);
+		elog(ERROR, "could not pin a SharedFileSet that is already destroyed");
+	}
+
+	fileset->refcnt++;
+
+	SpinLockRelease(&fileset->mutex);
+}

--- a/src/backend/storage/file/sharedfileset.c
+++ b/src/backend/storage/file/sharedfileset.c
@@ -260,7 +260,10 @@ SharedFilePath(char *path, SharedFileSet *fileset, const char *name)
 	SharedFileSetPath(dirpath, fileset, ChooseTablespace(fileset, name));
 	snprintf(path, MAXPGPATH, "%s/%s", dirpath, name);
 }
-
+/*
+ * Unpins shareinput fileset from HTAB.
+ * See comments on SharedFileSetPin() for more information. 
+ */
 void
 SharedFileSetUnpin(SharedFileSet *fileset)
 {
@@ -285,6 +288,18 @@ SharedFileSetUnpin(SharedFileSet *fileset)
 		SharedFileSetDeleteAll(fileset);
 }
 
+/*
+ * Beside pinning SharedFileSet with standard dsm commands
+ * exclusively for shareinput_filesets we need to make extra 
+ * pinning - as HTAB should be also considered as holder.
+ * Otherwise we might get into situation, when, for instance,
+ * writer will complete it's part of the job, detach and destroy
+ * set with on_dsm_detach(). 
+ * 
+ * When all jobs will be done, this fileset will be unpinned from HTAB's
+ * owning in tuplestore_cleanup() or AtAbort_SharedTuplestores() and
+ * cleared with according callback.
+ */
 void
 SharedFileSetPin(SharedFileSet *fileset)
 {

--- a/src/backend/storage/file/sharedfileset.c
+++ b/src/backend/storage/file/sharedfileset.c
@@ -293,7 +293,7 @@ SharedFileSetUnpin(SharedFileSet *fileset)
  * exclusively for shareinput_filesets we need to make extra 
  * pinning - as HTAB should be also considered as holder.
  * Otherwise we might get into situation, when, for instance,
- * writer will complete it's part of the job, detach and destroy
+ * writer will complete its part of the job, detach and destroy
  * set with on_dsm_detach(). 
  * 
  * When all jobs will be done, this fileset will be unpinned from HTAB's

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -198,6 +198,7 @@ CreateSharedMemoryAndSemaphores(int port)
 		size = add_size(size, CheckpointerShmemSize());
 		size = add_size(size, CancelBackendMsgShmemSize());
 		size = add_size(size, WorkFileShmemSize());
+		/* size = add_size(size, ShareInputShmemSize()); */
 		size = add_size(size, SharedTuplestoreShmemSize());
 
 #ifdef FAULT_INJECTOR
@@ -379,6 +380,7 @@ CreateSharedMemoryAndSemaphores(int port)
 	AsyncShmemInit();
 	BackendCancelShmemInit();
 	WorkFileShmemInit();
+	/* ShareInputShmemInit(); */
 	SharedTuplestoreShmemInit();
 
 	/*

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -198,7 +198,6 @@ CreateSharedMemoryAndSemaphores(int port)
 		size = add_size(size, CheckpointerShmemSize());
 		size = add_size(size, CancelBackendMsgShmemSize());
 		size = add_size(size, WorkFileShmemSize());
-		/* size = add_size(size, ShareInputShmemSize()); */
 		size = add_size(size, SharedTuplestoreShmemSize());
 
 #ifdef FAULT_INJECTOR
@@ -380,7 +379,6 @@ CreateSharedMemoryAndSemaphores(int port)
 	AsyncShmemInit();
 	BackendCancelShmemInit();
 	WorkFileShmemInit();
-	/* ShareInputShmemInit(); */
 	SharedTuplestoreShmemInit();
 
 	/*

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -198,7 +198,6 @@ CreateSharedMemoryAndSemaphores(int port)
 		size = add_size(size, CheckpointerShmemSize());
 		size = add_size(size, CancelBackendMsgShmemSize());
 		size = add_size(size, WorkFileShmemSize());
-		size = add_size(size, ShareInputShmemSize());
 		size = add_size(size, SharedTuplestoreShmemSize());
 
 #ifdef FAULT_INJECTOR
@@ -380,7 +379,6 @@ CreateSharedMemoryAndSemaphores(int port)
 	AsyncShmemInit();
 	BackendCancelShmemInit();
 	WorkFileShmemInit();
-	ShareInputShmemInit();
 	SharedTuplestoreShmemInit();
 
 	/*

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -2013,29 +2013,9 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *deprecated_va
 	sstate = get_shared_state(filename);
 	Assert(sstate->session_id == gp_session_id);
 
-	if (sstate->aborting) {
-		sstate->num_current--;
-		/*
-		 * This couldn't be a freshly created shared state,
-	     * so someone else must be holding it right now.
-		 */
-		Assert(sstate->num_current > 0);
-		ereport(ERROR,
-				(errcode(ERRCODE_GP_OPERATION_CANCELED),
-				errmsg("tuplestore operation aborted, canceling")));
-	}
-
-	if (sstate->sfs_handle == DSM_HANDLE_INVALID)
-	{
-		fileset = create_shareinput_fileset(&handle);
-
-		sstate->sfs_handle = handle;
-	}
-	else
-	{
-		handle = sstate->sfs_handle;
-		fileset = attach_shareinput_fileset(handle);
-	}
+	Assert(sstate->sfs_handle == DSM_HANDLE_INVALID);
+	fileset = create_shareinput_fileset(&handle);
+	sstate->sfs_handle = handle;
 
 	state->share_status = TSHARE_WRITER;
 	state->fileset = fileset;
@@ -2197,6 +2177,25 @@ tuplestore_open_shared_extended(SharedFileSet *deprecated_variable, const char *
 	sstate = get_shared_state(filename);
 	Assert(sstate->session_id == gp_session_id);
 
+	/*
+	 * Aborting flag can only be set under exclusive lock, so we can be sure
+	 * nobody will abort before we release the lock here. Someone else will
+	 * delete it after we are done here.
+	 */
+	if (sstate->aborting) 
+	{
+		sstate->num_current--;
+		/*
+		 * This couldn't be a freshly created shared state,
+	     * so someone else must be holding it right now.
+		 */
+		Assert(sstate->num_current > 0);
+		LWLockRelease(ShareInputScanLock);
+		ereport(ERROR,
+				(errcode(ERRCODE_GP_OPERATION_CANCELED),
+				 errmsg("tuplestore operation aborted, canceling")));
+	}
+
 	LWLockRelease(ShareInputScanLock);
 
 	eflags = EXEC_FLAG_BACKWARD | EXEC_FLAG_REWIND;
@@ -2218,14 +2217,11 @@ tuplestore_open_shared_extended(SharedFileSet *deprecated_variable, const char *
 
 	/* Only open file if requested */
 	if (!skip_open) {
-		SharedFileSet *fileset = NULL;
 		/* Wait until writer is ready */
 		tuplestore_reader_waitready(sstate);
 
-		fileset = attach_shareinput_fileset(sstate->sfs_handle);
-
-		state->fileset = fileset;
-		state->myfile = BufFileOpenShared(fileset, filename);
+		state->fileset = attach_shareinput_fileset(sstate->sfs_handle);;
+		state->myfile = BufFileOpenShared(state->fileset, filename);
 		state->readptrs[0].file = 0;
 		state->readptrs[0].offset = 0L;
 		state->status = TSS_READFILE;

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -2311,29 +2311,31 @@ AtAbort_SharedTuplestores()
 			continue;
 
 		dsm_handle handle = sstate->sfs_handle;
-		SharedFileSet *sisc_fileset = attach_shareinput_fileset(handle);
-		/*
-		 * No one is using it, and we're aborting so no one will use it
-		 * in the future either. It's safe to delete the files now.
-		 * Also delete the shared memory entry. We do not need to delete
-		 * files if the SharedFileSet was already cleaned up.
-		 */
-		if (sstate->created &&
-			sstate->sfs_creator_pid == sisc_fileset->creator_pid &&
-			sstate->sfs_number == sisc_fileset->number)
+		
+		if (handle != DSM_HANDLE_INVALID) 
 		{
-			BufFileDeleteShared(sisc_fileset, sstate->tag);
-			sstate->created = false;
-			elog((Debug_shareinput_xslice ? LOG : DEBUG1), "SISC (file=%s, slice=%d): file deleted on abort",
-				 sstate->tag, currentSliceId);
-		}
+			SharedFileSet *sisc_fileset = attach_shareinput_fileset(handle);
+		
+			/*
+			* No one is using it, and we're aborting so no one will use it
+			* in the future either. It's safe to delete the files now.
+			* Also delete the shared memory entry. We do not need to delete
+			* files if the SharedFileSet was already cleaned up.
+			*/
+			if (sstate->created &&
+				sstate->sfs_creator_pid == sisc_fileset->creator_pid &&
+				sstate->sfs_number == sisc_fileset->number)
+			{
+				BufFileDeleteShared(sisc_fileset, sstate->tag);
+				sstate->created = false;
+				elog((Debug_shareinput_xslice ? LOG : DEBUG1), "SISC (file=%s, slice=%d): file deleted on abort",
+					sstate->tag, currentSliceId);
+			}
 
-		if (handle != DSM_HANDLE_INVALID)
-		{
 			SharedFileSetUnpin(sisc_fileset);
 			dsm_unpin_segment(handle);
 		}
-
+		
 		if (hash_search(shared_tuplestores,
 						sstate->tag,
 						HASH_REMOVE, NULL) == NULL)

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -182,6 +182,8 @@ typedef struct
 	 */
 	bool aborting;
 
+	/* True if the file was created and should be deleted on abort */
+	bool created;
 	pg_atomic_uint32	ready;	/* is the input fully materialized and ready to be read? */
 
 	/*
@@ -633,7 +635,11 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 	 * Used after releasing the lock.
 	 */
 	bool		should_remove_entry = false;
+	bool		should_delete_file = false;
+	char		delete_tag[NAMEDATALEN];
 	dsm_handle	detach_handle = DSM_HANDLE_INVALID;
+	pid_t		delete_creator_pid = 0;
+	uint32		delete_sfs_number = 0;
 
 	tuplestore_report(state);
 
@@ -689,6 +695,15 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 				 */
 				Assert(strlen(state->shared_filename) < NAMEDATALEN);
 
+				strlcpy(delete_tag,
+						state->shared_filename,
+						sizeof(delete_tag));
+
+				delete_creator_pid = sstate->sfs_creator_pid;
+				delete_sfs_number = sstate->sfs_number;
+
+				should_delete_file = sstate->created;
+
 				if (hash_search(shared_tuplestores,
 								state->shared_filename,
 								HASH_REMOVE, NULL) == NULL)
@@ -717,6 +732,24 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 			if (fileset == NULL && detach_handle != DSM_HANDLE_INVALID)
 			{
 				fileset = attach_shareinput_fileset(detach_handle);
+			}
+
+			if (should_delete_file)
+			{
+				if (fileset != NULL &&
+					fileset->creator_pid == delete_creator_pid &&
+					fileset->number == delete_sfs_number)
+				{
+					BufFileDeleteShared(fileset, delete_tag);
+				}
+			}
+
+			/*
+			 * Release the htab-owned lifetime. This must happen exactly once:
+			 * only in the same path that removed shared_tuplestores[tag].
+			 */
+			if (detach_handle != DSM_HANDLE_INVALID)
+			{
 				if (fileset != NULL)
 					SharedFileSetUnpin(fileset);
 
@@ -1954,6 +1987,7 @@ get_shared_state(const char *filename)
 		sstate->num_current = 0;
 		sstate->num_done = 0;
 		sstate->aborting = false;
+		sstate->created = false;
 		/*
 		 * We might not know the total number of shares, the writer will set it.
 		 * It's okay to set it later since no process will cleanup before the
@@ -2077,6 +2111,7 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *deprecated_va
 	LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
 	
 	state->shared_state->num_total = ntotal;
+	state->shared_state->created = true;
 
 	LWLockRelease(ShareInputScanLock);
 
@@ -2349,6 +2384,22 @@ AtAbort_SharedTuplestores()
 			/* Get handler for fileset. */
 			fileset = attach_shareinput_fileset(handle);
 		
+			/*
+			* No one is using it, and we're aborting so no one will use it
+			* in the future either. It's safe to delete the files now.
+			* Also delete the shared memory entry. We do not need to delete
+			* files if the SharedFileSet was already cleaned up.
+			*/
+			if (sstate->created &&
+				fileset != NULL &&
+				sstate->sfs_creator_pid == fileset->creator_pid &&
+				sstate->sfs_number == fileset->number)
+			{
+				BufFileDeleteShared(fileset, sstate->tag);
+				elog((Debug_shareinput_xslice ? LOG : DEBUG1), "SISC (file=%s, slice=%d): file deleted on abort",
+					sstate->tag, currentSliceId);
+			}
+
 			/* 
 			 * Unpin fileset from htab if not NULL. 
 			 * Possibly can be NULL if skip_open was true in process of creation. 

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -2435,7 +2435,7 @@ AtAbort_SharedTuplestores()
  * 
  * Previously we used get_shareinput_fileset() for this purposes
  * except we shouldn't have been. As this function have been creating 
- * dsm_segments that lived until postmaster, holding segment, went down. That
+ * dsm_segments that lived until postmaster death, holding segment, went down. That
  * behavior have been creating problem, when this postmasters have been reused
  * as shareinput fileset were never updated. To keep filesets consistent
  * this system was reworked so from now we use hashtable for sharefilesets

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -197,6 +197,7 @@ typedef struct
 
 	/* Data to identify the SharedFileSet that was used */
 	pid_t		sfs_creator_pid;
+	dsm_handle	sfs_handle;
 	uint32		sfs_number;
 } TuplestoreSharingState;
 
@@ -377,6 +378,8 @@ static unsigned int getlen(Tuplestorestate *state, bool eofOK);
 static void *copytup_heap(Tuplestorestate *state, void *tup);
 static void writetup_heap(Tuplestorestate *state, void *tup);
 static void *readtup_heap(Tuplestorestate *state, unsigned int len);
+static SharedFileSet *attach_shareinput_fileset(dsm_handle handle);
+static SharedFileSet *create_shareinput_fileset(dsm_handle *handle_out);
 
 
 char *
@@ -646,6 +649,10 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 		 */
 		LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
 
+		dsm_handle handle = sstate->sfs_handle;
+
+		dsm_segment *seg = dsm_find_mapping(handle);
+
 		Assert(sstate->session_id == gp_session_id);
 		/*
 		 * If we are aborting, set the variable in shared memory.
@@ -674,7 +681,17 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 				 */
 				Assert(strlen(state->shared_filename) < NAMEDATALEN);
 				if (sstate->created)
+				{
 					BufFileDeleteShared(state->fileset, state->shared_filename);
+					sstate->created = false;
+				}
+
+				if (handle != DSM_HANDLE_INVALID)
+				{
+					SharedFileSetUnpin(state->fileset);
+					dsm_unpin_segment(handle);
+				}
+
 				if (hash_search(shared_tuplestores,
 								state->shared_filename,
 								HASH_REMOVE, NULL) == NULL)
@@ -683,6 +700,11 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 				elog((Debug_shareinput_xslice ? LOG : DEBUG1), "SISC (file=%s, slice=%d): file deleted",
 					 state->shared_filename, currentSliceId);
 			}
+		}
+
+		if (seg != NULL)
+		{
+			dsm_detach(seg);
 		}
 
 		LWLockRelease(ShareInputScanLock);
@@ -1881,13 +1903,12 @@ SharedTuplestoreShmemInit(void)
 }
 
 static TuplestoreSharingState *
-get_shared_state(SharedFileSet *fileset, const char *filename)
+get_shared_state(const char *filename)
 {
 	TuplestoreSharingState *sstate;
 	bool		found;
 
 	/* We only support one shared fileset currently */
-	Assert(fileset == get_shareinput_fileset());
 	Assert(LWLockHeldByMeInMode(ShareInputScanLock, LW_EXCLUSIVE));
 
 	Assert(strlen(filename) < NAMEDATALEN);
@@ -1914,8 +1935,9 @@ get_shared_state(SharedFileSet *fileset, const char *filename)
 		 * writer is ready anyway.
 		 */
 		sstate->num_total = UINT32_MAX;
-		sstate->sfs_creator_pid = fileset->creator_pid;
-		sstate->sfs_number = fileset->number;
+		sstate->sfs_creator_pid = 0;
+		sstate->sfs_handle = DSM_HANDLE_INVALID;
+		sstate->sfs_number = 0;
 
 		pg_atomic_init_u32(&sstate->ready, 0);
 		ConditionVariableInit(&sstate->ready_done_cv);
@@ -1946,9 +1968,12 @@ get_shared_state(SharedFileSet *fileset, const char *filename)
  * opened before it is automatically deleted.
  */
 void
-tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset, const char *filename, uint32 ntotal)
+tuplestore_make_shared_many(Tuplestorestate *state, const char *filename, uint32 ntotal)
 {
 	ResourceOwner oldowner;
+	TuplestoreSharingState *sstate;
+    SharedFileSet *fileset;
+    dsm_handle handle = DSM_HANDLE_INVALID;
 
 	state->work_set = workfile_mgr_create_set("SharedTupleStore", filename, true /* hold pin */);
 
@@ -1966,34 +1991,71 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset, cons
 
 	LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
 
+	sstate = get_shared_state(filename);
+	Assert(sstate->session_id == gp_session_id);
+
+	if (sstate->aborting)
+	{
+		sstate->num_current--;
+		LWLockRelease(ShareInputScanLock);
+
+		ereport(ERROR,
+				(errcode(ERRCODE_GP_OPERATION_CANCELED),
+				errmsg("tuplestore operation aborted, canceling")));
+	}
+
+	/* Unlock in case of error */
+	PG_TRY();
+	{
+		/*
+		* The first participant may have been a reader. The writer is the one
+		* who creates the actual SharedFileSet and BufFile.
+		*/
+		if (sstate->sfs_handle == DSM_HANDLE_INVALID)
+		{
+			fileset = create_shareinput_fileset(&handle);
+
+			sstate->sfs_handle = handle;
+			sstate->sfs_creator_pid = fileset->creator_pid;
+			sstate->sfs_number = fileset->number;
+		}
+		else
+		{
+			handle = sstate->sfs_handle;
+			fileset = attach_shareinput_fileset(handle);
+		}
+	}
+	PG_CATCH();
+	{
+		sstate->aborting = true;
+		sstate->num_current--;
+		LWLockRelease(ShareInputScanLock);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
 	state->share_status = TSHARE_WRITER;
 	state->fileset = fileset;
 	state->shared_filename = pstrdup(filename);
-
-	/*
-	 * Switch to tape-based operation, like in tuplestore_puttuple_common().
-	 * We could delay this until tuplestore_freeze(), but we know we'll have
-	 * to write everything to the file anyway, so let's not waste memory
-	 * buffering the tuples in the meanwhile.
-	 */
-	PrepareTempTablespaces();
+	state->shared_state = sstate;
 
 	/* associate the file with the store's resource owner */
 	oldowner = CurrentResourceOwner;
 	CurrentResourceOwner = state->resowner;
 
-	state->myfile = BufFileCreateShared(fileset, filename, state->work_set);
-	CurrentResourceOwner = oldowner;
-
 	/* Make sure the file only exists if and only if shared state was successfully created */
 	PG_TRY();
 	{
-		state->shared_state = get_shared_state(fileset, filename);
+		state->myfile = BufFileCreateShared(fileset, filename, state->work_set);
+		CurrentResourceOwner = oldowner;
 		state->shared_state->num_total = ntotal;
 		state->shared_state->created = true;
 	}
 	PG_CATCH();
 	{
+		CurrentResourceOwner = oldowner;
+		sstate->aborting = true;
+		sstate->num_current--;
 		BufFileDeleteShared(fileset, filename);
 		LWLockRelease(ShareInputScanLock);
 		PG_RE_THROW();
@@ -2025,9 +2087,9 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset, cons
  * after both the writer and a single reader close it.
  */
 void
-tuplestore_make_shared(Tuplestorestate *state, SharedFileSet *fileset, const char *filename)
+tuplestore_make_shared(Tuplestorestate *state, const char *filename)
 {
-	tuplestore_make_shared_many(state, fileset, filename, 2);
+	tuplestore_make_shared_many(state, filename, 2);
 }
 
 static void
@@ -2118,10 +2180,12 @@ tuplestore_reader_waitready(TuplestoreSharingState *sstate)
  * if this might be called on segments.
  */
 Tuplestorestate *
-tuplestore_open_shared_extended(SharedFileSet *fileset, const char *filename, bool skip_open)
+tuplestore_open_shared_extended(const char *filename, bool skip_open)
 {
 	Tuplestorestate *state;
 	TuplestoreSharingState *sstate;
+	SharedFileSet *fileset = NULL;
+	dsm_handle 	handle;
 	int			eflags;
 
 	/*
@@ -2134,7 +2198,7 @@ tuplestore_open_shared_extended(SharedFileSet *fileset, const char *filename, bo
 
 	LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
 
-	sstate = get_shared_state(fileset, filename);
+	sstate = get_shared_state(filename);
 	Assert(sstate->session_id == gp_session_id);
 
 	/*
@@ -2144,11 +2208,7 @@ tuplestore_open_shared_extended(SharedFileSet *fileset, const char *filename, bo
 	 */
 	if (sstate->aborting) {
 		sstate->num_current--;
-		/*
-		 * This couldn't be a freshly created shared state,
-	     * so someone else must be holding it right now.
-		 */
-		Assert(sstate->num_current > 0);
+		LWLockRelease(ShareInputScanLock);
 		ereport(ERROR,
 				(errcode(ERRCODE_GP_OPERATION_CANCELED),
 				 errmsg("tuplestore operation aborted, canceling")));
@@ -2171,22 +2231,25 @@ tuplestore_open_shared_extended(SharedFileSet *fileset, const char *filename, bo
 
 	state->share_status = TSHARE_READER;
 	state->frozen = false;
-	state->fileset = fileset;
 	state->shared_filename = pstrdup(filename);
+
+	/* Remember this tuplestore in case we have to close it while aborting */
+	local_shared_tuplestores = lappend(local_shared_tuplestores, state);
 
 	/* Only open file if requested */
 	if (!skip_open) {
 		/* Wait until writer is ready */
 		tuplestore_reader_waitready(sstate);
 
+		handle = sstate->sfs_handle;
+		fileset = attach_shareinput_fileset(handle);
+
+		state->fileset = fileset;
 		state->myfile = BufFileOpenShared(fileset, filename);
 		state->readptrs[0].file = 0;
 		state->readptrs[0].offset = 0L;
 		state->status = TSS_READFILE;
 	}
-
-	/* Remember this tuplestore in case we have to close it while aborting */
-	local_shared_tuplestores = lappend(local_shared_tuplestores, state);
 
 	return state;
 }
@@ -2202,9 +2265,9 @@ tuplestore_open_shared_extended(SharedFileSet *fileset, const char *filename, bo
  * if this might be called on segments.
  */
 Tuplestorestate *
-tuplestore_open_shared(SharedFileSet *fileset, const char *filename)
+tuplestore_open_shared(const char *filename)
 {
-	return tuplestore_open_shared_extended(fileset, filename, false);
+	return tuplestore_open_shared_extended(filename, false);
 }
 
 /*
@@ -2231,8 +2294,6 @@ AtAbort_SharedTuplestores()
 	/* Return early if nothing to delete */
 	if (hash_get_num_entries(shared_tuplestores) == 0)
 		return;
-	/* Must be done outside of lock */
-	SharedFileSet *sisc_fileset = get_shareinput_fileset();
 
 	/* Then attempt to delete the files */
 	LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
@@ -2249,6 +2310,8 @@ AtAbort_SharedTuplestores()
 		if (sstate->num_current > 0)
 			continue;
 
+		dsm_handle handle = sstate->sfs_handle;
+		SharedFileSet *sisc_fileset = attach_shareinput_fileset(handle);
 		/*
 		 * No one is using it, and we're aborting so no one will use it
 		 * in the future either. It's safe to delete the files now.
@@ -2260,8 +2323,15 @@ AtAbort_SharedTuplestores()
 			sstate->sfs_number == sisc_fileset->number)
 		{
 			BufFileDeleteShared(sisc_fileset, sstate->tag);
+			sstate->created = false;
 			elog((Debug_shareinput_xslice ? LOG : DEBUG1), "SISC (file=%s, slice=%d): file deleted on abort",
 				 sstate->tag, currentSliceId);
+		}
+
+		if (handle != DSM_HANDLE_INVALID)
+		{
+			SharedFileSetUnpin(sisc_fileset);
+			dsm_unpin_segment(handle);
 		}
 
 		if (hash_search(shared_tuplestores,
@@ -2271,4 +2341,67 @@ AtAbort_SharedTuplestores()
 	}
 
 	LWLockRelease(ShareInputScanLock);
+}
+
+static SharedFileSet *
+create_shareinput_fileset(dsm_handle *handle_out)
+{
+    dsm_segment *seg;
+    SharedFileSet *fileset;
+
+    seg = dsm_create(sizeof(SharedFileSet), 0);
+
+    /*
+     * Keep the DSM alive even if the writer QE finishes before consumers
+     * have attached.
+     */
+    dsm_pin_segment(seg);
+
+    fileset = dsm_segment_address(seg);
+    *handle_out = dsm_segment_handle(seg);
+
+    SharedFileSetInit(fileset, seg);
+
+	/*
+	 * Extra ref owned by shared_tuplestores[tag].
+	 *
+	 * This prevents SharedFileSetOnDetach() from destroying the fileset
+	 * when the creator backend detaches before consumers attach.
+	 */
+	SharedFileSetPin(fileset);
+
+    return fileset;
+}
+
+static SharedFileSet *
+attach_shareinput_fileset(dsm_handle handle)
+{
+    dsm_segment *seg;
+    SharedFileSet *fileset;
+
+    if (handle == DSM_HANDLE_INVALID)
+        elog(ERROR, "invalid ShareInputScan SharedFileSet DSM handle");
+
+    seg = dsm_find_mapping(handle);
+
+    if (seg == NULL)
+    {
+        seg = dsm_attach(handle);
+        if (seg == NULL)
+            elog(ERROR, "could not attach to ShareInputScan SharedFileSet DSM segment");
+
+        /*
+         * Do not dsm_pin_mapping().
+         * We want the mapping to go away when the tuplestore/backend cleanup
+         * detaches it.
+         */
+        fileset = dsm_segment_address(seg);
+        SharedFileSetAttach(fileset, seg);
+    }
+    else
+    {
+        fileset = dsm_segment_address(seg);
+    }
+
+    return fileset;
 }

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -98,7 +98,6 @@
 
 #include "cdb/cdbvars.h"
 #include "executor/instrument.h"        /* struct Instrumentation */
-#include "executor/nodeShareInputScan.h" /* get_shareinput_fileset */
 #include "utils/workfile_mgr.h"
 
 
@@ -378,8 +377,9 @@ static unsigned int getlen(Tuplestorestate *state, bool eofOK);
 static void *copytup_heap(Tuplestorestate *state, void *tup);
 static void writetup_heap(Tuplestorestate *state, void *tup);
 static void *readtup_heap(Tuplestorestate *state, unsigned int len);
-static SharedFileSet *attach_shareinput_fileset(dsm_handle handle);
+static void attach_shareinput_fileset(dsm_handle handle);
 static SharedFileSet *create_shareinput_fileset(dsm_handle *handle_out);
+static SharedFileSet *get_shareinput_fileset(dsm_handle handle_out);
 
 
 char *
@@ -1924,6 +1924,9 @@ get_shared_state(const char *filename)
 					(errcode(ERRCODE_OUT_OF_MEMORY),
 					errmsg("out of shared tuplestore slots")));
 		}
+
+		SharedFileSet *fileset = NULL;
+
 		sstate->session_id = gp_session_id;
 		sstate->num_current = 0;
 		sstate->num_done = 0;
@@ -1935,9 +1938,20 @@ get_shared_state(const char *filename)
 		 * writer is ready anyway.
 		 */
 		sstate->num_total = UINT32_MAX;
-		sstate->sfs_creator_pid = 0;
-		sstate->sfs_handle = DSM_HANDLE_INVALID;
-		sstate->sfs_number = 0;
+		/* Unlock in case of error */
+		PG_TRY();
+		{
+			fileset = create_shareinput_fileset(&(sstate->sfs_handle));
+		}
+		PG_CATCH();
+		{
+			sstate->aborting = true;
+			LWLockRelease(ShareInputScanLock);
+			PG_RE_THROW();
+		}
+		PG_END_TRY();
+		sstate->sfs_creator_pid = fileset->creator_pid;
+		sstate->sfs_number = fileset->number;
 
 		pg_atomic_init_u32(&sstate->ready, 0);
 		ConditionVariableInit(&sstate->ready_done_cv);
@@ -1945,7 +1959,20 @@ get_shared_state(const char *filename)
 		elog((Debug_shareinput_xslice ? LOG : DEBUG1), "SISC (file=%s, slice=%d): initialized shared state",
 			 filename, currentSliceId);
 	}
-
+	else
+	{
+		PG_TRY();
+		{
+			attach_shareinput_fileset(sstate->sfs_handle);
+		}
+		PG_CATCH();
+		{
+			sstate->aborting = true;
+			LWLockRelease(ShareInputScanLock);
+			PG_RE_THROW();
+		}
+		PG_END_TRY();
+	}
 	/*
 	 * This ensures the shared state won't be suddenly deleted after we
 	 * release the lock.
@@ -1973,7 +2000,6 @@ tuplestore_make_shared_many(Tuplestorestate *state, const char *filename, uint32
 	ResourceOwner oldowner;
 	TuplestoreSharingState *sstate;
     SharedFileSet *fileset;
-    dsm_handle handle = DSM_HANDLE_INVALID;
 
 	state->work_set = workfile_mgr_create_set("SharedTupleStore", filename, true /* hold pin */);
 
@@ -2004,26 +2030,10 @@ tuplestore_make_shared_many(Tuplestorestate *state, const char *filename, uint32
 				errmsg("tuplestore operation aborted, canceling")));
 	}
 
-	/* Unlock in case of error */
+	state->share_status = TSHARE_WRITER;
 	PG_TRY();
 	{
-		/*
-		* The first participant may have been a reader. The writer is the one
-		* who creates the actual SharedFileSet and BufFile.
-		*/
-		if (sstate->sfs_handle == DSM_HANDLE_INVALID)
-		{
-			fileset = create_shareinput_fileset(&handle);
-
-			sstate->sfs_handle = handle;
-			sstate->sfs_creator_pid = fileset->creator_pid;
-			sstate->sfs_number = fileset->number;
-		}
-		else
-		{
-			handle = sstate->sfs_handle;
-			fileset = attach_shareinput_fileset(handle);
-		}
+		fileset = get_shareinput_fileset(sstate->sfs_handle);
 	}
 	PG_CATCH();
 	{
@@ -2033,8 +2043,6 @@ tuplestore_make_shared_many(Tuplestorestate *state, const char *filename, uint32
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
-
-	state->share_status = TSHARE_WRITER;
 	state->fileset = fileset;
 	state->shared_filename = pstrdup(filename);
 	state->shared_state = sstate;
@@ -2047,9 +2055,6 @@ tuplestore_make_shared_many(Tuplestorestate *state, const char *filename, uint32
 	PG_TRY();
 	{
 		state->myfile = BufFileCreateShared(fileset, filename, state->work_set);
-		CurrentResourceOwner = oldowner;
-		state->shared_state->num_total = ntotal;
-		state->shared_state->created = true;
 	}
 	PG_CATCH();
 	{
@@ -2061,6 +2066,10 @@ tuplestore_make_shared_many(Tuplestorestate *state, const char *filename, uint32
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
+
+	CurrentResourceOwner = oldowner;
+	state->shared_state->num_total = ntotal;
+	state->shared_state->created = true;
 
 	/*
 	 * For now, be conservative and always use trailing length words for
@@ -2185,7 +2194,6 @@ tuplestore_open_shared_extended(const char *filename, bool skip_open)
 	Tuplestorestate *state;
 	TuplestoreSharingState *sstate;
 	SharedFileSet *fileset = NULL;
-	dsm_handle 	handle;
 	int			eflags;
 
 	/*
@@ -2214,8 +2222,6 @@ tuplestore_open_shared_extended(const char *filename, bool skip_open)
 				 errmsg("tuplestore operation aborted, canceling")));
 	}
 
-	LWLockRelease(ShareInputScanLock);
-
 	eflags = EXEC_FLAG_BACKWARD | EXEC_FLAG_REWIND;
 
 	state = tuplestore_begin_common(eflags,
@@ -2233,18 +2239,31 @@ tuplestore_open_shared_extended(const char *filename, bool skip_open)
 	state->frozen = false;
 	state->shared_filename = pstrdup(filename);
 
+	PG_TRY();
+	{
+		fileset = get_shareinput_fileset(sstate->sfs_handle);
+	}
+	PG_CATCH();
+	{
+		sstate->aborting = true;
+		sstate->num_current--;
+		LWLockRelease(ShareInputScanLock);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	state->fileset = fileset;
+
 	/* Remember this tuplestore in case we have to close it while aborting */
 	local_shared_tuplestores = lappend(local_shared_tuplestores, state);
+
+	LWLockRelease(ShareInputScanLock);
 
 	/* Only open file if requested */
 	if (!skip_open) {
 		/* Wait until writer is ready */
 		tuplestore_reader_waitready(sstate);
 
-		handle = sstate->sfs_handle;
-		fileset = attach_shareinput_fileset(handle);
-
-		state->fileset = fileset;
 		state->myfile = BufFileOpenShared(fileset, filename);
 		state->readptrs[0].file = 0;
 		state->readptrs[0].offset = 0L;
@@ -2314,7 +2333,7 @@ AtAbort_SharedTuplestores()
 		
 		if (handle != DSM_HANDLE_INVALID) 
 		{
-			SharedFileSet *sisc_fileset = attach_shareinput_fileset(handle);
+			SharedFileSet *sisc_fileset = get_shareinput_fileset(handle);
 		
 			/*
 			* No one is using it, and we're aborting so no one will use it
@@ -2372,10 +2391,10 @@ create_shareinput_fileset(dsm_handle *handle_out)
 	 */
 	SharedFileSetPin(fileset);
 
-    return fileset;
+	return fileset;
 }
 
-static SharedFileSet *
+static void
 attach_shareinput_fileset(dsm_handle handle)
 {
     dsm_segment *seg;
@@ -2400,10 +2419,25 @@ attach_shareinput_fileset(dsm_handle handle)
         fileset = dsm_segment_address(seg);
         SharedFileSetAttach(fileset, seg);
     }
-    else
+}
+
+static SharedFileSet *
+get_shareinput_fileset(dsm_handle handle)
+{
+    dsm_segment *seg;
+    SharedFileSet *fileset;
+
+    if (handle == DSM_HANDLE_INVALID)
+        elog(ERROR, "invalid ShareInputScan SharedFileSet DSM handle");
+
+    seg = dsm_find_mapping(handle);
+
+    if (seg == NULL)
     {
-        fileset = dsm_segment_address(seg);
+		elog(ERROR, "could not get SharedFileSet from DSM segment");
     }
+
+	fileset = dsm_segment_address(seg);
 
     return fileset;
 }

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -187,16 +187,12 @@ typedef struct
 	/*
 	 * ready_cv is used for signaling when the scan becomes "ready". 
 	 * The producer wakes up everyone waiting on this condition variable when
-	 * it sets ready = true. Also, when the last consumer finishes the scan
-	 * (ndone reaches nconsumers), it wakes up the producer using this same
-	 * condition variable.
+	 * it sets ready = true.
 	 */
 	ConditionVariable ready_cv;
 
 	/* Data to identify the SharedFileSet that was used */
-	pid_t		sfs_creator_pid;
 	dsm_handle	sfs_handle;
-	uint32		sfs_number;
 } TuplestoreSharingState;
 
 /*
@@ -1957,9 +1953,7 @@ get_shared_state(const char *filename)
 		 * writer is ready anyway.
 		 */
 		sstate->num_total = UINT32_MAX;
-		sstate->sfs_creator_pid = 0;
 		sstate->sfs_handle = DSM_HANDLE_INVALID;
-		sstate->sfs_number = 0;
 
 		pg_atomic_init_u32(&sstate->ready, 0);
 		ConditionVariableInit(&sstate->ready_cv);
@@ -2036,8 +2030,6 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *deprecated_va
 		fileset = create_shareinput_fileset(&handle);
 
 		sstate->sfs_handle = handle;
-		sstate->sfs_creator_pid = fileset->creator_pid;
-		sstate->sfs_number = fileset->number;
 	}
 	else
 	{
@@ -2065,6 +2057,7 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *deprecated_va
 	CurrentResourceOwner = state->resowner;
 
 	state->myfile = BufFileCreateShared(fileset, filename, state->work_set);
+	CurrentResourceOwner = oldowner;
 
 	/*
 	 * For now, be conservative and always use trailing length words for
@@ -2074,8 +2067,6 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *deprecated_va
 	 */
 	state->backward = true;
 	state->status = TSS_WRITEFILE;
-
-	CurrentResourceOwner = oldowner;
 }
 
 /*
@@ -2191,8 +2182,6 @@ tuplestore_open_shared_extended(SharedFileSet *deprecated_variable, const char *
 {
 	Tuplestorestate *state;
 	TuplestoreSharingState *sstate;
-	SharedFileSet *fileset = NULL;
-	dsm_handle 	handle = DSM_HANDLE_INVALID;
 	int			eflags;
 
 	/*
@@ -2207,25 +2196,6 @@ tuplestore_open_shared_extended(SharedFileSet *deprecated_variable, const char *
 
 	sstate = get_shared_state(filename);
 	Assert(sstate->session_id == gp_session_id);
-
-	/*
-	 * Aborting flag can only be set under exclusive lock, so we can be sure
-	 * nobody will abort before we release the lock here. Someone else will
-	 * delete it after we are done here.
-	 */
-	if (sstate->aborting) 
-	{
-		sstate->num_current--;
-		/*
-		 * This couldn't be a freshly created shared state,
-	     * so someone else must be holding it right now.
-		 */
-		Assert(sstate->num_current > 0);
-		LWLockRelease(ShareInputScanLock);
-		ereport(ERROR,
-				(errcode(ERRCODE_GP_OPERATION_CANCELED),
-				 errmsg("tuplestore operation aborted, canceling")));
-	}
 
 	LWLockRelease(ShareInputScanLock);
 
@@ -2248,12 +2218,11 @@ tuplestore_open_shared_extended(SharedFileSet *deprecated_variable, const char *
 
 	/* Only open file if requested */
 	if (!skip_open) {
+		SharedFileSet *fileset = NULL;
 		/* Wait until writer is ready */
 		tuplestore_reader_waitready(sstate);
 
-		handle = sstate->sfs_handle;
-
-		fileset = attach_shareinput_fileset(handle);
+		fileset = attach_shareinput_fileset(sstate->sfs_handle);
 
 		state->fileset = fileset;
 		state->myfile = BufFileOpenShared(fileset, filename);

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -636,10 +636,8 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 	 */
 	bool		should_remove_entry = false;
 	bool		should_delete_file = false;
-	bool		should_release_fileset = false;
 	char		delete_tag[NAMEDATALEN];
-	dsm_handle	delete_handle = DSM_HANDLE_INVALID;
-	dsm_handle	local_detach_handle = DSM_HANDLE_INVALID;
+	dsm_handle	detach_handle = DSM_HANDLE_INVALID;
 	pid_t		delete_creator_pid = 0;
 	uint32		delete_sfs_number = 0;
 
@@ -665,7 +663,7 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 		Assert(sstate->session_id == gp_session_id);
 
 		/* Remember handle, so we will detach in any way. */
-		local_detach_handle = sstate->sfs_handle;
+		detach_handle = sstate->sfs_handle;
 		/*
 		 * If we are aborting, set the variable in shared memory.
 		 * This must be done before everything else, since if we can't
@@ -701,14 +699,10 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 						state->shared_filename,
 						sizeof(delete_tag));
 
-				delete_handle = sstate->sfs_handle;
 				delete_creator_pid = sstate->sfs_creator_pid;
 				delete_sfs_number = sstate->sfs_number;
 
 				should_delete_file = sstate->created;
-				should_release_fileset = delete_handle != DSM_HANDLE_INVALID;
-
-				sstate->created = false;
 
 				if (hash_search(shared_tuplestores,
 								state->shared_filename,
@@ -735,9 +729,9 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 		{
 			SharedFileSet *fileset = state->fileset;
 
-			if (fileset == NULL && should_release_fileset)
+			if (fileset == NULL && detach_handle != DSM_HANDLE_INVALID)
 			{
-				fileset = attach_shareinput_fileset(delete_handle);
+				fileset = attach_shareinput_fileset(detach_handle);
 			}
 
 			if (should_delete_file)
@@ -754,12 +748,12 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 			 * Release the htab-owned lifetime. This must happen exactly once:
 			 * only in the same path that removed shared_tuplestores[tag].
 			 */
-			if (should_release_fileset)
+			if (detach_handle != DSM_HANDLE_INVALID)
 			{
 				if (fileset != NULL)
 					SharedFileSetUnpin(fileset);
 
-				dsm_unpin_segment(delete_handle);
+				dsm_unpin_segment(detach_handle);
 			}
 		}
 	}
@@ -768,11 +762,11 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 		BufFileClose(state->myfile);
 
 	/* Detach manually so we don't get warning */
-	if (local_detach_handle != DSM_HANDLE_INVALID)
+	if (detach_handle != DSM_HANDLE_INVALID)
 	{
 		dsm_segment *seg;
 
-		seg = dsm_find_mapping(local_detach_handle);
+		seg = dsm_find_mapping(detach_handle);
 		/* Check if we already detached and destroyed segment */
 		if (seg != NULL)
 			dsm_detach(seg);
@@ -1968,7 +1962,7 @@ SharedTuplestoreShmemInit(void)
 }
 
 static TuplestoreSharingState *
-get_shared_state(SharedFileSet *fileset, const char *filename)
+get_shared_state(const char *filename)
 {
 	TuplestoreSharingState *sstate;
 	bool		found;
@@ -2031,13 +2025,16 @@ get_shared_state(SharedFileSet *fileset, const char *filename)
  *
  * The ntotal parameter sets the number of times the tuplestore can be
  * opened before it is automatically deleted.
+ * 
+ * SharedFileSet parameter kept for ABI reasons only and should not be 
+ * used in current state.
  */
 void
-tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset, const char *filename, uint32 ntotal)
+tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *deprecated_variable, const char *filename, uint32 ntotal)
 {
 	ResourceOwner oldowner;
 	TuplestoreSharingState *sstate;
-    SharedFileSet *real_fileset;
+    SharedFileSet *fileset;
     dsm_handle handle = DSM_HANDLE_INVALID;
 
 	state->work_set = workfile_mgr_create_set("SharedTupleStore", filename, true /* hold pin */);
@@ -2056,7 +2053,7 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset, cons
 
 	LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
 
-	sstate = get_shared_state(NULL, filename);
+	sstate = get_shared_state(filename);
 	Assert(sstate->session_id == gp_session_id);
 
 	if (sstate->aborting)
@@ -2071,20 +2068,20 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset, cons
 
 	if (sstate->sfs_handle == DSM_HANDLE_INVALID)
 	{
-		real_fileset = create_shareinput_fileset(&handle);
+		fileset = create_shareinput_fileset(&handle);
 
 		sstate->sfs_handle = handle;
-		sstate->sfs_creator_pid = real_fileset->creator_pid;
-		sstate->sfs_number = real_fileset->number;
+		sstate->sfs_creator_pid = fileset->creator_pid;
+		sstate->sfs_number = fileset->number;
 	}
 	else
 	{
 		handle = sstate->sfs_handle;
-		real_fileset = attach_shareinput_fileset(handle);
+		fileset = attach_shareinput_fileset(handle);
 	}
 
 	state->share_status = TSHARE_WRITER;
-	state->fileset = real_fileset;
+	state->fileset = fileset;
 	state->shared_filename = pstrdup(filename);
 	state->shared_state = sstate;
 
@@ -2100,22 +2097,7 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset, cons
 	oldowner = CurrentResourceOwner;
 	CurrentResourceOwner = state->resowner;
 
-	/* Make sure the file only exists if and only if shared state was successfully created */
-	PG_TRY();
-	{
-		state->myfile = BufFileCreateShared(real_fileset, filename, state->work_set);
-	}
-	PG_CATCH();
-	{
-		CurrentResourceOwner = oldowner;
-
-		LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
-		sstate->aborting = true;
-		ConditionVariableBroadcast(&sstate->ready_done_cv);
-		LWLockRelease(ShareInputScanLock);
-		PG_RE_THROW();
-	}
-	PG_END_TRY();
+	state->myfile = BufFileCreateShared(fileset, filename, state->work_set);
 
 	/*
 	 * For now, be conservative and always use trailing length words for
@@ -2145,11 +2127,14 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset, cons
  *
  * The ntotal parameter defaults to 2, so the tuplestore will be deleted
  * after both the writer and a single reader close it.
+ *
+ * SharedFileSet parameter kept for ABI reasons only and should not be 
+ * used in current state.
  */
 void
-tuplestore_make_shared(Tuplestorestate *state, SharedFileSet *fileset, const char *filename)
+tuplestore_make_shared(Tuplestorestate *state, SharedFileSet *deprecated_variable, const char *filename)
 {
-	tuplestore_make_shared_many(state, fileset, filename, 2);
+	tuplestore_make_shared_many(state, deprecated_variable, filename, 2);
 }
 
 static void
@@ -2238,13 +2223,16 @@ tuplestore_reader_waitready(TuplestoreSharingState *sstate)
  *
  * The caller must make sure to set transaction-level MemoryContext
  * if this might be called on segments.
+ * 
+ * SharedFileSet parameter kept for ABI reasons only and should not be 
+ * used in current state.
  */
 Tuplestorestate *
-tuplestore_open_shared_extended(SharedFileSet *fileset, const char *filename, bool skip_open)
+tuplestore_open_shared_extended(SharedFileSet *deprecated_variable, const char *filename, bool skip_open)
 {
 	Tuplestorestate *state;
 	TuplestoreSharingState *sstate;
-	SharedFileSet *real_fileset = NULL;
+	SharedFileSet *fileset = NULL;
 	dsm_handle 	handle = DSM_HANDLE_INVALID;
 	int			eflags;
 
@@ -2258,7 +2246,7 @@ tuplestore_open_shared_extended(SharedFileSet *fileset, const char *filename, bo
 
 	LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
 
-	sstate = get_shared_state(NULL, filename);
+	sstate = get_shared_state(filename);
 	Assert(sstate->session_id == gp_session_id);
 
 	/*
@@ -2315,10 +2303,10 @@ tuplestore_open_shared_extended(SharedFileSet *fileset, const char *filename, bo
 
 		LWLockRelease(ShareInputScanLock);
 
-		real_fileset = attach_shareinput_fileset(handle);
+		fileset = attach_shareinput_fileset(handle);
 
-		state->fileset = real_fileset;
-		state->myfile = BufFileOpenShared(real_fileset, filename);
+		state->fileset = fileset;
+		state->myfile = BufFileOpenShared(fileset, filename);
 		state->readptrs[0].file = 0;
 		state->readptrs[0].offset = 0L;
 		state->status = TSS_READFILE;
@@ -2336,11 +2324,14 @@ tuplestore_open_shared_extended(SharedFileSet *fileset, const char *filename, bo
  *
  * The caller must make sure to set transaction-level MemoryContext
  * if this might be called on segments.
+ * 
+ * SharedFileSet parameter kept for ABI reasons only and should not be 
+ * used in current state.
  */
 Tuplestorestate *
-tuplestore_open_shared(SharedFileSet *fileset, const char *filename)
+tuplestore_open_shared(SharedFileSet *deprecated_variable, const char *filename)
 {
-	return tuplestore_open_shared_extended(fileset, filename, false);
+	return tuplestore_open_shared_extended(deprecated_variable, filename, false);
 }
 
 /*
@@ -2405,7 +2396,6 @@ AtAbort_SharedTuplestores()
 				sstate->sfs_number == fileset->number)
 			{
 				BufFileDeleteShared(fileset, sstate->tag);
-				sstate->created = false;
 				elog((Debug_shareinput_xslice ? LOG : DEBUG1), "SISC (file=%s, slice=%d): file deleted on abort",
 					sstate->tag, currentSliceId);
 			}

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -662,7 +662,6 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 		 */
 		if (should_abort)
 			sstate->aborting = true;
-			
 		sstate->num_done++;
 		sstate->num_current--;
 		Assert(sstate->num_done <= sstate->num_total);
@@ -681,7 +680,6 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 				 * after us.
 				 */
 				Assert(strlen(state->shared_filename) < NAMEDATALEN);
-
 				if (hash_search(shared_tuplestores,
 								state->shared_filename,
 								HASH_REMOVE, NULL) == NULL)
@@ -1927,7 +1925,6 @@ get_shared_state(const char *filename)
 	TuplestoreSharingState *sstate;
 	bool		found;
 
-	/* We only support one shared fileset currently */
 	Assert(LWLockHeldByMeInMode(ShareInputScanLock, LW_EXCLUSIVE));
 
 	Assert(strlen(filename) < NAMEDATALEN);
@@ -2182,8 +2179,7 @@ tuplestore_open_shared_extended(SharedFileSet *deprecated_variable, const char *
 	 * nobody will abort before we release the lock here. Someone else will
 	 * delete it after we are done here.
 	 */
-	if (sstate->aborting) 
-	{
+	if (sstate->aborting) {
 		sstate->num_current--;
 		/*
 		 * This couldn't be a freshly created shared state,
@@ -2283,7 +2279,6 @@ AtAbort_SharedTuplestores()
 	while ((sstate = hash_seq_search(&seq_status)) != NULL)
 	{
 		dsm_handle handle;
-		SharedFileSet *fileset = NULL;
 
 		/* Check if this is tuplestore belongs to this session */
 		if (sstate->session_id != gp_session_id)
@@ -2299,7 +2294,7 @@ AtAbort_SharedTuplestores()
 		if (handle != DSM_HANDLE_INVALID) 
 		{
 			/* Get handler for fileset. */
-			fileset = attach_shareinput_fileset(handle);
+			SharedFileSet *fileset = attach_shareinput_fileset(handle);
 		
 			/* 
 			 * Unpin fileset from htab if not NULL. 
@@ -2310,7 +2305,7 @@ AtAbort_SharedTuplestores()
 			/* Release the global pin */
 			dsm_unpin_segment(handle);
 		}
-		
+
 		if (hash_search(shared_tuplestores,
 						sstate->tag,
 						HASH_REMOVE, NULL) == NULL)

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -182,8 +182,6 @@ typedef struct
 	 */
 	bool aborting;
 
-	/* True if the file was created and should be deleted on abort */
-	bool created;
 	pg_atomic_uint32	ready;	/* is the input fully materialized and ready to be read? */
 
 	/*
@@ -635,11 +633,7 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 	 * Used after releasing the lock.
 	 */
 	bool		should_remove_entry = false;
-	bool		should_delete_file = false;
-	char		delete_tag[NAMEDATALEN];
 	dsm_handle	detach_handle = DSM_HANDLE_INVALID;
-	pid_t		delete_creator_pid = 0;
-	uint32		delete_sfs_number = 0;
 
 	tuplestore_report(state);
 
@@ -695,15 +689,6 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 				 */
 				Assert(strlen(state->shared_filename) < NAMEDATALEN);
 
-				strlcpy(delete_tag,
-						state->shared_filename,
-						sizeof(delete_tag));
-
-				delete_creator_pid = sstate->sfs_creator_pid;
-				delete_sfs_number = sstate->sfs_number;
-
-				should_delete_file = sstate->created;
-
 				if (hash_search(shared_tuplestores,
 								state->shared_filename,
 								HASH_REMOVE, NULL) == NULL)
@@ -732,24 +717,6 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 			if (fileset == NULL && detach_handle != DSM_HANDLE_INVALID)
 			{
 				fileset = attach_shareinput_fileset(detach_handle);
-			}
-
-			if (should_delete_file)
-			{
-				if (fileset != NULL &&
-					fileset->creator_pid == delete_creator_pid &&
-					fileset->number == delete_sfs_number)
-				{
-					BufFileDeleteShared(fileset, delete_tag);
-				}
-			}
-
-			/*
-			 * Release the htab-owned lifetime. This must happen exactly once:
-			 * only in the same path that removed shared_tuplestores[tag].
-			 */
-			if (detach_handle != DSM_HANDLE_INVALID)
-			{
 				if (fileset != NULL)
 					SharedFileSetUnpin(fileset);
 
@@ -1987,7 +1954,6 @@ get_shared_state(const char *filename)
 		sstate->num_current = 0;
 		sstate->num_done = 0;
 		sstate->aborting = false;
-		sstate->created = false;
 		/*
 		 * We might not know the total number of shares, the writer will set it.
 		 * It's okay to set it later since no process will cleanup before the
@@ -2111,7 +2077,6 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *deprecated_va
 	LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
 	
 	state->shared_state->num_total = ntotal;
-	state->shared_state->created = true;
 
 	LWLockRelease(ShareInputScanLock);
 
@@ -2384,22 +2349,6 @@ AtAbort_SharedTuplestores()
 			/* Get handler for fileset. */
 			fileset = attach_shareinput_fileset(handle);
 		
-			/*
-			* No one is using it, and we're aborting so no one will use it
-			* in the future either. It's safe to delete the files now.
-			* Also delete the shared memory entry. We do not need to delete
-			* files if the SharedFileSet was already cleaned up.
-			*/
-			if (sstate->created &&
-				fileset != NULL &&
-				sstate->sfs_creator_pid == fileset->creator_pid &&
-				sstate->sfs_number == fileset->number)
-			{
-				BufFileDeleteShared(fileset, sstate->tag);
-				elog((Debug_shareinput_xslice ? LOG : DEBUG1), "SISC (file=%s, slice=%d): file deleted on abort",
-					sstate->tag, currentSliceId);
-			}
-
 			/* 
 			 * Unpin fileset from htab if not NULL. 
 			 * Possibly can be NULL if skip_open was true in process of creation. 

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -2435,7 +2435,7 @@ AtAbort_SharedTuplestores()
  * 
  * Previously we used get_shareinput_fileset() for this purposes
  * except we shouldn't have been. As this function have been creating 
- * dsm_segments that lived until postmaster death, holding segment, went down. That
+ * dsm_segments that lived until postmaster, holding segment, went down. That
  * behavior have been creating problem, when this postmasters have been reused
  * as shareinput fileset were never updated. To keep filesets consistent
  * this system was reworked so from now we use hashtable for sharefilesets

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -2037,7 +2037,7 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset, cons
 {
 	ResourceOwner oldowner;
 	TuplestoreSharingState *sstate;
-    SharedFileSet *fileset;
+    SharedFileSet *real_fileset;
     dsm_handle handle = DSM_HANDLE_INVALID;
 
 	state->work_set = workfile_mgr_create_set("SharedTupleStore", filename, true /* hold pin */);
@@ -2056,7 +2056,7 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset, cons
 
 	LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
 
-	sstate = get_shared_state(filename);
+	sstate = get_shared_state(NULL, filename);
 	Assert(sstate->session_id == gp_session_id);
 
 	if (sstate->aborting)
@@ -2071,20 +2071,20 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset, cons
 
 	if (sstate->sfs_handle == DSM_HANDLE_INVALID)
 	{
-		fileset = create_shareinput_fileset(&handle);
+		real_fileset = create_shareinput_fileset(&handle);
 
 		sstate->sfs_handle = handle;
-		sstate->sfs_creator_pid = fileset->creator_pid;
-		sstate->sfs_number = fileset->number;
+		sstate->sfs_creator_pid = real_fileset->creator_pid;
+		sstate->sfs_number = real_fileset->number;
 	}
 	else
 	{
 		handle = sstate->sfs_handle;
-		fileset = attach_shareinput_fileset(handle);
+		real_fileset = attach_shareinput_fileset(handle);
 	}
 
 	state->share_status = TSHARE_WRITER;
-	state->fileset = fileset;
+	state->fileset = real_fileset;
 	state->shared_filename = pstrdup(filename);
 	state->shared_state = sstate;
 
@@ -2103,7 +2103,7 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset, cons
 	/* Make sure the file only exists if and only if shared state was successfully created */
 	PG_TRY();
 	{
-		state->myfile = BufFileCreateShared(fileset, filename, state->work_set);
+		state->myfile = BufFileCreateShared(real_fileset, filename, state->work_set);
 	}
 	PG_CATCH();
 	{
@@ -2240,11 +2240,11 @@ tuplestore_reader_waitready(TuplestoreSharingState *sstate)
  * if this might be called on segments.
  */
 Tuplestorestate *
-tuplestore_open_shared_extended(const char *filename, bool skip_open)
+tuplestore_open_shared_extended(SharedFileSet *fileset, const char *filename, bool skip_open)
 {
 	Tuplestorestate *state;
 	TuplestoreSharingState *sstate;
-	SharedFileSet *fileset = NULL;
+	SharedFileSet *real_fileset = NULL;
 	dsm_handle 	handle = DSM_HANDLE_INVALID;
 	int			eflags;
 
@@ -2258,7 +2258,7 @@ tuplestore_open_shared_extended(const char *filename, bool skip_open)
 
 	LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
 
-	sstate = get_shared_state(filename);
+	sstate = get_shared_state(NULL, filename);
 	Assert(sstate->session_id == gp_session_id);
 
 	/*
@@ -2315,10 +2315,10 @@ tuplestore_open_shared_extended(const char *filename, bool skip_open)
 
 		LWLockRelease(ShareInputScanLock);
 
-		fileset = attach_shareinput_fileset(handle);
+		real_fileset = attach_shareinput_fileset(handle);
 
-		state->fileset = fileset;
-		state->myfile = BufFileOpenShared(fileset, filename);
+		state->fileset = real_fileset;
+		state->myfile = BufFileOpenShared(real_fileset, filename);
 		state->readptrs[0].file = 0;
 		state->readptrs[0].offset = 0L;
 		state->status = TSS_READFILE;

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -182,8 +182,6 @@ typedef struct
 	 */
 	bool aborting;
 
-	/* True if the file was created and should be deleted on abort */
-	bool created;
 	pg_atomic_uint32	ready;	/* is the input fully materialized and ready to be read? */
 
 	/*
@@ -635,11 +633,7 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 	 * Used after releasing the lock.
 	 */
 	bool		should_remove_entry = false;
-	bool		should_delete_file = false;
-	char		delete_tag[NAMEDATALEN];
 	dsm_handle	detach_handle = DSM_HANDLE_INVALID;
-	pid_t		delete_creator_pid = 0;
-	uint32		delete_sfs_number = 0;
 
 	tuplestore_report(state);
 
@@ -692,15 +686,6 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 				 */
 				Assert(strlen(state->shared_filename) < NAMEDATALEN);
 
-				strlcpy(delete_tag,
-						state->shared_filename,
-						sizeof(delete_tag));
-
-				delete_creator_pid = sstate->sfs_creator_pid;
-				delete_sfs_number = sstate->sfs_number;
-
-				should_delete_file = sstate->created;
-
 				if (hash_search(shared_tuplestores,
 								state->shared_filename,
 								HASH_REMOVE, NULL) == NULL)
@@ -729,24 +714,6 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 			if (fileset == NULL && detach_handle != DSM_HANDLE_INVALID)
 			{
 				fileset = attach_shareinput_fileset(detach_handle);
-			}
-
-			if (should_delete_file)
-			{
-				if (fileset != NULL &&
-					fileset->creator_pid == delete_creator_pid &&
-					fileset->number == delete_sfs_number)
-				{
-					BufFileDeleteShared(fileset, delete_tag);
-				}
-			}
-
-			/*
-			 * Release the htab-owned lifetime. This must happen exactly once:
-			 * only in the same path that removed shared_tuplestores[tag].
-			 */
-			if (detach_handle != DSM_HANDLE_INVALID)
-			{
 				if (fileset != NULL)
 					SharedFileSetUnpin(fileset);
 
@@ -1984,7 +1951,6 @@ get_shared_state(const char *filename)
 		sstate->num_current = 0;
 		sstate->num_done = 0;
 		sstate->aborting = false;
-		sstate->created = false;
 		/*
 		 * We might not know the total number of shares, the writer will set it.
 		 * It's okay to set it later since no process will cleanup before the
@@ -2371,22 +2337,6 @@ AtAbort_SharedTuplestores()
 			/* Get handler for fileset. */
 			fileset = attach_shareinput_fileset(handle);
 		
-			/*
-			* No one is using it, and we're aborting so no one will use it
-			* in the future either. It's safe to delete the files now.
-			* Also delete the shared memory entry. We do not need to delete
-			* files if the SharedFileSet was already cleaned up.
-			*/
-			if (sstate->created &&
-				fileset != NULL &&
-				sstate->sfs_creator_pid == fileset->creator_pid &&
-				sstate->sfs_number == fileset->number)
-			{
-				BufFileDeleteShared(fileset, sstate->tag);
-				elog((Debug_shareinput_xslice ? LOG : DEBUG1), "SISC (file=%s, slice=%d): file deleted on abort",
-					sstate->tag, currentSliceId);
-			}
-
 			/* 
 			 * Unpin fileset from htab if not NULL. 
 			 * Possibly can be NULL if skip_open was true in process of creation. 

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -98,6 +98,7 @@
 
 #include "cdb/cdbvars.h"
 #include "executor/instrument.h"        /* struct Instrumentation */
+#include "executor/nodeShareInputScan.h" /* get_shareinput_fileset */
 #include "utils/workfile_mgr.h"
 
 
@@ -377,9 +378,8 @@ static unsigned int getlen(Tuplestorestate *state, bool eofOK);
 static void *copytup_heap(Tuplestorestate *state, void *tup);
 static void writetup_heap(Tuplestorestate *state, void *tup);
 static void *readtup_heap(Tuplestorestate *state, unsigned int len);
-static void attach_shareinput_fileset(dsm_handle handle);
+static SharedFileSet *attach_shareinput_fileset(dsm_handle handle);
 static SharedFileSet *create_shareinput_fileset(dsm_handle *handle_out);
-static SharedFileSet *get_shareinput_fileset(dsm_handle handle_out);
 
 
 char *
@@ -1924,9 +1924,6 @@ get_shared_state(const char *filename)
 					(errcode(ERRCODE_OUT_OF_MEMORY),
 					errmsg("out of shared tuplestore slots")));
 		}
-
-		SharedFileSet *fileset = NULL;
-
 		sstate->session_id = gp_session_id;
 		sstate->num_current = 0;
 		sstate->num_done = 0;
@@ -1938,20 +1935,9 @@ get_shared_state(const char *filename)
 		 * writer is ready anyway.
 		 */
 		sstate->num_total = UINT32_MAX;
-		/* Unlock in case of error */
-		PG_TRY();
-		{
-			fileset = create_shareinput_fileset(&(sstate->sfs_handle));
-		}
-		PG_CATCH();
-		{
-			sstate->aborting = true;
-			LWLockRelease(ShareInputScanLock);
-			PG_RE_THROW();
-		}
-		PG_END_TRY();
-		sstate->sfs_creator_pid = fileset->creator_pid;
-		sstate->sfs_number = fileset->number;
+		sstate->sfs_creator_pid = 0;
+		sstate->sfs_handle = DSM_HANDLE_INVALID;
+		sstate->sfs_number = 0;
 
 		pg_atomic_init_u32(&sstate->ready, 0);
 		ConditionVariableInit(&sstate->ready_done_cv);
@@ -1959,20 +1945,7 @@ get_shared_state(const char *filename)
 		elog((Debug_shareinput_xslice ? LOG : DEBUG1), "SISC (file=%s, slice=%d): initialized shared state",
 			 filename, currentSliceId);
 	}
-	else
-	{
-		PG_TRY();
-		{
-			attach_shareinput_fileset(sstate->sfs_handle);
-		}
-		PG_CATCH();
-		{
-			sstate->aborting = true;
-			LWLockRelease(ShareInputScanLock);
-			PG_RE_THROW();
-		}
-		PG_END_TRY();
-	}
+
 	/*
 	 * This ensures the shared state won't be suddenly deleted after we
 	 * release the lock.
@@ -2000,6 +1973,7 @@ tuplestore_make_shared_many(Tuplestorestate *state, const char *filename, uint32
 	ResourceOwner oldowner;
 	TuplestoreSharingState *sstate;
     SharedFileSet *fileset;
+    dsm_handle handle = DSM_HANDLE_INVALID;
 
 	state->work_set = workfile_mgr_create_set("SharedTupleStore", filename, true /* hold pin */);
 
@@ -2030,10 +2004,26 @@ tuplestore_make_shared_many(Tuplestorestate *state, const char *filename, uint32
 				errmsg("tuplestore operation aborted, canceling")));
 	}
 
-	state->share_status = TSHARE_WRITER;
+	/* Unlock in case of error */
 	PG_TRY();
 	{
-		fileset = get_shareinput_fileset(sstate->sfs_handle);
+		/*
+		* The first participant may have been a reader. The writer is the one
+		* who creates the actual SharedFileSet and BufFile.
+		*/
+		if (sstate->sfs_handle == DSM_HANDLE_INVALID)
+		{
+			fileset = create_shareinput_fileset(&handle);
+
+			sstate->sfs_handle = handle;
+			sstate->sfs_creator_pid = fileset->creator_pid;
+			sstate->sfs_number = fileset->number;
+		}
+		else
+		{
+			handle = sstate->sfs_handle;
+			fileset = attach_shareinput_fileset(handle);
+		}
 	}
 	PG_CATCH();
 	{
@@ -2043,6 +2033,8 @@ tuplestore_make_shared_many(Tuplestorestate *state, const char *filename, uint32
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
+
+	state->share_status = TSHARE_WRITER;
 	state->fileset = fileset;
 	state->shared_filename = pstrdup(filename);
 	state->shared_state = sstate;
@@ -2055,6 +2047,9 @@ tuplestore_make_shared_many(Tuplestorestate *state, const char *filename, uint32
 	PG_TRY();
 	{
 		state->myfile = BufFileCreateShared(fileset, filename, state->work_set);
+		CurrentResourceOwner = oldowner;
+		state->shared_state->num_total = ntotal;
+		state->shared_state->created = true;
 	}
 	PG_CATCH();
 	{
@@ -2066,10 +2061,6 @@ tuplestore_make_shared_many(Tuplestorestate *state, const char *filename, uint32
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
-
-	CurrentResourceOwner = oldowner;
-	state->shared_state->num_total = ntotal;
-	state->shared_state->created = true;
 
 	/*
 	 * For now, be conservative and always use trailing length words for
@@ -2194,6 +2185,7 @@ tuplestore_open_shared_extended(const char *filename, bool skip_open)
 	Tuplestorestate *state;
 	TuplestoreSharingState *sstate;
 	SharedFileSet *fileset = NULL;
+	dsm_handle 	handle;
 	int			eflags;
 
 	/*
@@ -2222,6 +2214,8 @@ tuplestore_open_shared_extended(const char *filename, bool skip_open)
 				 errmsg("tuplestore operation aborted, canceling")));
 	}
 
+	LWLockRelease(ShareInputScanLock);
+
 	eflags = EXEC_FLAG_BACKWARD | EXEC_FLAG_REWIND;
 
 	state = tuplestore_begin_common(eflags,
@@ -2239,31 +2233,18 @@ tuplestore_open_shared_extended(const char *filename, bool skip_open)
 	state->frozen = false;
 	state->shared_filename = pstrdup(filename);
 
-	PG_TRY();
-	{
-		fileset = get_shareinput_fileset(sstate->sfs_handle);
-	}
-	PG_CATCH();
-	{
-		sstate->aborting = true;
-		sstate->num_current--;
-		LWLockRelease(ShareInputScanLock);
-		PG_RE_THROW();
-	}
-	PG_END_TRY();
-
-	state->fileset = fileset;
-
 	/* Remember this tuplestore in case we have to close it while aborting */
 	local_shared_tuplestores = lappend(local_shared_tuplestores, state);
-
-	LWLockRelease(ShareInputScanLock);
 
 	/* Only open file if requested */
 	if (!skip_open) {
 		/* Wait until writer is ready */
 		tuplestore_reader_waitready(sstate);
 
+		handle = sstate->sfs_handle;
+		fileset = attach_shareinput_fileset(handle);
+
+		state->fileset = fileset;
 		state->myfile = BufFileOpenShared(fileset, filename);
 		state->readptrs[0].file = 0;
 		state->readptrs[0].offset = 0L;
@@ -2333,7 +2314,7 @@ AtAbort_SharedTuplestores()
 		
 		if (handle != DSM_HANDLE_INVALID) 
 		{
-			SharedFileSet *sisc_fileset = get_shareinput_fileset(handle);
+			SharedFileSet *sisc_fileset = attach_shareinput_fileset(handle);
 		
 			/*
 			* No one is using it, and we're aborting so no one will use it
@@ -2391,10 +2372,10 @@ create_shareinput_fileset(dsm_handle *handle_out)
 	 */
 	SharedFileSetPin(fileset);
 
-	return fileset;
+    return fileset;
 }
 
-static void
+static SharedFileSet *
 attach_shareinput_fileset(dsm_handle handle)
 {
     dsm_segment *seg;
@@ -2419,25 +2400,10 @@ attach_shareinput_fileset(dsm_handle handle)
         fileset = dsm_segment_address(seg);
         SharedFileSetAttach(fileset, seg);
     }
-}
-
-static SharedFileSet *
-get_shareinput_fileset(dsm_handle handle)
-{
-    dsm_segment *seg;
-    SharedFileSet *fileset;
-
-    if (handle == DSM_HANDLE_INVALID)
-        elog(ERROR, "invalid ShareInputScan SharedFileSet DSM handle");
-
-    seg = dsm_find_mapping(handle);
-
-    if (seg == NULL)
+    else
     {
-		elog(ERROR, "could not get SharedFileSet from DSM segment");
+        fileset = dsm_segment_address(seg);
     }
-
-	fileset = dsm_segment_address(seg);
 
     return fileset;
 }

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -352,8 +352,8 @@ struct Tuplestorestate
 
 /*
  * Hash table of all shared tuplestores. The entry should be
- * created when a shared tuplestore is opened, and deleted
- * when it is deleted.
+ * created when a shared tuplestore is opened, and removed
+ * when tuplestore within it is being deleted.
  */
 static HTAB *shared_tuplestores = NULL;
 /*

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -2190,7 +2190,6 @@ tuplestore_open_shared_extended(SharedFileSet *deprecated_variable, const char *
 	     * so someone else must be holding it right now.
 		 */
 		Assert(sstate->num_current > 0);
-		LWLockRelease(ShareInputScanLock);
 		ereport(ERROR,
 				(errcode(ERRCODE_GP_OPERATION_CANCELED),
 				 errmsg("tuplestore operation aborted, canceling")));

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -187,13 +187,13 @@ typedef struct
 	pg_atomic_uint32	ready;	/* is the input fully materialized and ready to be read? */
 
 	/*
-	 * ready_done_cv is used for signaling when the scan becomes "ready", and
-	 * when it becomes "done". The producer wakes up everyone waiting on this
-	 * condition variable when it sets ready = true. Also, when the last
-	 * consumer finishes the scan (ndone reaches nconsumers), it wakes up the
-	 * producer using this same condition variable.
+	 * ready_cv is used for signaling when the scan becomes "ready". 
+	 * The producer wakes up everyone waiting on this condition variable when
+	 * it sets ready = true. Also, when the last consumer finishes the scan
+	 * (ndone reaches nconsumers), it wakes up the producer using this same
+	 * condition variable.
 	 */
-	ConditionVariable ready_done_cv;
+	ConditionVariable ready_cv;
 
 	/* Data to identify the SharedFileSet that was used */
 	pid_t		sfs_creator_pid;
@@ -671,10 +671,7 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 		 * do so after they're done using it.
 		 */
 		if (should_abort)
-		{
 			sstate->aborting = true;
-			ConditionVariableBroadcast(&sstate->ready_done_cv);
-		}
 			
 		sstate->num_done++;
 		sstate->num_current--;
@@ -1999,7 +1996,7 @@ get_shared_state(const char *filename)
 		sstate->sfs_number = 0;
 
 		pg_atomic_init_u32(&sstate->ready, 0);
-		ConditionVariableInit(&sstate->ready_done_cv);
+		ConditionVariableInit(&sstate->ready_cv);
 
 		elog((Debug_shareinput_xslice ? LOG : DEBUG1), "SISC (file=%s, slice=%d): initialized shared state",
 			 filename, currentSliceId);
@@ -2056,11 +2053,13 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *deprecated_va
 	sstate = get_shared_state(filename);
 	Assert(sstate->session_id == gp_session_id);
 
-	if (sstate->aborting)
-	{
+	if (sstate->aborting) {
 		sstate->num_current--;
-		LWLockRelease(ShareInputScanLock);
-
+		/*
+		 * This couldn't be a freshly created shared state,
+	     * so someone else must be holding it right now.
+		 */
+		Assert(sstate->num_current > 0);
 		ereport(ERROR,
 				(errcode(ERRCODE_GP_OPERATION_CANCELED),
 				errmsg("tuplestore operation aborted, canceling")));
@@ -2085,6 +2084,8 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *deprecated_va
 	state->shared_filename = pstrdup(filename);
 	state->shared_state = sstate;
 
+	state->shared_state->num_total = ntotal;
+
 	/*
 	 * From this point, AtAbort_SharedTuplestores() can find this state
 	 * and tuplestore_cleanup() owns num_current.
@@ -2105,18 +2106,10 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *deprecated_va
 	 * reader processes agree on this, and forcing it to true is the
 	 * simplest way to achieve that.
 	 */
-
-	CurrentResourceOwner = oldowner;
-
-	LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
-	
-	state->shared_state->num_total = ntotal;
-	state->shared_state->created = true;
-
-	LWLockRelease(ShareInputScanLock);
-
 	state->backward = true;
 	state->status = TSS_WRITEFILE;
+
+	CurrentResourceOwner = oldowner;
 }
 
 /*
@@ -2167,7 +2160,7 @@ tuplestore_freeze(Tuplestorestate *state)
 	SIMPLE_FAULT_INJECTOR("tuplestore_freeze");
 #endif
 
-	ConditionVariableBroadcast(&sstate->ready_done_cv);
+	ConditionVariableBroadcast(&sstate->ready_cv);
 
 	elog((Debug_shareinput_xslice ? LOG : DEBUG1), "SISC WRITER (file=%s, slice=%d): wrote notify_ready",
 		 state->shared_filename, currentSliceId);
@@ -2200,7 +2193,7 @@ tuplestore_reader_waitready(TuplestoreSharingState *sstate)
 		if (ready)
 			break;
 
-		ConditionVariableSleep(&sstate->ready_done_cv, WAIT_EVENT_SHAREINPUT_SCAN);
+		ConditionVariableSleep(&sstate->ready_cv, WAIT_EVENT_SHAREINPUT_SCAN);
 	}
 	ConditionVariableCancelSleep();
 
@@ -2257,6 +2250,11 @@ tuplestore_open_shared_extended(SharedFileSet *deprecated_variable, const char *
 	if (sstate->aborting) 
 	{
 		sstate->num_current--;
+		/*
+		 * This couldn't be a freshly created shared state,
+	     * so someone else must be holding it right now.
+		 */
+		Assert(sstate->num_current > 0);
 		LWLockRelease(ShareInputScanLock);
 		ereport(ERROR,
 				(errcode(ERRCODE_GP_OPERATION_CANCELED),
@@ -2282,26 +2280,12 @@ tuplestore_open_shared_extended(SharedFileSet *deprecated_variable, const char *
 	state->frozen = false;
 	state->shared_filename = pstrdup(filename);
 
-	/* Remember this tuplestore in case we have to close it while aborting */
-	local_shared_tuplestores = lappend(local_shared_tuplestores, state);
-
 	/* Only open file if requested */
 	if (!skip_open) {
 		/* Wait until writer is ready */
 		tuplestore_reader_waitready(sstate);
 
-		LWLockAcquire(ShareInputScanLock, LW_SHARED);
-
-		if (sstate->aborting) 
-		{
-			LWLockRelease(ShareInputScanLock);
-			ereport(ERROR,
-					(errcode(ERRCODE_GP_OPERATION_CANCELED),
-					errmsg("tuplestore operation aborted, canceling")));
-		}
 		handle = sstate->sfs_handle;
-
-		LWLockRelease(ShareInputScanLock);
 
 		fileset = attach_shareinput_fileset(handle);
 
@@ -2311,6 +2295,9 @@ tuplestore_open_shared_extended(SharedFileSet *deprecated_variable, const char *
 		state->readptrs[0].offset = 0L;
 		state->status = TSS_READFILE;
 	}
+
+	/* Remember this tuplestore in case we have to close it while aborting */
+	local_shared_tuplestores = lappend(local_shared_tuplestores, state);
 
 	return state;
 }

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -714,11 +714,11 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 			if (fileset == NULL && detach_handle != DSM_HANDLE_INVALID)
 			{
 				fileset = attach_shareinput_fileset(detach_handle);
-				if (fileset != NULL)
-					SharedFileSetUnpin(fileset);
-
-				dsm_unpin_segment(detach_handle);
 			}
+			if (fileset != NULL)
+				SharedFileSetUnpin(fileset);
+
+			dsm_unpin_segment(detach_handle);
 		}
 	}
 

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -630,6 +630,19 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 {
 	int			i;
 
+	/*
+	 * Values copied from shared state while holding ShareInputScanLock.
+	 * Used after releasing the lock.
+	 */
+	bool		should_remove_entry = false;
+	bool		should_delete_file = false;
+	bool		should_release_fileset = false;
+	char		delete_tag[NAMEDATALEN];
+	dsm_handle	delete_handle = DSM_HANDLE_INVALID;
+	dsm_handle	local_detach_handle = DSM_HANDLE_INVALID;
+	pid_t		delete_creator_pid = 0;
+	uint32		delete_sfs_number = 0;
+
 	tuplestore_report(state);
 
 	if (state->share_status != TSHARE_NOT_SHARED)
@@ -649,11 +662,8 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 		 */
 		LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
 
-		dsm_handle handle = sstate->sfs_handle;
-
-		dsm_segment *seg = dsm_find_mapping(handle);
-
 		Assert(sstate->session_id == gp_session_id);
+		local_detach_handle = sstate->sfs_handle;
 		/*
 		 * If we are aborting, set the variable in shared memory.
 		 * This must be done before everything else, since if we can't
@@ -661,7 +671,11 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 		 * do so after they're done using it.
 		 */
 		if (should_abort)
+		{
 			sstate->aborting = true;
+			ConditionVariableBroadcast(&sstate->ready_done_cv); // fixme
+		}
+			
 		sstate->num_done++;
 		sstate->num_current--;
 		Assert(sstate->num_done <= sstate->num_total);
@@ -680,38 +694,88 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 				 * after us.
 				 */
 				Assert(strlen(state->shared_filename) < NAMEDATALEN);
-				if (sstate->created)
-				{
-					BufFileDeleteShared(state->fileset, state->shared_filename);
-					sstate->created = false;
-				}
 
-				if (handle != DSM_HANDLE_INVALID)
-				{
-					SharedFileSetUnpin(state->fileset);
-					dsm_unpin_segment(handle);
-				}
+				strlcpy(delete_tag,
+						state->shared_filename,
+						sizeof(delete_tag));
+
+				delete_handle = sstate->sfs_handle;
+				delete_creator_pid = sstate->sfs_creator_pid;
+				delete_sfs_number = sstate->sfs_number;
+
+				should_delete_file = sstate->created;
+				should_release_fileset = delete_handle != DSM_HANDLE_INVALID;
+
+				sstate->created = false;
 
 				if (hash_search(shared_tuplestores,
 								state->shared_filename,
 								HASH_REMOVE, NULL) == NULL)
 					elog(ERROR, "hash table corrupted");
+
+				should_remove_entry = true;
 				
 				elog((Debug_shareinput_xslice ? LOG : DEBUG1), "SISC (file=%s, slice=%d): file deleted",
 					 state->shared_filename, currentSliceId);
 			}
 		}
 
-		if (seg != NULL)
-		{
-			dsm_detach(seg);
-		}
-
 		LWLockRelease(ShareInputScanLock);
+
+		/*
+		 * External cleanup happens outside ShareInputScanLock.
+		 *
+		 * state->fileset can be NULL here. This happens for skip_open /
+		 * squelch paths, but such a participant can still become the last
+		 * user and therefore be responsible for deleting the shared file.
+		 */
+		if (should_remove_entry)
+		{
+			SharedFileSet *fileset = state->fileset;
+
+			if (fileset == NULL && should_release_fileset)
+			{
+				fileset = attach_shareinput_fileset(delete_handle);
+			}
+
+			if (should_delete_file)
+			{
+				if (fileset != NULL &&
+					fileset->creator_pid == delete_creator_pid &&
+					fileset->number == delete_sfs_number)
+				{
+					BufFileDeleteShared(fileset, delete_tag);
+
+					elog((Debug_shareinput_xslice ? LOG : DEBUG1),
+						 "SISC (file=%s, slice=%d): file deleted",
+						 delete_tag, currentSliceId);
+				}
+			}
+
+			/*
+			 * Release the htab-owned lifetime. This must happen exactly once:
+			 * only in the same path that removed shared_tuplestores[tag].
+			 */
+			if (should_release_fileset)
+			{
+				if (fileset != NULL)
+					SharedFileSetUnpin(fileset);
+
+				dsm_unpin_segment(delete_handle);
+			}
+		}
 	}
 
 	if (state->myfile)
 		BufFileClose(state->myfile);
+	if (local_detach_handle != DSM_HANDLE_INVALID)
+	{
+		dsm_segment *seg;
+
+		seg = dsm_find_mapping(local_detach_handle);
+		if (seg != NULL)
+			dsm_detach(seg);
+	}
 	if (state->work_set)
 		workfile_mgr_close_set(state->work_set);
 	if (state->shared_filename)
@@ -2004,40 +2068,32 @@ tuplestore_make_shared_many(Tuplestorestate *state, const char *filename, uint32
 				errmsg("tuplestore operation aborted, canceling")));
 	}
 
-	/* Unlock in case of error */
-	PG_TRY();
+	if (sstate->sfs_handle == DSM_HANDLE_INVALID)
 	{
-		/*
-		* The first participant may have been a reader. The writer is the one
-		* who creates the actual SharedFileSet and BufFile.
-		*/
-		if (sstate->sfs_handle == DSM_HANDLE_INVALID)
-		{
-			fileset = create_shareinput_fileset(&handle);
+		fileset = create_shareinput_fileset(&handle);
 
-			sstate->sfs_handle = handle;
-			sstate->sfs_creator_pid = fileset->creator_pid;
-			sstate->sfs_number = fileset->number;
-		}
-		else
-		{
-			handle = sstate->sfs_handle;
-			fileset = attach_shareinput_fileset(handle);
-		}
+		sstate->sfs_handle = handle;
+		sstate->sfs_creator_pid = fileset->creator_pid;
+		sstate->sfs_number = fileset->number;
 	}
-	PG_CATCH();
+	else
 	{
-		sstate->aborting = true;
-		sstate->num_current--;
-		LWLockRelease(ShareInputScanLock);
-		PG_RE_THROW();
+		handle = sstate->sfs_handle;
+		fileset = attach_shareinput_fileset(handle);
 	}
-	PG_END_TRY();
 
 	state->share_status = TSHARE_WRITER;
 	state->fileset = fileset;
 	state->shared_filename = pstrdup(filename);
 	state->shared_state = sstate;
+
+	/*
+	 * From this point, AtAbort_SharedTuplestores() can find this state
+	 * and tuplestore_cleanup() owns num_current.
+	 */
+	local_shared_tuplestores = lappend(local_shared_tuplestores, state);
+
+	LWLockRelease(ShareInputScanLock);
 
 	/* associate the file with the store's resource owner */
 	oldowner = CurrentResourceOwner;
@@ -2047,16 +2103,14 @@ tuplestore_make_shared_many(Tuplestorestate *state, const char *filename, uint32
 	PG_TRY();
 	{
 		state->myfile = BufFileCreateShared(fileset, filename, state->work_set);
-		CurrentResourceOwner = oldowner;
-		state->shared_state->num_total = ntotal;
-		state->shared_state->created = true;
 	}
 	PG_CATCH();
 	{
 		CurrentResourceOwner = oldowner;
+
+		LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
 		sstate->aborting = true;
-		sstate->num_current--;
-		BufFileDeleteShared(fileset, filename);
+		ConditionVariableBroadcast(&sstate->ready_done_cv); //fixme
 		LWLockRelease(ShareInputScanLock);
 		PG_RE_THROW();
 	}
@@ -2068,13 +2122,18 @@ tuplestore_make_shared_many(Tuplestorestate *state, const char *filename, uint32
 	 * reader processes agree on this, and forcing it to true is the
 	 * simplest way to achieve that.
 	 */
-	state->backward = true;
-	state->status = TSS_WRITEFILE;
 
-	/* Remember this tuplestore to clear it in case of error */
-	local_shared_tuplestores = lappend(local_shared_tuplestores, state);
+	CurrentResourceOwner = oldowner;
+
+	LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
+	
+	state->shared_state->num_total = ntotal;
+	state->shared_state->created = true;
 
 	LWLockRelease(ShareInputScanLock);
+
+	state->backward = true;
+	state->status = TSS_WRITEFILE;
 }
 
 /*
@@ -2185,7 +2244,7 @@ tuplestore_open_shared_extended(const char *filename, bool skip_open)
 	Tuplestorestate *state;
 	TuplestoreSharingState *sstate;
 	SharedFileSet *fileset = NULL;
-	dsm_handle 	handle;
+	dsm_handle 	handle = DSM_HANDLE_INVALID;
 	int			eflags;
 
 	/*
@@ -2206,7 +2265,8 @@ tuplestore_open_shared_extended(const char *filename, bool skip_open)
 	 * nobody will abort before we release the lock here. Someone else will
 	 * delete it after we are done here.
 	 */
-	if (sstate->aborting) {
+	if (sstate->aborting) 
+	{
 		sstate->num_current--;
 		LWLockRelease(ShareInputScanLock);
 		ereport(ERROR,
@@ -2241,7 +2301,19 @@ tuplestore_open_shared_extended(const char *filename, bool skip_open)
 		/* Wait until writer is ready */
 		tuplestore_reader_waitready(sstate);
 
+		LWLockAcquire(ShareInputScanLock, LW_SHARED);
+
+		if (sstate->aborting) 
+		{
+			LWLockRelease(ShareInputScanLock);
+			ereport(ERROR,
+					(errcode(ERRCODE_GP_OPERATION_CANCELED),
+					errmsg("tuplestore operation aborted, canceling")));
+		}
 		handle = sstate->sfs_handle;
+
+		LWLockRelease(ShareInputScanLock);
+
 		fileset = attach_shareinput_fileset(handle);
 
 		state->fileset = fileset;
@@ -2301,6 +2373,9 @@ AtAbort_SharedTuplestores()
 	hash_seq_init(&seq_status, shared_tuplestores);
 	while ((sstate = hash_seq_search(&seq_status)) != NULL)
 	{
+		dsm_handle handle;
+		SharedFileSet *fileset = NULL;
+
 		/* Check if this is tuplestore belongs to this session */
 		if (sstate->session_id != gp_session_id)
 			continue;
@@ -2310,11 +2385,11 @@ AtAbort_SharedTuplestores()
 		if (sstate->num_current > 0)
 			continue;
 
-		dsm_handle handle = sstate->sfs_handle;
+		handle = sstate->sfs_handle;
 		
 		if (handle != DSM_HANDLE_INVALID) 
 		{
-			SharedFileSet *sisc_fileset = attach_shareinput_fileset(handle);
+			fileset = attach_shareinput_fileset(handle);
 		
 			/*
 			* No one is using it, and we're aborting so no one will use it
@@ -2323,16 +2398,18 @@ AtAbort_SharedTuplestores()
 			* files if the SharedFileSet was already cleaned up.
 			*/
 			if (sstate->created &&
-				sstate->sfs_creator_pid == sisc_fileset->creator_pid &&
-				sstate->sfs_number == sisc_fileset->number)
+				fileset != NULL &&
+				sstate->sfs_creator_pid == fileset->creator_pid &&
+				sstate->sfs_number == fileset->number)
 			{
-				BufFileDeleteShared(sisc_fileset, sstate->tag);
+				BufFileDeleteShared(fileset, sstate->tag);
 				sstate->created = false;
 				elog((Debug_shareinput_xslice ? LOG : DEBUG1), "SISC (file=%s, slice=%d): file deleted on abort",
 					sstate->tag, currentSliceId);
 			}
 
-			SharedFileSetUnpin(sisc_fileset);
+			if (fileset != NULL)
+				SharedFileSetUnpin(fileset);
 			dsm_unpin_segment(handle);
 		}
 		
@@ -2353,16 +2430,15 @@ create_shareinput_fileset(dsm_handle *handle_out)
 
     seg = dsm_create(sizeof(SharedFileSet), 0);
 
-    /*
-     * Keep the DSM alive even if the writer QE finishes before consumers
-     * have attached.
-     */
-    dsm_pin_segment(seg);
-
     fileset = dsm_segment_address(seg);
     *handle_out = dsm_segment_handle(seg);
 
     SharedFileSetInit(fileset, seg);
+
+	/*
+	 * Keep DSM alive between writer and consumers.
+	 */
+	dsm_pin_segment(seg);
 
 	/*
 	 * Extra ref owned by shared_tuplestores[tag].

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -745,10 +745,6 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 					fileset->number == delete_sfs_number)
 				{
 					BufFileDeleteShared(fileset, delete_tag);
-
-					elog((Debug_shareinput_xslice ? LOG : DEBUG1),
-						 "SISC (file=%s, slice=%d): file deleted",
-						 delete_tag, currentSliceId);
 				}
 			}
 
@@ -1967,7 +1963,7 @@ SharedTuplestoreShmemInit(void)
 }
 
 static TuplestoreSharingState *
-get_shared_state(const char *filename)
+get_shared_state(SharedFileSet *fileset, const char *filename)
 {
 	TuplestoreSharingState *sstate;
 	bool		found;
@@ -2032,7 +2028,7 @@ get_shared_state(const char *filename)
  * opened before it is automatically deleted.
  */
 void
-tuplestore_make_shared_many(Tuplestorestate *state, const char *filename, uint32 ntotal)
+tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset, const char *filename, uint32 ntotal)
 {
 	ResourceOwner oldowner;
 	TuplestoreSharingState *sstate;
@@ -2146,9 +2142,9 @@ tuplestore_make_shared_many(Tuplestorestate *state, const char *filename, uint32
  * after both the writer and a single reader close it.
  */
 void
-tuplestore_make_shared(Tuplestorestate *state, const char *filename)
+tuplestore_make_shared(Tuplestorestate *state, SharedFileSet *fileset, const char *filename)
 {
-	tuplestore_make_shared_many(state, filename, 2);
+	tuplestore_make_shared_many(state, fileset, filename, 2);
 }
 
 static void
@@ -2337,9 +2333,9 @@ tuplestore_open_shared_extended(const char *filename, bool skip_open)
  * if this might be called on segments.
  */
 Tuplestorestate *
-tuplestore_open_shared(const char *filename)
+tuplestore_open_shared(SharedFileSet *fileset, const char *filename)
 {
-	return tuplestore_open_shared_extended(filename, false);
+	return tuplestore_open_shared_extended(fileset, filename, false);
 }
 
 /*

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -2435,7 +2435,7 @@ AtAbort_SharedTuplestores()
  * 
  * Previously we used get_shareinput_fileset() for this purposes
  * except we shouldn't have been. As this function have been creating 
- * dsm_segments that live until postmaster, holding segment, went down. That
+ * dsm_segments that lived until postmaster, holding segment, went down. That
  * behavior have been creating problem, when this postmasters have been reused
  * as shareinput fileset were never updated. To keep filesets consistent
  * this system was reworked so from now we use hashtable for sharefilesets

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -663,6 +663,8 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 		LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
 
 		Assert(sstate->session_id == gp_session_id);
+
+		/* Remember handle, so we will detach in any way. */
 		local_detach_handle = sstate->sfs_handle;
 		/*
 		 * If we are aborting, set the variable in shared memory.
@@ -673,7 +675,7 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 		if (should_abort)
 		{
 			sstate->aborting = true;
-			ConditionVariableBroadcast(&sstate->ready_done_cv); // fixme
+			ConditionVariableBroadcast(&sstate->ready_done_cv);
 		}
 			
 		sstate->num_done++;
@@ -725,9 +727,9 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 		/*
 		 * External cleanup happens outside ShareInputScanLock.
 		 *
-		 * state->fileset can be NULL here. This happens for skip_open /
-		 * squelch paths, but such a participant can still become the last
-		 * user and therefore be responsible for deleting the shared file.
+		 * state->fileset can be NULL here. This happens for skip_open 
+		 * paths, and such participants can still become last users 
+		 * and therefore be responsible for deleting the shared file.
 		 */
 		if (should_remove_entry)
 		{
@@ -764,11 +766,14 @@ tuplestore_cleanup(Tuplestorestate *state, bool should_abort)
 
 	if (state->myfile)
 		BufFileClose(state->myfile);
+
+	/* Detach manually so we don't get warning */
 	if (local_detach_handle != DSM_HANDLE_INVALID)
 	{
 		dsm_segment *seg;
 
 		seg = dsm_find_mapping(local_detach_handle);
+		/* Check if we already detached and destroyed segment */
 		if (seg != NULL)
 			dsm_detach(seg);
 	}
@@ -2106,7 +2111,7 @@ tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset, cons
 
 		LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
 		sstate->aborting = true;
-		ConditionVariableBroadcast(&sstate->ready_done_cv); //fixme
+		ConditionVariableBroadcast(&sstate->ready_done_cv);
 		LWLockRelease(ShareInputScanLock);
 		PG_RE_THROW();
 	}
@@ -2385,6 +2390,7 @@ AtAbort_SharedTuplestores()
 		
 		if (handle != DSM_HANDLE_INVALID) 
 		{
+			/* Get handler for fileset. */
 			fileset = attach_shareinput_fileset(handle);
 		
 			/*
@@ -2404,8 +2410,13 @@ AtAbort_SharedTuplestores()
 					sstate->tag, currentSliceId);
 			}
 
+			/* 
+			 * Unpin fileset from htab if not NULL. 
+			 * Possibly can be NULL if skip_open was true in process of creation. 
+			 */
 			if (fileset != NULL)
 				SharedFileSetUnpin(fileset);
+			/* Release the global pin */
 			dsm_unpin_segment(handle);
 		}
 		
@@ -2418,6 +2429,19 @@ AtAbort_SharedTuplestores()
 	LWLockRelease(ShareInputScanLock);
 }
 
+/*
+ * Initializes given dsm_handle with further initialization of 
+ * shareinput fileset by this handle. After that pins fileset to HTAB.
+ * 
+ * Previously we used get_shareinput_fileset() for this purposes
+ * except we shouldn't have been. As this function have been creating 
+ * dsm_segments that live until postmaster, holding segment, went down. That
+ * behavior have been creating problem, when this postmasters have been reused
+ * as shareinput fileset were never updated. To keep filesets consistent
+ * this system was reworked so from now we use hashtable for sharefilesets
+ * where handle for according fileset is placed and kept until query execution
+ * ends (either successfully or with abort). 
+ */
 static SharedFileSet *
 create_shareinput_fileset(dsm_handle *handle_out)
 {
@@ -2447,6 +2471,9 @@ create_shareinput_fileset(dsm_handle *handle_out)
     return fileset;
 }
 
+/*
+ * Returns shareinput fileset placed in dsm.
+ */
 static SharedFileSet *
 attach_shareinput_fileset(dsm_handle handle)
 {

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -2215,7 +2215,7 @@ tuplestore_open_shared_extended(SharedFileSet *deprecated_variable, const char *
 		/* Wait until writer is ready */
 		tuplestore_reader_waitready(sstate);
 
-		state->fileset = attach_shareinput_fileset(sstate->sfs_handle);;
+		state->fileset = attach_shareinput_fileset(sstate->sfs_handle);
 		state->myfile = BufFileOpenShared(state->fileset, filename);
 		state->readptrs[0].file = 0;
 		state->readptrs[0].offset = 0L;

--- a/src/include/executor/nodeShareInputScan.h
+++ b/src/include/executor/nodeShareInputScan.h
@@ -29,6 +29,4 @@ extern void ShareInputReaderNotifyDone(ShareInputScanState *node); /* obsolete *
 extern Size ShareInputShmemSize(void);
 extern void ShareInputShmemInit(void);
 
-extern SharedFileSet *get_shareinput_fileset(void);
-
 #endif   /* NODESHAREINPUTSCAN_H */

--- a/src/include/executor/nodeShareInputScan.h
+++ b/src/include/executor/nodeShareInputScan.h
@@ -29,4 +29,6 @@ extern void ShareInputReaderNotifyDone(ShareInputScanState *node); /* obsolete *
 extern Size ShareInputShmemSize(void);
 extern void ShareInputShmemInit(void);
 
+extern SharedFileSet *get_shareinput_fileset(void);
+
 #endif   /* NODESHAREINPUTSCAN_H */

--- a/src/include/storage/sharedfileset.h
+++ b/src/include/storage/sharedfileset.h
@@ -41,5 +41,7 @@ extern File SharedFileSetOpen(SharedFileSet *fileset, const char *name);
 extern bool SharedFileSetDelete(SharedFileSet *fileset, const char *name,
 								bool error_on_failure);
 extern void SharedFileSetDeleteAll(SharedFileSet *fileset);
+extern void SharedFileSetPin(SharedFileSet *fileset);
+extern void SharedFileSetUnpin(SharedFileSet *fileset);
 
 #endif

--- a/src/include/utils/tuplestore.h
+++ b/src/include/utils/tuplestore.h
@@ -101,14 +101,14 @@ extern void tuplestore_set_instrument(Tuplestorestate *state,
 extern Size SharedTuplestoreShmemSize(void);
 extern void SharedTuplestoreShmemInit(void);
 
-extern void tuplestore_make_shared(Tuplestorestate *state,
+extern void tuplestore_make_shared(Tuplestorestate *state, SharedFileSet *fileset,
 								   const char *filename);
-extern void tuplestore_make_shared_many(Tuplestorestate *state, 
-										const char *filename, 
-										uint32 ntotal);
+extern void tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset,
+										const char *filename, uint32 ntotal);
 extern void tuplestore_freeze(Tuplestorestate *state);
-extern Tuplestorestate *tuplestore_open_shared(const char *filename);
-extern Tuplestorestate *tuplestore_open_shared_extended(const char *filename,
+extern Tuplestorestate *tuplestore_open_shared(SharedFileSet *fileset, const char *filename);
+extern Tuplestorestate *tuplestore_open_shared_extended(SharedFileSet *fileset,
+														const char *filename,
 														bool skip_wait);
 
 extern void AtAbort_SharedTuplestores(void);

--- a/src/include/utils/tuplestore.h
+++ b/src/include/utils/tuplestore.h
@@ -101,13 +101,13 @@ extern void tuplestore_set_instrument(Tuplestorestate *state,
 extern Size SharedTuplestoreShmemSize(void);
 extern void SharedTuplestoreShmemInit(void);
 
-extern void tuplestore_make_shared(Tuplestorestate *state, SharedFileSet *fileset,
+extern void tuplestore_make_shared(Tuplestorestate *state, SharedFileSet *deprecated_variable,
 								   const char *filename);
-extern void tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset,
+extern void tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *deprecated_variable,
 										const char *filename, uint32 ntotal);
 extern void tuplestore_freeze(Tuplestorestate *state);
-extern Tuplestorestate *tuplestore_open_shared(SharedFileSet *fileset, const char *filename);
-extern Tuplestorestate *tuplestore_open_shared_extended(SharedFileSet *fileset,
+extern Tuplestorestate *tuplestore_open_shared(SharedFileSet *deprecated_variable, const char *filename);
+extern Tuplestorestate *tuplestore_open_shared_extended(SharedFileSet *deprecated_variable,
 														const char *filename,
 														bool skip_wait);
 

--- a/src/include/utils/tuplestore.h
+++ b/src/include/utils/tuplestore.h
@@ -101,14 +101,14 @@ extern void tuplestore_set_instrument(Tuplestorestate *state,
 extern Size SharedTuplestoreShmemSize(void);
 extern void SharedTuplestoreShmemInit(void);
 
-extern void tuplestore_make_shared(Tuplestorestate *state, SharedFileSet *fileset,
+extern void tuplestore_make_shared(Tuplestorestate *state,
 								   const char *filename);
-extern void tuplestore_make_shared_many(Tuplestorestate *state, SharedFileSet *fileset,
-										const char *filename, uint32 ntotal);
+extern void tuplestore_make_shared_many(Tuplestorestate *state, 
+										const char *filename, 
+										uint32 ntotal);
 extern void tuplestore_freeze(Tuplestorestate *state);
-extern Tuplestorestate *tuplestore_open_shared(SharedFileSet *fileset, const char *filename);
-extern Tuplestorestate *tuplestore_open_shared_extended(SharedFileSet *fileset,
-														const char *filename,
+extern Tuplestorestate *tuplestore_open_shared(const char *filename);
+extern Tuplestorestate *tuplestore_open_shared_extended(const char *filename,
 														bool skip_wait);
 
 extern void AtAbort_SharedTuplestores(void);

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -186,6 +186,7 @@ tablespace-setup:
         ./testtablespace_1111111111222222222233333333334444444444555555555566666666667777777777888888888899999999990000000000/ \
 	./testtablespace_default_tablespace \
 	./testtablespace_temp_tablespace \
+	./testtablespace_temp_tablespace2 \
 	./testtablespace_mytempsp0 \
 	./testtablespace_mytempsp1 \
 	./testtablespace_mytempsp2 \

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -27,6 +27,103 @@ drop tablespace some_default_tablespace;
 reset default_tablespace;
 reset temp_tablespaces;
 
+-- We should be able to switch temp_tablespaces even in case of backends reusage
+
+create tablespace some_temp_tablespace2 location '@testtablespace@_temp_tablespace2';
+create table tts_temp (i int, j int) distributed by (i);
+insert into tts_temp select i, i from generate_series(1, 1000) i;
+analyze tts_temp;
+set optimizer = off;
+
+select gp_inject_fault('sisc_xslice_temp_files', 'skip', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+
+set gp_cached_segworkers_threshold = 20;
+
+--
+-- First execution: set temp_tablespaces.
+-- SharedInputScan files should use temp tablespace.
+--
+
+set temp_tablespaces = some_temp_tablespace2;
+
+-- start_ignore
+select quote_literal(now()) query_start_set;
+\gset
+-- end_ignore
+
+with a1 as materialized (select * from tts_temp)
+select count(*) from a1 t1, a1 t2;
+
+-- start_ignore
+SELECT quote_literal(now()) query_end_set;
+\gset
+-- end_ignore
+
+--
+-- Second execution: set temp_tablespaces to nothing.
+-- Cached QE backends should be reused, but SharedFileSet must be 
+-- recreated, so it honors the new temp_tablespaces value.
+--
+
+select gp_inject_fault('sisc_xslice_temp_files', 'reset', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+select gp_inject_fault('sisc_xslice_temp_files', 'skip', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+
+set temp_tablespaces = '';
+
+-- start_ignore
+select quote_literal(now()) query_start_unset;
+\gset
+-- end_ignore
+
+with a1 as materialized (select * from tts_temp)
+select count(*) from a1 t1, a1 t2;
+
+-- start_ignore
+SELECT quote_literal(now()) query_end_unset;
+\gset
+-- end_ignore
+
+-- start_ignore
+create temp table sisc_set_pids as
+select logpid
+from gp_toolkit.gp_log_system
+where logseverity = 'LOG'
+  and logtime between :query_start_set and :query_end_set
+  and logmessage like $$%fault triggered, fault name:'sisc_xslice_temp_files' fault type:'skip'%$$;
+
+create temp table sisc_unset_pids as
+select logpid
+from gp_toolkit.gp_log_system
+where logseverity = 'LOG'
+  and logtime between :query_start_unset and :query_end_unset
+  and logmessage like $$%fault triggered, fault name:'sisc_xslice_temp_files' fault type:'skip'%$$;
+-- end_ignore
+
+select count(*) from sisc_set_pids;
+select count(*) from sisc_unset_pids;
+
+select count(*) = 0 as set_minus_unset_empty
+from (
+    select logpid from sisc_set_pids
+    except
+    select logpid from sisc_unset_pids
+) s;
+
+reset temp_tablespaces;
+reset gp_cte_sharing;
+reset optimizer;
+reset gp_cached_segworkers_threshold;
+
+select gp_inject_fault('sisc_xslice_temp_files', 'reset', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+
+drop table tts_temp;
+drop table sisc_unset_pids;
+drop table sisc_set_pids;
+drop tablespace some_temp_tablespace2;
 
 -- When the GUC temp_tablespaces is set, one of the temp tablespaces is used instead of the default tablespace.
 -- create several tablespaces and use them as temp tablespaces

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -40,6 +40,111 @@ drop tablespace some_temp_tablespace;
 drop tablespace some_default_tablespace;
 reset default_tablespace;
 reset temp_tablespaces;
+-- We should be able to switch temp_tablespaces even in case of backends reusage
+create tablespace some_temp_tablespace2 location '/home/gpadmin/gpdb_src/src/test/regress/testtablespace_temp_tablespace2';
+create table tts_temp (i int, j int) distributed by (i);
+insert into tts_temp select i, i from generate_series(1, 1000) i;
+analyze tts_temp;
+set optimizer = off;
+select gp_inject_fault('sisc_xslice_temp_files', 'skip', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+set gp_cached_segworkers_threshold = 20;
+--
+-- First execution: set temp_tablespaces.
+-- SharedInputScan files should use temp tablespace.
+--
+set temp_tablespaces = some_temp_tablespace2;
+with a1 as materialized (select * from tts_temp)
+select count(*) from a1 t1, a1 t2;
+NOTICE:  sisc_xslice: Use temp tablespace  (seg0 slice2 172.17.0.4:7002 pid=205052)
+NOTICE:  sisc_xslice: Use temp tablespace  (seg2 slice2 172.17.0.4:7004 pid=205053)
+NOTICE:  sisc_xslice: Use temp tablespace  (seg1 slice2 172.17.0.4:7003 pid=205051)
+  count  
+---------
+ 1000000
+(1 row)
+
+--
+-- Second execution: set temp_tablespaces to nothing.
+-- Cached QE backends should be reused, but SharedFileSet must be 
+-- recreated, so it honors the new temp_tablespaces value.
+--
+select gp_inject_fault('sisc_xslice_temp_files', 'reset', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+select gp_inject_fault('sisc_xslice_temp_files', 'skip', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+set temp_tablespaces = '';
+with a1 as materialized (select * from tts_temp)
+select count(*) from a1 t1, a1 t2;
+NOTICE:  sisc_xslice: Use default tablespace  (seg0 slice2 172.17.0.4:7002 pid=205052)
+NOTICE:  sisc_xslice: Use default tablespace  (seg1 slice2 172.17.0.4:7003 pid=205051)
+NOTICE:  sisc_xslice: Use default tablespace  (seg2 slice2 172.17.0.4:7004 pid=205053)
+  count  
+---------
+ 1000000
+(1 row)
+
+select count(*) from sisc_set_pids;
+ count 
+-------
+     3
+(1 row)
+
+select count(*) from sisc_unset_pids;
+ count 
+-------
+     3
+(1 row)
+
+select count(*) = 0 as set_minus_unset_empty
+from (
+    select logpid from sisc_set_pids
+    except
+    select logpid from sisc_unset_pids
+) s;
+ set_minus_unset_empty 
+-----------------------
+ t
+(1 row)
+
+reset temp_tablespaces;
+reset gp_cte_sharing;
+reset optimizer;
+reset gp_cached_segworkers_threshold;
+select gp_inject_fault('sisc_xslice_temp_files', 'reset', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+drop table tts_temp;
+drop table sisc_unset_pids;
+drop table sisc_set_pids;
+drop tablespace some_temp_tablespace2;
 -- When the GUC temp_tablespaces is set, one of the temp tablespaces is used instead of the default tablespace.
 -- create several tablespaces and use them as temp tablespaces
 -- all QD/QEs in one session should have the same temp tablespace


### PR DESCRIPTION
Make temp_tablespaces test stable

Previously we used get_shareinput_fileset() for getting shared fileset for shareinput scans 
except we shouldn't have been. As this function have been creating 
dsm_segments that lived until postmaster, holding segment, goes down. 

That behavior have been creating problems, when this postmasters have been reused,
because shareinput fileset are never updated. 

To keep filesets consistent this system was reworked so from now we use hashtable for
sharefilesets where handle for according fileset is placed and kept until query execution
ends (either successfully or with abort).

Co-authored-by: Maksim Michkov <m.michkov@arenadata.io>