### PR TITLE
CI-5713: Replace matrix with branch-driven OS config

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -87,65 +87,66 @@ automatically upon the completion of the `Greengage CI` workflow.
 
 - **Triggers:** `workflow_run: workflows: ["Greengage CI"],
   types: [completed]`
-- **Branch Targeting:** Runs only for the `6.x` and `7.x` branches.
-- **Version Detection:** Automatically determines the database version (6 or 7)
-  based on the triggering branch (`6.x` → version 6, `7.x` → version 7).
-  Since `Greengage SQL Dump` is not branch-specific itself, the version is
-  derived at runtime from the branch of the triggering `Greengage CI` run.
-- **Matrix Strategy:** Runs across multiple OS configurations to generate dumps
-  for all available build targets. The set of configurations mirrors what was
-  built in `Greengage CI`:
-  - `ubuntu` (default, no version suffix — compatible with Ubuntu 22.04
+- **Branch Targeting:** Runs only for the `6.x`, `7.x`, and `next` branches.
+- **Version Detection:** Automatically determines the database version (6, 7,
+  or 8) based on the triggering branch. Since `Greengage SQL Dump` is not
+  branch-specific itself, the version is derived at runtime from the branch of
+  the triggering `Greengage CI` run.
+- **Branch-driven OS Configuration:** Instead of a matrix strategy, the target
+  OS and its version are determined at runtime from the triggering branch via
+  workflow-level environment variables `TARGET_OS` and `TARGET_OS_VERSION`:
+  - `6.x` → `ubuntu 24.04`
+  - `7.x` → `ubuntu` (no version suffix — compatible with Ubuntu 22.04
     artifact naming)
-  - `ubuntu24.04` (version 6.x only)
+  - `next` → `ubuntu` (no version suffix)
 - **Image Pull Check:** Before creating a SQL dump, the workflow attempts to
-  pull the Docker image from GHCR. This handles cases where the matrix includes
-  OS versions for which no image was built in the triggering CI run.
+  pull the Docker image from GHCR. If the pull fails, the dump creation and
+  upload steps are skipped without failing the job.
 - **Conditional Dump Generation:** If the image is pulled successfully, the
   workflow runs the regression test suite with the `dump_db: "true"` parameter
-  to generate a SQL dump archive. If the pull fails, the dump creation and
-  upload steps are skipped for that matrix entry.
+  to generate a SQL dump archive.
 - **Artifact Upload:** Uploads the generated SQL dump archive as a named
-  artifact (e.g., `sqldump_ggdb6_ubuntu`, `sqldump_ggdb7_ubuntu24.04`).
-- **Verification Job:** A final job checks if at least one SQL dump was created
-  across all matrix configurations by querying the GitHub Actions jobs API. If
-  no dumps were uploaded, the workflow fails with an error.
-- **Controlled Execution:** Since the main CI workflow runs on `6.x` and `7.x`
-  branches only for push events (which occur after final merge of a PR), SQL
-  dumps are generated exclusively for verified, approved patches after they are
-  merged into the main branches.
+  artifact (e.g., `sqldump_ggdb6_ubuntu24.04`, `sqldump_ggdb7_ubuntu`).
+- **Verification Job:** A final job checks if the SQL dump was created by
+  querying the GitHub Actions jobs API. If no dump was uploaded, the workflow
+  fails with an error.
+- **Controlled Execution:** Since the main CI workflow runs on `6.x`, `7.x`,
+  and `next` branches only for push events (which occur after final merge of a
+  PR), SQL dumps are generated exclusively for verified, approved patches after
+  they are merged into the main branches.
 - **Artifact Retention:** The generated SQL dump artifact is retained 90 days
   after the last download. Each new run of the `behave tests gpexpand` workflow
-  (which consumes this artifact as a consumer) resets this retention period to
-  90 days when it downloads the artifact.
+  (which consumes this artifact) resets this retention period when it downloads
+  the artifact.
 
 ### Behavior
 
 1. **Triggering:** Automatically starts after the `Greengage CI` workflow
-   finishes on the `6.x` or `7.x` branch for push events where the conclusion
-   is `success`.
-2. **Version Mapping:** Maps the branch name (`6.x` → version 6, `7.x` →
-   version 7) and constructs the expected Docker image name using the commit
-   SHA.
-3. **Image Pull:** For each matrix entry, attempts to pull the Docker image
-   from GHCR. If the pull succeeds, subsequent steps proceed; if it fails, all
-   remaining steps for that matrix entry are skipped without failing the job.
+   finishes on the `6.x`, `7.x`, or `next` branch for push events where the
+   conclusion is `success`.
+2. **Version and OS Mapping:** Maps the branch name to a version number and
+   target OS configuration via workflow-level environment variables `VERSION`,
+   `TARGET_OS`, and `TARGET_OS_VERSION`. Constructs the expected Docker image
+   name using the commit SHA.
+3. **Image Pull:** Attempts to pull the Docker image from GHCR. If the pull
+   succeeds, subsequent steps proceed; if it fails, all remaining steps are
+   skipped without failing the job.
 4. **Disk Space:** Maximizes available disk space on the runner before running
    regression tests.
 5. **Conditional Dump Generation:** If the image was pulled successfully, runs
    the regression test suite with the `dump_db` option enabled, which creates a
    `*_postgres_sqldump.tar` file.
 6. **Artifact Upload:** Uploads the generated SQL dump archive as a named
-   artifact (e.g., `sqldump_ggdb6_ubuntu`, `sqldump_ggdb7_ubuntu24.04`).
-7. **Artifact Reporting:** Logs the artifact name and direct URL for each
+   artifact reflecting the branch-specific OS configuration.
+7. **Artifact Reporting:** Logs the artifact name and direct URL for the
    successfully uploaded dump.
-8. **Verification:** A final job queries the GitHub Actions jobs API to count
-   how many matrix jobs completed the `Upload SQL Dump` step successfully.
-   Fails the workflow if none succeeded; passes if at least one dump was
-   created.
+8. **Verification:** A final job queries the GitHub Actions jobs API to confirm
+   the `Upload SQL Dump` step completed successfully. Fails the workflow if it
+   did not.
 
 This workflow ensures that a current database schema dump is available as an
-artifact following successful CI runs on the primary branches `6.x` and `7.x`.
+artifact following successful CI runs on the primary branches `6.x`, `7.x`,
+and `next`.
 
 ## Configuration
 

--- a/.github/workflows/greengage-sql-dump.yml
+++ b/.github/workflows/greengage-sql-dump.yml
@@ -23,6 +23,8 @@ env:
     github.event.workflow_run.head_branch == 'next', '8',
     ''
     ) }}
