### PR TITLE
GG-502: Fix pg_dump not assigning oids for array types

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -319,7 +319,8 @@ static void binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 													 bool force_array_type);
 static void binary_upgrade_set_type_oids_by_rel(Archive *fout,
 													PQExpBuffer upgrade_buffer,
-													const TableInfo *tblinfo);
+													const TableInfo *tblinfo,
+													bool force_array_type);
 static void binary_upgrade_set_pg_class_oids(Archive *fout,
 											 PQExpBuffer upgrade_buffer,
 											 Oid pg_class_oid, bool is_index);
@@ -4937,11 +4938,12 @@ binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 static void
 binary_upgrade_set_type_oids_by_rel(Archive *fout,
 										PQExpBuffer upgrade_buffer,
-										const TableInfo *tblinfo)
+										const TableInfo *tblinfo,
+										bool force_array_type)
 {
 	TypeInfo *typinfo = findTypeByOid(tblinfo->reltype);
 	binary_upgrade_set_type_oids_by_type_oid(fout, upgrade_buffer,
-											 typinfo, false);
+											 typinfo, force_array_type);
 }
 
 static void
@@ -16891,6 +16893,7 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 	char	   *ftoptions = NULL;
 	char	   *srvname = NULL;
 	char	   *partkeydef = NULL;
+	bool	   force_array_type = false;
 
 	/* We had better have loaded per-column details about this table */
 	Assert(tbinfo->interesting);
@@ -16905,8 +16908,9 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 		pg_log_warning("WITH OIDS is not supported anymore (table \"%s\")",
 					   qrelname);
 
-	if (dopt->binary_upgrade)
-		binary_upgrade_set_type_oids_by_rel(fout, q, 	tbinfo);
+	if (dopt->binary_upgrade) {
+		binary_upgrade_set_type_oids_by_rel(fout, q, 	tbinfo, false);
+	}
 
 	/* Is it a table or a view? */
 	if (tbinfo->relkind == RELKIND_VIEW)
@@ -17071,8 +17075,21 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 						if (tbinfo->relstorage == 'x')
 							hasExternalPartitions = true;
 
+						if (!tbinfo->aotbl) {
+							/*
+							 * Array types for children of a partitioned table are created
+							 * only starting from Greengage 7, so specify arbitrary OIDs for
+							 * them.
+							 *
+							 * Also, don't do it for AO tables, we don't create array types
+							 * for them.
+							 */
+							force_array_type = true;
+						}
+
+
 						binary_upgrade_set_pg_class_oids(fout, q, part_oid, false);
-						binary_upgrade_set_type_oids_by_rel(fout, q, tbinfo);
+						binary_upgrade_set_type_oids_by_rel(fout, q, tbinfo, force_array_type);
 					}
 				}
 

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -16907,9 +16907,8 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 		pg_log_warning("WITH OIDS is not supported anymore (table \"%s\")",
 					   qrelname);
 
-	if (dopt->binary_upgrade) {
+	if (dopt->binary_upgrade)
 		binary_upgrade_set_type_oids_by_rel(fout, q, 	tbinfo, false);
-	}
 
 	/* Is it a table or a view? */
 	if (tbinfo->relkind == RELKIND_VIEW)

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -17078,7 +17078,7 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 						{
 							/*
 							 * Array types for children of a partitioned table are created
-							 * only starting from Greengage 7, so specify arbitrary OIDs for
+							 * only starting from Greengage 7, so pick unused OIDs for
 							 * them.
 							 *
 							 * Also, don't do it for AO tables, array types are not created

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -16893,7 +16893,6 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 	char	   *ftoptions = NULL;
 	char	   *srvname = NULL;
 	char	   *partkeydef = NULL;
-	bool	   force_array_type = false;
 
 	/* We had better have loaded per-column details about this table */
 	Assert(tbinfo->interesting);
@@ -17071,11 +17070,13 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 					{
 						Oid part_oid = atooid(PQgetvalue(partres, i, 0));
 						TableInfo *tbinfo = findTableByOid(part_oid);
+						bool force_array_type = false;
 
 						if (tbinfo->relstorage == 'x')
 							hasExternalPartitions = true;
 
-						if (!tbinfo->aotbl) {
+						if (!tbinfo->aotbl)
+						{
 							/*
 							 * Array types for children of a partitioned table are created
 							 * only starting from Greengage 7, so specify arbitrary OIDs for

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -17087,7 +17087,6 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 							force_array_type = true;
 						}
 
-
 						binary_upgrade_set_pg_class_oids(fout, q, part_oid, false);
 						binary_upgrade_set_type_oids_by_rel(fout, q, tbinfo, force_array_type);
 					}

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -17081,7 +17081,7 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 							 * only starting from Greengage 7, so specify arbitrary OIDs for
 							 * them.
 							 *
-							 * Also, don't do it for AO tables, we don't create array types
+							 * Also, don't do it for AO tables, array types are not created
 							 * for them.
 							 */
 							force_array_type = true;


### PR DESCRIPTION
Partitioning implementations in Greengage 6 and Greengage 7
differ in array type creation: 
- in Greengage 6, array type is created only for the root 
  table in a hierarchy
- in Greengage 7, they are created for every table in a
  hierarchy

This difference caused pg_restore to fail, as there where
no preassigned OIDs for these types in the dump.

This patch makes pg_dump assign unused OIDs for 
these types.

One notable exception is AO tables, because array types
are not created for them. So leave their dump logic 
unchanged.

This patch is done as a part of fixing cross-version
pg_upgrade test errors.