### PR TITLE
CI-5751: Implement Package CI for Ubuntu 24.04 6.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -146,7 +146,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target_os: [ubuntu]
+        include:
+          - target_os: ubuntu
+          - target_os: ubuntu
+            target_os_version: "24.04"
     permissions:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -158,6 +158,7 @@ jobs:
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
+      target_os_version: ${{ matrix.target_os_version }}
       test_docker: ${{ matrix.target_os }}:${{ matrix.target_os_version || '22.04' }}
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -158,6 +158,6 @@ jobs:
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
-      test_docker: ubuntu:22.04 # Docker Image  (e.g., ubuntu:22.04, ubuntu:noble) for deploy test. Skip if empty
+      test_docker: ${{ matrix.target_os }}:${{ matrix.target_os_version || '22.04' }}
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -154,7 +154,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v34
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v37
     with:
       version: 6
       target_os: ${{ matrix.target_os }}

--- a/gpAux/debian/rules
+++ b/gpAux/debian/rules
@@ -13,7 +13,7 @@ ifeq ($(LSB_SI),Ubuntu)
     DEPS = python2,python2.7
     CONFLICTS = python-is-python3
   else
-    DEPS = python3
+    DEPS = python3,python-is-python3
   endif
 else
   DEPS = python2,python2.7


### PR DESCRIPTION
## Implement Package CI for Ubuntu 24.04 (#461)

- [ci(package): add ubuntu 24.04 to package matrix](https://github.com/GreengageDB/greengage/commit/5aff49b4a6c1859dba8e8fd4f0b0dcdb3e866dbc)
- [ci(package): parametrize test_docker option](https://github.com/GreengageDB/greengage/commit/9ebfaa58d63c5d7ffafbe7d54a51321241367983)
- [upd(deb): add python-is-python3 to DEPS for Ubuntu 24.04](https://github.com/GreengageDB/greengage/pull/461/commits/52a3ba04e2a92e51b8937c363ddf241f469db579)
- [ci(package): bump hotfix `v34` to `v37` (hotfix)](https://github.com/GreengageDB/greengage/pull/461/commits/4209383aad366d934a84840a809ec2e4701f9beb)
  - Use single quotes in apt sources echo to prevent shell expansion
  - Remove commented-out upload-to-release job

Task: [CI-5751](https://tracker.yandex.ru/CI-5751)