+  TARGET_OS: 'ubuntu'
+  TARGET_OS_VERSION: ${{ github.event.workflow_run.head_branch == '6.x' && '24.04' || '' }}
 
 jobs:
   create-sql-dump-regression:
@@ -33,13 +35,6 @@ jobs:
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.conclusion == 'success' &&
       !startsWith(github.event.workflow_run.head_branch, 'refs/tags/')
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target_os: ubuntu
-          # - target_os: ubuntu
-          #   target_os_version: "24.04"
     permissions:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
@@ -48,7 +43,7 @@ jobs:
     steps:
       - name: Determine Greengage Image name
         run: |
-          image="ghcr.io/${{ github.repository }}/ggdb${VERSION}_${{ matrix.target_os }}${{ matrix.target_os_version }}:${RUN_HEAD_SHA}"
+          image="ghcr.io/${{ github.repository }}/ggdb${{ env.VERSION }}_${{ env.TARGET_OS }}${{ env.TARGET_OS_VERSION }}:${RUN_HEAD_SHA}"
           echo "IMAGE=${image,,}" >> $GITHUB_ENV
 
       - name: Display trigger information
@@ -83,8 +78,8 @@ jobs:
         with:
           image: ${{ env.IMAGE }}
           optimizer: postgres
-          target_os: ${{ matrix.target_os }}
-          target_os_version: ${{ matrix.target_os_version }}
+          target_os: ${{ env.TARGET_OS }}
+          target_os_version: ${{ env.TARGET_OS_VERSION }}
           dump_db: "true"
 
       - name: Upload SQL Dump
