### PR TITLE
GG-479: Fix issue with SET LOCAL inside PL functions (6.x)

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5241,7 +5241,6 @@ AtEOXact_GUC(bool isCommit, int nestLevel)
 			 * record it and restore QE before next query start
 			 */
 			if (Gp_role == GP_ROLE_DISPATCH
-					&& !IsTransactionBlock()
 					&& changed
 					&& ((isCommit) || (!isCommit && gp_guc_need_restore))
 					&& (gconf->flags & GUC_GPDB_NEED_SYNC))
@@ -5921,6 +5920,14 @@ set_config_option(const char *name, const char *value,
 			   errmsg("unrecognized configuration parameter \"%s\"", name)));
 		return 0;
 	}
+	/*
+	 * Make SET LOCAL just SET when executing on segments. It is needed for
+	 * correct passage of local GUCs as they might be discarded. Anyway,
+	 * master executes SET as LOCAL, so on next transaction GUC will
+	 * resynchronize and everything will be back in place.
+	 */
+	if (Gp_role == GP_ROLE_EXECUTE && action == GUC_ACTION_LOCAL)
+		action = GUC_ACTION_SET;
 
 	/*
 	 * Check if option can be set by the user.

--- a/src/test/regress/expected/plpgsql.out
+++ b/src/test/regress/expected/plpgsql.out
@@ -5555,3 +5555,24 @@ NOTICE:  outer_func() done
 drop function outer_outer_func(int);
 drop function outer_func(int);
 drop function inner_func(int);
+-- Test consistency and passage of SET LOCAL GUC to writing commands
+create schema s;
+do $$
+begin
+  set local search_path to s;
+  create table test_table(a int) distributed by (a);
+  drop table test_table;
+end $$;
+-- check existence on master and segments
+with c as (
+    select gp_segment_id, relname, relkind, relnamespace from pg_class
+    union all
+    select gp_segment_id, relname, relkind, relnamespace from gp_dist_random('pg_class')
+) select gp_segment_id from c
+join pg_namespace n on n.oid = c.relnamespace
+where c.relname = 'test_table' and c.relkind = 'r' and n.nspname = 's';
+ gp_segment_id 
+---------------
+(0 rows)
+
+drop schema s cascade;

--- a/src/test/regress/expected/plpgsql_optimizer.out
+++ b/src/test/regress/expected/plpgsql_optimizer.out
@@ -5533,3 +5533,24 @@ NOTICE:  outer_func() done
 drop function outer_outer_func(int);
 drop function outer_func(int);
 drop function inner_func(int);
+-- Test consistency and passage of SET LOCAL GUC to writing commands
+create schema s;
+do $$
+begin
+  set local search_path to s;
+  create table test_table(a int) distributed by (a);
+  drop table test_table;
+end $$;
+-- check existence on master and segments
+with c as (
+    select gp_segment_id, relname, relkind, relnamespace from pg_class
+    union all
+    select gp_segment_id, relname, relkind, relnamespace from gp_dist_random('pg_class')
+) select gp_segment_id from c
+join pg_namespace n on n.oid = c.relnamespace
+where c.relname = 'test_table' and c.relkind = 'r' and n.nspname = 's';
+ gp_segment_id 
+---------------
+(0 rows)
+
+drop schema s cascade;

--- a/src/test/regress/sql/plpgsql.sql
+++ b/src/test/regress/sql/plpgsql.sql
@@ -4232,3 +4232,28 @@ select outer_outer_func(20);
 drop function outer_outer_func(int);
 drop function outer_func(int);
 drop function inner_func(int);
+
+-- Test consistency and passage of SET LOCAL GUC to writing commands
+--start_ignore
+drop schema if exists s cascade;
+--end_ignore
+
+create schema s;
+
+do $$
+begin
+  set local search_path to s;
+  create table test_table(a int) distributed by (a);
+  drop table test_table;
+end $$;
+
+-- check existence on master and segments
+with c as (
+    select gp_segment_id, relname, relkind, relnamespace from pg_class
+    union all
+    select gp_segment_id, relname, relkind, relnamespace from gp_dist_random('pg_class')
+) select gp_segment_id from c
+join pg_namespace n on n.oid = c.relnamespace
+where c.relname = 'test_table' and c.relkind = 'r' and n.nspname = 's';
+
+drop schema s cascade;


### PR DESCRIPTION
What happened?
Local GUCs (SET LOCAL) get lost inside PLPG functions (see test case for
more details), thus writing commands may have unexpected results or fail.

Why it happens?
It happens because SET LOCAL is executed in a separate transaction,
because no DTX (2PC) is set up, so its effect is popped.

How do we fix this?
Let's make all SET LOCAL commands on segments be just SET, so that they
will last until master synchronizes them using previously saved value
(gp_guc_restore_list). Synchronization happens on next master's
transaction or when transaction control statement is met (COMMIT, ROLLBACK).
Specifically,syncing is handled inside AtEOXact_SPI(). Note - on master, SET
LOCAL is still executed as SET LOCAL.

Alternate solutions?
DTX transaction context could be set up on the SET step, so that all subsequent
writing commands get inside this new transaction and thus, get required GUC.

Tests?
Test case to check consistency and correct passage of local GUCs inside DO was
developed.

Changes from original commit?
As 6.x does not support control statements inside DO - removed in between SPI
GUC synchronization code from AtEOXact_SPI(), connected test. GUC syncing
happens on the next master's transaction using mechanism inside PostgresMain().

(cherry picked from commit https://github.com/GreengageDB/greengage/commit/762fb85b27549a678af806803b499c92b2ba2006)

Ticket: GG-479