### PR TITLE
CI-5752: Delivery of deb-package for Ubuntu 24.04 to Release 6.x

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -39,9 +39,9 @@ operating systems:
 
 ## Release Workflow
 
-A separate workflow `Greengage release` handles the uploading of Debian package
-to GitHub releases. It is triggered when a release is published and uses a
-composite action to manage package deployment.
+A separate workflow `Greengage release` handles the uploading of Debian
+packages to GitHub releases. It is triggered when a release is published and
+uses a composite action to manage package deployment.
 
 ### Key Features
 
@@ -50,8 +50,13 @@ including re-publishing.
 - **Concurrency:** Uses the same concurrency group as the CI workflow
   (`Greengage CI-${{ github.ref }}`) to ensure proper sequencing and prevent
   race conditions.
-- **Cache-based Artifacts:** Restores built packages from cache using the
+- **Multi-OS Matrix:** Builds and uploads packages for ubuntu 22.04 and
+  ubuntu 24.04 in parallel.
+- **Cache-based Artifacts:** Restores built packages from cache using OS and
   commit SHA as the key, rather than downloading artifacts from previous jobs.
+- **OS-specific Filenames:** Inserts `~{target_os}{target_os_version}` into
+  each package filename before the architecture suffix prior to upload
+  (e.g. `greengage6_6.30.1_amd64.deb` → `greengage6_6.30.1~ubuntu24.04_amd64.deb`).
 - **Manual Recovery:** If the cache is missing, the workflow checks the status
   of the last build for the tag and provides clear instructions for manual
   intervention. It does not automatically trigger builds to avoid infinite
@@ -130,6 +135,10 @@ To use this pipeline:
 > - target_os: ubuntu
 >   target_os_version: "22.04"
 > ```
+>
+> **Note**: The release workflow (`greengage-release.yml`) is exempt from this
+> rule — it explicitly sets `target_os_version` for all matrix entries to
+> ensure unambiguous cache key matching with the build workflow.
 
 ## Additional Documentation
 

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -154,7 +154,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@CI-5752
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v38
     with:
       version: 6
       target_os: ${{ matrix.target_os }}

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -154,7 +154,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v37
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@CI-5752
     with:
       version: 6
       target_os: ${{ matrix.target_os }}

--- a/.github/workflows/greengage-release.yml
+++ b/.github/workflows/greengage-release.yml
@@ -1,4 +1,4 @@
-# Release creation workflow
+# .github/workflows/greengage-release.yml
 name: Greengage release
 
 on:
@@ -11,15 +11,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - artifact_name: deb-packages
-          extensions:    deb ddeb
+        - version: 6
+          target_os: ubuntu
+          target_os_version: '22.04'
+          extensions:  deb ddeb
+          package_dir: deb-packages
+        - version: 6
+          target_os: ubuntu
+          target_os_version: '24.04'
+          extensions:  deb ddeb
+          package_dir: deb-packages
     runs-on: ubuntu-24.04
     permissions:
       contents: write
       actions: read
     steps:
       - name: Upload packages to release
-        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v27
+        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@CI-5752
         with:
-          extensions: ${{ matrix.extensions }}
-          artifact_name: ${{ matrix.artifact_name }}
+          version:     ${{ matrix.version }}
+          extensions:  ${{ matrix.extensions }}
+          package_dir: ${{ matrix.package_dir }}
+          cache_key:   ${{ matrix.package_dir }}-${{ matrix.target_os }}${{ matrix.target_os_version }}-${{ github.sha }}

--- a/.github/workflows/greengage-release.yml
+++ b/.github/workflows/greengage-release.yml
@@ -27,9 +27,10 @@ jobs:
       actions: read
     steps:
       - name: Upload packages to release
-        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@CI-5752
+        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v38
         with:
-          version:     ${{ matrix.version }}
-          extensions:  ${{ matrix.extensions }}
-          package_dir: ${{ matrix.package_dir }}
-          cache_key:   ${{ matrix.package_dir }}-${{ matrix.target_os }}${{ matrix.target_os_version }}-${{ github.sha }}
+          version:           ${{ matrix.version }}
+          extensions:        ${{ matrix.extensions }}
+          package_dir:       ${{ matrix.package_dir }}
+          target_os:         ${{ matrix.target_os }}
+          target_os_version: ${{ matrix.target_os_version }}


### PR DESCRIPTION
## Delivery of deb-package for Ubuntu 24.04 to Release 6.x

- update CI README
- replace file header comment with canonical workflow path
- add `version`, `target_os`, `target_os_version`, `package_dir` to matrix
- add ubuntu 24.04 alongside existing ubuntu 22.04 matrix entry
- replace `artifact_name` parameter with
  `version`, `target_os`, `target_os_version`, `package_dir`
- bump 'upload-pkgs-to-release' action v27 to v38
  - replace `artifact_name` input with
    `version`, `target_os`, `target_os_version`, `package_dir`
  - construct cache key internally
  - rename packages with OS revision before upload

Task: [CI-5752](https://tracker.yandex.ru/CI-5752)

- bump 'package' job v37 to v38
  - append `target_os` + `target_os_version` to artifact names and cache keys

Task: [CI-5768](https://tracker.yandex.ru/CI-5768)