### PR TITLE
GG-515: Improve autocomplete for RESOURCE GROUP

### DIFF
--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2746,6 +2746,7 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH("WITH (");
 	else if (TailMatches("ALTER", "RESOURCE", "GROUP", MatchAny))
 		COMPLETE_WITH("SET");
+	/* RESOURCE GROUP <name> WITH ( / SET */
 	else if (TailMatches("RESOURCE", "GROUP", MatchAny, "WITH", "(") ||
 			 TailMatches("RESOURCE", "GROUP", MatchAny, "SET"))
 		COMPLETE_WITH("CONCURRENCY", "CPU_MAX_PERCENT", "CPU_WEIGHT", "CPUSET",

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2766,10 +2766,14 @@ psql_completion(const char *text, int start, int end)
 								"UNION SELECT '*'");
 	else if(TailMatches("IO_LIMIT", "=", "'", MatchAny) ||
 			TailMatches("IO_LIMIT", "'", MatchAny))
-			COMPLETE_WITH(":");
+		COMPLETE_WITH(":");
 	else if(TailMatches("IO_LIMIT", "=", "'", MatchAny, ":") ||
 			TailMatches("IO_LIMIT", "'", MatchAny, ":"))
-			COMPLETE_WITH("wpbs", "rbps", "wiops", "riops");
+		COMPLETE_WITH("wbps", "rbps", "wiops", "riops");
+	else if(TailMatches("wbps|rbps|wiops|riops"))
+		COMPLETE_WITH("=");
+	else if(TailMatches("wbps|rbps|wiops|riops", "="))
+		COMPLETE_WITH("max");
 
 /* CREATE VIEW --- is allowed inside CREATE SCHEMA, so use TailMatches */
 	/* Complete CREATE VIEW <name> with AS */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1841,6 +1841,10 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("ALTER", "POLICY", MatchAny, "ON", MatchAny, "WITH", "CHECK"))
 		COMPLETE_WITH("(");
 
+	/* ALTER RESOURCE GROUP <name> */
+	else if (TailMatches("ALTER", "RESOURCE", "GROUP", MatchAny))
+		COMPLETE_WITH("SET");
+
 	/* ALTER RULE <name>, add ON */
 	else if (Matches("ALTER", "RULE", MatchAny))
 		COMPLETE_WITH("ON");
@@ -2741,11 +2745,10 @@ psql_completion(const char *text, int start, int end)
 	/* ALTER/CREATE/DROP RESOURCE GROUP */
 	else if (TailMatches("ALTER|CREATE|DROP", "RESOURCE", "GROUP"))
 		COMPLETE_WITH_QUERY(Query_for_list_of_resgroups);
+
 	/* CREATE RESOURCE GROUP <name> */
 	else if (TailMatches("CREATE", "RESOURCE", "GROUP", MatchAny))
 		COMPLETE_WITH("WITH (");
-	else if (TailMatches("ALTER", "RESOURCE", "GROUP", MatchAny))
-		COMPLETE_WITH("SET");
 	/* RESOURCE GROUP <name> WITH ( / SET */
 	else if (TailMatches("RESOURCE", "GROUP", MatchAny, "WITH", "(") ||
 			 TailMatches("RESOURCE", "GROUP", MatchAny, "SET"))
@@ -2753,7 +2756,7 @@ psql_completion(const char *text, int start, int end)
 					  "MEMORY_LIMIT", "MIN_COST", "IO_LIMIT");
 	else if (TailMatches("RESOURCE", "GROUP", MatchAny, "WITH", "(", MatchAny))
 		COMPLETE_WITH("=");
-	/* Complete IO_LIMIT with delimeter, tablespaces and options */
+	/* Complete IO_LIMIT option with delimeter, tablespaces and options */
 	else if (TailMatches("RESOURCE", "GROUP", MatchAny, "WITH", "(", "IO_LIMIT", "=") ||
 			 TailMatches("RESOURCE", "GROUP", MatchAny, "SET", "IO_LIMIT"))
 		COMPLETE_WITH("'");
@@ -2767,8 +2770,6 @@ psql_completion(const char *text, int start, int end)
 	else if(TailMatches("IO_LIMIT", "=", "'", MatchAny, ":") ||
 			TailMatches("IO_LIMIT", "'", MatchAny, ":"))
 			COMPLETE_WITH("wpbs", "rbps", "wiops", "riops");
-
-
 
 /* CREATE VIEW --- is allowed inside CREATE SCHEMA, so use TailMatches */
 	/* Complete CREATE VIEW <name> with AS */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2734,27 +2734,24 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("CREATE", "ROLE|USER|GROUP", MatchAny, "IN"))
 		COMPLETE_WITH("GROUP", "ROLE");
 
