### PR TITLE
Fix ggrebalance error with '--target-datadirs-file' option in some cases

### DIFF
--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -210,10 +210,6 @@ def validate_options(options, args, parser):
     if options.duration:
         options.end = datetime.now() + options.duration
 
-    if (option_is_set('target_hosts') or option_is_set('add_hosts')) and not option_is_set('target_datadirs'):
-        logger.error("--target-datadirs option is required when using --target-hosts or --add-hosts")
-        parser.exit(1)
-
     if option_is_set('mirror_mode') and options.mirror_mode not in ('grouped', 'spread'):
         logger.error('Mirroring strategy %s is not supported' % options.mirror_mode)
         parser.exit(1)

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
@@ -372,7 +372,7 @@ class GGRebalanceMainSM:
             if self.plan != None:
                 self.logger.error("Can't start a new operation, because the previous one was interrupted. "
                                   "Please try to launch again without a plan to continue from the interrupted state, "
-                                  "or use '--rollback' or '--cleanup' options.")
+                                  "or use '--rollback' or '--clean' options.")
                 self.trigger('move_to_STATE_ERROR')
                 return
 

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -88,6 +88,12 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
+        # make a dry run without '-d' option to check default datadirs
+        When the user runs "ggrebalance --non-interactive-mode -x 4 --target-hosts 'sdw2, sdw3' -p --skip-resource-estimation"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "To:   sdw2:20500:/data1/primary/gpseg0" to logfile with latest timestamp
+         And ggrebalance should print "To:   sdw3:21500:/data1/mirror/gpseg0" to logfile with latest timestamp
+         And all files in gpAdminLogs directory are deleted
         When the user runs "ggrebalance --non-interactive-mode -x 4 --target-hosts 'sdw2, sdw3' -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
@@ -114,6 +120,12 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And schema "test_schema_2" exists in "test_db_2"
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And all files in gpAdminLogs directory are deleted
+        # make a dry run without '-d' option to check default datadirs
+        When the user runs "ggrebalance --non-interactive-mode -x 4 --add-hosts 'sdw2, sdw3' --remove-hosts 'sdw1' -p --skip-resource-estimation"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "To:   sdw2:20500:/data1/primary/gpseg0" to logfile with latest timestamp
+         And ggrebalance should print "To:   sdw3:21500:/data1/mirror/gpseg0" to logfile with latest timestamp
          And all files in gpAdminLogs directory are deleted
         When the user runs "ggrebalance --non-interactive-mode -x 4 --add-hosts 'sdw2, sdw3' --remove-hosts 'sdw1' -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
@@ -299,6 +311,19 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has some segments where "datadir like '/home/gpadmin/gpdb\_src/gpAux/gpdemo/datadirs\_sdw_/dbfast/new\_seg_'"
          And the cluster configuration has some segments where "datadir like '/home/gpadmin/gpdb\_src/gpAux/gpdemo/datadirs\_sdw_/dbfast\_mirror/new\_seg_'"
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 6, row count = 100
+         And the temporary file "/tmp/ggrebalance_target_datadirs" is removed
+        When the user runs "ggrebalance -c"
+         And all files in gpAdminLogs directory are deleted
+         And there is a file "/tmp/ggrebalance_target_datadirs" with hosts "/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_{hostname}/new_dbfast/new_seg{content}|/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_{hostname}/new_dbfast_mirror/new_seg{content}"
+        When the user runs "ggrebalance --non-interactive-mode -x 6 --add-hosts sdw3 --target-datadirs-file /tmp/ggrebalance_target_datadirs"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And the cluster configuration has some segments where "datadir like '/home/gpadmin/gpdb\_src/gpAux/gpdemo/datadirs\_sdw_/new\_dbfast/new\_seg_'"
+         And the cluster configuration has some segments where "datadir like '/home/gpadmin/gpdb\_src/gpAux/gpdemo/datadirs\_sdw_/new\_dbfast\_mirror/new\_seg_'"
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 6, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 6, row count = 100
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 6, row count = 100


### PR DESCRIPTION
Fix ggrebalance error with '--target-datadirs-file' option in some cases

Problem description:
ggrebalance didn't take into account '--target-datadirs-file' option when
'--target-hosts' or '--add-hosts' was specified and failed with an error.

Root cause:
According to old requirements, if new hosts were added, user had to specify
target datadirs via '--target-datadirs' or '--target-datadirs-file', but only
'--target-datadirs' was checked for presence.

Fix:
Remove the check completely, as now we have default values for target datadirs,
that will be used if '--target-datadirs' or '--target-datadirs-file' is not
specified.

Note: requirements will be updated separately as well to be aligned with this
change.

Plus, this patch fixes a wrong hint in the error log output.