@@ -92,8 +87,8 @@ jobs:
         id: upload
         uses: actions/upload-artifact@v4
         with:
-          name: sqldump_ggdb${{ env.VERSION }}_${{ matrix.target_os }}${{ matrix.target_os_version }}
-          path: /mnt/logs/${{ matrix.target_os }}${{ matrix.target_os_version }}_postgres_sqldump.tar
+          name: sqldump_ggdb${{ env.VERSION }}_${{ env.TARGET_OS }}${{ env.TARGET_OS_VERSION }}
+          path: /mnt/logs/${{ env.TARGET_OS }}${{ env.TARGET_OS_VERSION }}_postgres_sqldump.tar
           if-no-files-found: error
 
       - name: Report artifact info
@@ -103,7 +98,7 @@ jobs:
           ## SQL Dump Creation Report
           | Field         | Value |
           |---------------|-------|
-          | Artifact name | sqldump_ggdb${{ env.VERSION }}_${{ matrix.target_os }}${{ matrix.target_os_version }} |
+          | Artifact name | sqldump_ggdb${{ env.VERSION }}_${{ env.TARGET_OS }}${{ env.TARGET_OS_VERSION }} |
           | Artifact URL  | https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.upload.outputs.artifact-id }} |
           EOF
 
@@ -130,6 +125,6 @@ jobs:
           )
           echo "::notice::SQL dump(s) uploaded: ${success_count}"
           if [ "${success_count}" -eq 0 ]; then
-            echo "::error::No SQL dumps were created - no images found for any matrix configuration"
+            echo "::error::No SQL dumps were created - no images found"
             exit 1
           fi

--- a/.github/workflows/greengage-sql-dump.yml
+++ b/.github/workflows/greengage-sql-dump.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Determine Greengage Image name
         run: |
-          image="ghcr.io/${{ github.repository }}/ggdb${{ env.VERSION }}_${{ env.TARGET_OS }}${{ env.TARGET_OS_VERSION }}:${RUN_HEAD_SHA}"
+          image="ghcr.io/${{ github.repository }}/ggdb${VERSION}_${TARGET_OS}${TARGET_OS_VERSION}:${RUN_HEAD_SHA}"
           echo "IMAGE=${image,,}" >> $GITHUB_ENV
 
       - name: Display trigger information
@@ -98,7 +98,7 @@ jobs:
           ## SQL Dump Creation Report
           | Field         | Value |
           |---------------|-------|
-          | Artifact name | sqldump_ggdb${{ env.VERSION }}_${{ env.TARGET_OS }}${{ env.TARGET_OS_VERSION }} |
+          | Artifact name | sqldump_ggdb${VERSION}_${TARGET_OS}${TARGET_OS_VERSION} |
           | Artifact URL  | https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.upload.outputs.artifact-id }} |
           EOF
 


### PR DESCRIPTION
## Replace matrix with branch-driven OS config (#450)

- Replace static matrix with workflow-level TARGET_OS and TARGET_OS_VERSION
  environment variables derived from the triggering branch:
  - 6.x  -> ubuntu 24.04 (fixes artifact mismatch: regression tests were fully switched to ubuntu24)
  - 7.x  -> ubuntu (22.04, legacy empty version suffix)
  - next -> ubuntu (22.04, legacy empty version suffix)
- Update CI README:
  - Describe these changes
  - Add 'next' branch description added in commit eaf70fc

Task: [CI-5678](https://tracker.yandex.ru/CI-5713)