### PR TITLE
CI-5717: CI behave gpexpand @skip, SQL dump changes 6.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -69,7 +69,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v35
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v28
     with:
       version: 6
       target_os: ${{ matrix.target_os }}

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -48,7 +48,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v28
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v35
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
@@ -69,7 +69,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v28
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v35
     with:
       version: 6
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
## CI behave gpexpand @skips, SQL dump changes 6.x (#453)

Bump CI behave tests v28 to v35 changes:
- Detect `@skip` tag in Behave CI matrix generation
  - Replace `ls | grep` with glob to handle non-alphanumeric filenames
  - Split matrix into `run_matrix` / `skip_matrix` based on `@skip` tag
    detection on the `Feature:` line
  - Skipped features excluded from the run matrix and listed in the
    Job Summary of `generate-matrix` step
  - `continue-on-error: true` on SQL dump fetch step for `gpexpand` -
    failure surfaces in the test run itself
  - Add `set -e` to Allure report generation step

Task: CI-5599

- Look for ubuntu24.04 SQL dump artifact on 6.x.
  The `gpexpand` behave test was looking for `sqldump_ggdb6_ubuntu` artifact,
  but the SQL dump workflow now generates `sqldump_ggdb6_ubuntu24.04`
  after regression tests were fully switched to `ubuntu24`.

  - Fix `artifact_name` and `artifact_archive_name` to include `ubuntu24.04`
    suffix for `6.x`, keeping legacy empty suffix for `7.x`.

Task: CI-5678