-/* CREATE/DROP RESOURCE GROUP/QUEUE */
-	else if (Matches("CREATE|DROP", "RESOURCE"))
-	 {
-		static const char *const list_CREATERESOURCEGROUP[] =
-		{"GROUP", "QUEUE", NULL};
+/* ALTER/CREATE/DROP RESOURCE GROUP/QUEUE */
+	else if (Matches("ALTER|CREATE|DROP", "RESOURCE"))
+		COMPLETE_WITH("GROUP", "QUEUE");
 
-		COMPLETE_WITH_LIST(list_CREATERESOURCEGROUP);
-	 }
-	/* CREATE/DROP RESOURCE GROUP */
-	else if (TailMatches("CREATE|DROP", "RESOURCE", "GROUP"))
+	/* ALTER/CREATE/DROP RESOURCE GROUP */
+	else if (TailMatches("ALTER|CREATE|DROP", "RESOURCE", "GROUP"))
 		COMPLETE_WITH_QUERY(Query_for_list_of_resgroups);
 	/* CREATE RESOURCE GROUP <name> */
-	else if (TailMatches("CREATE|DROP", "RESOURCE", "GROUP", MatchAny))
+	else if (TailMatches("CREATE", "RESOURCE", "GROUP", MatchAny))
 		COMPLETE_WITH("WITH (");
-	else if (TailMatches("RESOURCE", "GROUP", MatchAny, "WITH", "("))
-	{
-		static const char *const list_CREATERESOURCEGROUP[] =
-		{"CONCURRENCY", "cpu_max_percent", "MEMORY_LIMIT", "MEMORY_REDZONE_LIMIT", NULL};
-
-		COMPLETE_WITH_LIST(list_CREATERESOURCEGROUP);
-	}
+	else if (TailMatches("ALTER", "RESOURCE", "GROUP", MatchAny))
+		COMPLETE_WITH("SET");
+	else if (TailMatches("RESOURCE", "GROUP", MatchAny, "WITH", "(") ||
+			 TailMatches("RESOURCE", "GROUP", MatchAny, "SET"))
+		COMPLETE_WITH("CONCURRENCY", "CPU_MAX_PERCENT", "CPU_WEIGHT", "CPUSET",
+					  "MEMORY_LIMIT", "MIN_COST", "IO_LIMIT");
+	else if (TailMatches("RESOURCE", "GROUP", MatchAny, "WITH", "(", MatchAny))
+		COMPLETE_WITH("=");
 
 
 /* CREATE VIEW --- is allowed inside CREATE SCHEMA, so use TailMatches */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2753,6 +2753,21 @@ psql_completion(const char *text, int start, int end)
 					  "MEMORY_LIMIT", "MIN_COST", "IO_LIMIT");
 	else if (TailMatches("RESOURCE", "GROUP", MatchAny, "WITH", "(", MatchAny))
 		COMPLETE_WITH("=");
+	/* Complete IO_LIMIT with delimeter, tablespaces and options */
+	else if (TailMatches("RESOURCE", "GROUP", MatchAny, "WITH", "(", "IO_LIMIT", "=") ||
+			 TailMatches("RESOURCE", "GROUP", MatchAny, "SET", "IO_LIMIT"))
+		COMPLETE_WITH("'");
+	else if(TailMatches("IO_LIMIT", "=", "'") ||
+			TailMatches("IO_LIMIT", "'"))
+			COMPLETE_WITH_QUERY(Query_for_list_of_tablespaces
+								"UNION SELECT '*'");
+	else if(TailMatches("IO_LIMIT", "=", "'", MatchAny) ||
+			TailMatches("IO_LIMIT", "'", MatchAny))
+			COMPLETE_WITH(":");
+	else if(TailMatches("IO_LIMIT", "=", "'", MatchAny, ":") ||
+			TailMatches("IO_LIMIT", "'", MatchAny, ":"))
+			COMPLETE_WITH("wpbs", "rbps", "wiops", "riops");
+
 
 
 /* CREATE VIEW --- is allowed inside CREATE SCHEMA, so use TailMatches */


### PR DESCRIPTION
Some commands for RESOURCE GROUP lacked autocompletion support in psql.
ALTER RESOURCE GROUP suggested wrong list of objects (GROUP objects instead).
DROP RESOURCE GROUP suggested extra WITH.

Add missing group attributes in CREATE/ALTER RESOURCE GROUP commands.
Add IO_LIMIT option support.
Fix wrong suggestions in ALTER RESOURCE GROUP.
Fix wrong suggestion in DROP RESOURCE GROUP.

Don't address autocompletion support for multiple consecutive options, because 
postgres lacks proper capabilities to do it without messing up existing
completions.