### PR TITLE
CI-5719: CI behave gpexpand @skip changes 7.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -41,7 +41,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v28
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v35
     with:
       version: 7
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
## CI behave gpexpand @skip changes 7.x

Bump CI behave tests v28 to v35 changes:
- Detect `@skip` tag in Behave CI matrix generation
  - Replace `ls | grep` with glob to handle non-alphanumeric filenames
  - Split matrix into `run_matrix` / `skip_matrix` based on `@skip` tag
    detection on the `Feature:` line
  - Skipped features excluded from the run matrix and listed in the
    Job Summary of `generate-matrix` step
  - `continue-on-error: true` on SQL dump fetch step for `gpexpand` -
    failure surfaces in the test run itself
  - Add `set -e` to Allure report generation step

Task: CI-5599

Note: bump also carries transitive 6.x and resgroup commits, CI-5678.
