### PR TITLE
CI-5690: Add Greengage package replacement

### DIFF
--- a/gpAux/debian/control
+++ b/gpAux/debian/control
@@ -19,7 +19,8 @@ Depends: ${shlibs:Depends},
 	 zip,
 	 net-tools,
 	 ${pythonRequires}
-Conflicts: greengage-loaders, ${pythonConflicts}
+Conflicts: greengage, greengage-loaders, ${pythonConflicts}
+Replaces:  greengage
 Description: Greengage MPP database engine
 	Greengage Database (GPDB) is an advanced, fully featured, open
 	source data warehouse, based on PostgreSQL. It provides powerful and


### PR DESCRIPTION
## Add Greengage package replacement (#448)

Package `greengage6` is a rename of `greengage`.
Allow `greengage6` to replace `greengage`.

Add to `debian/control`:
- `Conflicts: greengage`
  apt removes old package including `/opt/greengagedb/greengage`
- `Replaces: greengage`
  dpkg is allowed to overwrite shared files registered under old package

Task: [CI-5690](https://tracker.yandex.ru/CI-5690)