### PR TITLE
Don't report compress option errors if not validating

### DIFF
--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -851,7 +851,7 @@ validate_and_adjust_options(StdRdOptions *result,
 	appendonly_opt = get_option_set(options, num_options, SOPT_APPENDONLY);
 	if (appendonly_opt != NULL)
 	{
-		if (!KIND_IS_RELATION(kind))
+		if (!KIND_IS_RELATION(kind) && validate)
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("usage of parameter \"appendonly\" in a non relation object is not supported")));
@@ -905,7 +905,7 @@ validate_and_adjust_options(StdRdOptions *result,
 					 errmsg("invalid option \"compresstype\" for base relation"),
 					 errhint("\"compresstype\" is only valid for Append Only relations, create an AO relation to use \"compresstype\".")));
 
-		if (!compresstype_is_valid(comptype_opt->values.string_val))
+		if (!compresstype_is_valid(comptype_opt->values.string_val) && validate)
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_OBJECT),
 					 errmsg("unknown compresstype \"%s\"",
@@ -964,10 +964,11 @@ validate_and_adjust_options(StdRdOptions *result,
 			(pg_strcasecmp(result->compresstype, "zlib") == 0))
 		{
 #ifndef HAVE_LIBZ
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("zlib compression is not supported by this build"),
-					 errhint("Compile without --without-zlib to use zlib compression.")));
+			if (validate)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("zlib compression is not supported by this build"),
+						 errhint("Compile without --without-zlib to use zlib compression.")));
 #endif
 			if (result->compresslevel > 9)
 			{
@@ -985,10 +986,11 @@ validate_and_adjust_options(StdRdOptions *result,
 			(pg_strcasecmp(result->compresstype, "zstd") == 0))
 		{
 #ifndef HAVE_LIBZSTD
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("Zstandard library is not supported by this build"),
-					 errhint("Compile with --with-zstd to use Zstandard compression.")));
+			if (validate)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("Zstandard library is not supported by this build"),
+						 errhint("Compile with --with-zstd to use Zstandard compression.")));
 #endif
 			if (result->compresslevel > 19)
 			{
@@ -1006,10 +1008,11 @@ validate_and_adjust_options(StdRdOptions *result,
 			(pg_strcasecmp(result->compresstype, "quicklz") == 0))
 		{
 #ifndef HAVE_LIBQUICKLZ
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("QuickLZ library is not supported by this build"),
-					 errhint("Compile with --with-quicklz to use QuickLZ compression.")));
+			if (validate)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("QuickLZ library is not supported by this build"),
+						 errhint("Compile with --with-quicklz to use QuickLZ compression.")));
 #endif
 			if (result->compresslevel != 1)
 			{
@@ -1100,7 +1103,7 @@ validate_and_adjust_options(StdRdOptions *result,
 	analyze_hll_non_part_table_opt = get_option_set(options, num_options, SOPT_ANALYZEHLL);
 	if (analyze_hll_non_part_table_opt != NULL)
 	{
-		if (!KIND_IS_RELATION(kind))
+		if (!KIND_IS_RELATION(kind) && validate)
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("usage of parameter \"analyze_hll_non_part_table\" in a non relation object is not supported")));

--- a/src/backend/catalog/pg_compression.c
+++ b/src/backend/catalog/pg_compression.c
@@ -144,7 +144,7 @@ GetCompressionImplementation(char *comptype)
 	scan = systable_beginscan(comprel, CompressionCompnameIndexId, true,
 							  NULL, 1, &scankey);
 	tuple = systable_getnext(scan);
-	if (!HeapTupleIsValid(tuple))
+	if (!HeapTupleIsValid(tuple) || !compresstype_is_valid(NameStr(compname)))
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
 				 errmsg("unknown compress type \"%s\"",

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -3089,3 +3089,28 @@ DROP TABLE dist_replicated;
 DROP TABLE dist_by_key;
 DROP FUNCTION fn_vol();
 DROP FUNCTION fn_val();
+-- DROP TABLE with invalid reloptions
+CREATE TABLE ao_reloptions_t1 (c1 INT) WITH (appendonly=true,compresstype=zstd);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE ao_reloptions_t2 (c1 INT) WITH (appendonly=true,compresstype=zstd);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SET allow_system_table_mods = on;
+UPDATE pg_class SET reloptions = '{appendonly=true,foo=bar,compresstype=quicklz,compresslevel=3}' WHERE relname = 'ao_reloptions_t1';
+UPDATE pg_class SET reloptions = '{appendonly=true,foo=bar,compresstype=zzzz,compresslevel=3}' WHERE relname = 'ao_reloptions_t2';
+SELECT reloptions FROM pg_class WHERE relname = 'ao_reloptions_t1';
+                           reloptions                           
+----------------------------------------------------------------
+ {appendonly=true,foo=bar,compresstype=quicklz,compresslevel=3}
+(1 row)
+
+SELECT reloptions FROM pg_class WHERE relname = 'ao_reloptions_t2';
+                         reloptions                          
+-------------------------------------------------------------
+ {appendonly=true,foo=bar,compresstype=zzzz,compresslevel=3}
+(1 row)
+
+SET allow_system_table_mods = off;
+DROP TABLE ao_reloptions_t1;
+DROP TABLE ao_reloptions_t2;

--- a/src/test/regress/sql/alter_table.sql
+++ b/src/test/regress/sql/alter_table.sql
@@ -1906,3 +1906,15 @@ DROP TABLE dist_replicated;
 DROP TABLE dist_by_key;
 DROP FUNCTION fn_vol();
 DROP FUNCTION fn_val();
+
+-- DROP TABLE with invalid reloptions
+CREATE TABLE ao_reloptions_t1 (c1 INT) WITH (appendonly=true,compresstype=zstd);
+CREATE TABLE ao_reloptions_t2 (c1 INT) WITH (appendonly=true,compresstype=zstd);
+SET allow_system_table_mods = on;
+UPDATE pg_class SET reloptions = '{appendonly=true,foo=bar,compresstype=quicklz,compresslevel=3}' WHERE relname = 'ao_reloptions_t1';
+UPDATE pg_class SET reloptions = '{appendonly=true,foo=bar,compresstype=zzzz,compresslevel=3}' WHERE relname = 'ao_reloptions_t2';
+SELECT reloptions FROM pg_class WHERE relname = 'ao_reloptions_t1';
+SELECT reloptions FROM pg_class WHERE relname = 'ao_reloptions_t2';
+SET allow_system_table_mods = off;
+DROP TABLE ao_reloptions_t1;
+DROP TABLE ao_reloptions_t2;


### PR DESCRIPTION
Address issue #460 

```
adam=# CREATE TABLE ao_reloptions_t1 (c1 INT) WITH (appendonly=true, compresstype=zstd);
CREATE TABLE
adam=# SET allow_system_table_mods = on;
SET
adam=# UPDATE pg_class SET reloptions = '{compresstype=zzzz}' WHERE relname = 'ao_reloptions_t1';
UPDATE 1
adam=# DROP TABLE ao_reloptions_t1;
ERROR:  unknown compresstype "zzzz"

adam=# CREATE TABLE ao_reloptions_t2 (c1 INT) WITH (appendonly=true, compresstype=zstd);
CREATE TABLE
adam=# UPDATE pg_class SET reloptions = '{appendonly=true,compresstype=quicklz,compresslevel=3}' WHERE relname = 'ao_reloptions_t2';
UPDATE 1
adam=# DROP TABLE ao_reloptions_t2;
ERROR:  QuickLZ library is not supported by this build
HINT:  Compile with --with-quicklz to use QuickLZ compression.
```

`validate_and_adjust_options()` doesn't respect the bool parameter `validate` in some cases. This commit fixes it.

(cherry picked from commit [warehouse-pg/warehouse-pg@d8f394b](https://github.com/warehouse-pg/warehouse-pg/commit/d8f394be232e44793e0dc44adbd7e0ff49b5c910))

Changes compared to the original commit:
- add check for compression type before loading shared library

Please merge with rebase!
