### PR TITLE
GG-511: Fix pg_dump transferring TOASTs for partitioned tables

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -4951,6 +4951,11 @@ binary_upgrade_set_pg_class_oids(Archive *fout,
 								 PQExpBuffer upgrade_buffer, Oid pg_class_oid,
 								 bool is_index)
 {
+	PGresult * res;
+	PQExpBuffer gpdb6_partition_query;
+	bool gpdb6_partitioned_table;
+	bool aoco;
+
 	if (!is_index)
 	{
 		TableInfo *tblinfo = findTableByOid(pg_class_oid);
@@ -4965,10 +4970,37 @@ binary_upgrade_set_pg_class_oids(Archive *fout,
 		 * Starting GPDB7 CO tables no longer have TOAST tables. Hence, ignore
 		 * toast OIDs for CO tables to avoid upgrade failures.
 		 */
-		if ((OidIsValid(tblinfo->toast_oid) && !tblinfo->aotbl) ||
-					(OidIsValid(tblinfo->toast_oid) &&
-					tblinfo->aotbl &&
-					strncmp(tblinfo->amname, "ao_row", 6) == 0))
+		aoco = tblinfo->aotbl && strncmp(tblinfo->amname, "ao_column", 6) == 0;
+
+		/* Starting from Greengage 7, only leafs of a partition hierarchy
+		 * have TOAST tables.
+		 */
+		gpdb6_partitioned_table = false;
+		if (fout->remoteVersion < GPDB7_MAJOR_PGVERSION) {
+			gpdb6_partition_query = createPQExpBuffer();
+			appendPQExpBuffer(gpdb6_partition_query,
+				"WITH gpdb6_partitioned_tables (oid) AS ("
+				"	SELECT oid FROM pg_class c WHERE EXISTS ("
+				"		SELECT 1 FROM pg_partition p WHERE c.oid = p.parrelid"
+				"	)"
+				"	UNION ALL"
+				"	SELECT parchildrelid FROM pg_partition_rule parent WHERE EXISTS ("
+				"		SELECT 1 FROM pg_partition_rule child WHERE child.parparentrule = parent.oid"
+				"	)"
+				")"
+				"SELECT EXISTS ("
+				"	SELECT 1 FROM gpdb6_partitioned_tables p"
+				"		WHERE p.oid = %u::pg_catalog.oid );",
+				tblinfo->dobj.catId.oid);
+
+			res = ExecuteSqlQueryForSingleRow(fout, gpdb6_partition_query->data);
+			if (strcmp(PQgetvalue(res, 0, 0), "t") == 0)
+				gpdb6_partitioned_table = true;
+
+			destroyPQExpBuffer(gpdb6_partition_query);
+		}
+
+		if (OidIsValid(tblinfo->toast_oid) && !aoco && !gpdb6_partitioned_table)
 			binary_upgrade_set_toast_oids_by_rel(fout, upgrade_buffer, tblinfo);
 
 		/* Set up any AO auxiliary tables with preallocated OIDs as well. */

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -4976,7 +4976,8 @@ binary_upgrade_set_pg_class_oids(Archive *fout,
 		 * have TOAST tables.
 		 */
 		gpdb6_partitioned_table = false;
-		if (fout->remoteVersion < GPDB7_MAJOR_PGVERSION) {
+		if (fout->remoteVersion < GPDB7_MAJOR_PGVERSION)
+		{
 			gpdb6_partition_query = createPQExpBuffer();
 			appendPQExpBuffer(gpdb6_partition_query,
 				"WITH gpdb6_partitioned_tables (oid) AS ("

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -4981,12 +4981,12 @@ binary_upgrade_set_pg_class_oids(Archive *fout,
 			gpdb6_partition_query = createPQExpBuffer();
 			appendPQExpBuffer(gpdb6_partition_query,
 				"WITH gpdb6_partitioned_tables (oid) AS ("
-				"	SELECT oid FROM pg_class c WHERE EXISTS ("
-				"		SELECT 1 FROM pg_partition p WHERE c.oid = p.parrelid"
+				"	SELECT oid FROM pg_catalog.pg_class c WHERE EXISTS ("
+				"		SELECT 1 FROM pg_catalog.pg_partition p WHERE c.oid = p.parrelid"
 				"	)"
 				"	UNION ALL"
-				"	SELECT parchildrelid FROM pg_partition_rule parent WHERE EXISTS ("
-				"		SELECT 1 FROM pg_partition_rule child WHERE child.parparentrule = parent.oid"
+				"	SELECT parchildrelid FROM pg_catalog.pg_partition_rule parent WHERE EXISTS ("
+				"		SELECT 1 FROM pg_catalog.pg_partition_rule child WHERE child.parparentrule = parent.oid"
 				"	)"
 				")"
 				"SELECT EXISTS ("

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -4951,7 +4951,7 @@ binary_upgrade_set_pg_class_oids(Archive *fout,
 								 PQExpBuffer upgrade_buffer, Oid pg_class_oid,
 								 bool is_index)
 {
-	PGresult * res;
+	PGresult *res;
 	PQExpBuffer gpdb6_partition_query;
 	bool gpdb6_partitioned_table;
 	bool aoco;

--- a/src/bin/pg_upgrade/info.c
+++ b/src/bin/pg_upgrade/info.c
@@ -29,6 +29,18 @@ static void free_rel_infos(RelInfoArr *rel_arr);
 static void print_db_infos(DbInfoArr *dbinfo);
 static void print_rel_infos(RelInfoArr *rel_arr);
 
+/*
+ * compare_oids()
+ *
+ * comparison function for bsearch() over "old_db" or "new_db"
+ */
+static int
+compare_oids(const void *v1, const void *v2)
+{
+	Oid oid1 = *((Oid*) v1);
+	Oid oid2 = ((RelInfo*) v2)->reloid;
+	return (oid1 > oid2) - (oid1 < oid2);
+}
 
 /*
  * gen_db_file_maps()
@@ -74,8 +86,44 @@ gen_db_file_maps(DbInfo *old_db, DbInfo *new_db,
 			 * old_rel is unmatched.  This should never happen, because we
 			 * force new rels to have TOAST tables if the old one did.
 			 */
-			report_unmatched_relation(old_rel, old_db, false);
-			all_matched = false;
+
+			/*
+			 * ...except that when upgrading from Greengage 6 to Greengage 7,
+			 * old cluster might have TOAST tables for relations that are
+			 * considered partitioned in the new cluster, and we can't
+			 * filter them out during get_rel_infos().
+			 */
+			if (strcmp(old_rel->nspname, "pg_toast") != 0)
+			{
+				report_unmatched_relation(old_rel, old_db, false);
+				all_matched = false;
+				old_relnum++;
+				continue;
+			}
+
+			Oid toastheap_oid = old_rel->toastheap;
+			if (old_rel->relkind == RELKIND_INDEX)
+			{
+				/* For an index over a TOAST table, first find the info of the table itself */
+				Oid toast_oid = old_rel->indtable;
+				RelInfo *toast = bsearch(&toast_oid, old_db->rel_arr.rels, old_db->rel_arr.nrels, sizeof(RelInfo), compare_oids);
+
+				Assert(toast);
+				Assert(toast->toastheap);
+
+				toastheap_oid = toast->toastheap;
+			}
+
+			RelInfo *res = bsearch(&toastheap_oid, new_db->rel_arr.rels, new_db->rel_arr.nrels, sizeof(RelInfo), compare_oids);
+			if (!res || res->relkind != RELKIND_PARTITIONED_TABLE)
+			{
+				report_unmatched_relation(old_rel, old_db, false);
+				all_matched = false;
+				old_relnum++;
+				continue;
+			}
+
+			/* This table is indeed a TOAST over a partitioned table, skip it */
 			old_relnum++;
 			continue;
 		}
@@ -100,8 +148,37 @@ gen_db_file_maps(DbInfo *old_db, DbInfo *new_db,
 		if (old_rel->reloid < new_rel->reloid)
 		{
 			/* old_rel is unmatched, see comment above */
-			report_unmatched_relation(old_rel, old_db, false);
-			all_matched = false;
+			if (strcmp(old_rel->nspname, "pg_toast") != 0)
+			{
+				report_unmatched_relation(old_rel, old_db, false);
+				all_matched = false;
+				old_relnum++;
+				continue;
+			}
+
+			Oid toastheap_oid = old_rel->toastheap;
+			if (old_rel->relkind == RELKIND_INDEX)
+			{
+				/* For an index over a TOAST table, first find the info of the table itself */
+				Oid toast_oid = old_rel->indtable;
+				RelInfo *toast = bsearch(&toast_oid, old_db->rel_arr.rels, old_db->rel_arr.nrels, sizeof(RelInfo), compare_oids);
+
+				Assert(toast);
+				Assert(toast->toastheap);
+
+				toastheap_oid = toast->toastheap;
+			}
+
+			RelInfo *res = bsearch(&toastheap_oid, new_db->rel_arr.rels, new_db->rel_arr.nrels, sizeof(RelInfo), compare_oids);
+			if (!res || res->relkind != RELKIND_PARTITIONED_TABLE)
+			{
+				report_unmatched_relation(old_rel, old_db, false);
+				all_matched = false;
+				old_relnum++;
+				continue;
+			}
+
+			/* This table is indeed a TOAST over a partitioned table, skip it */
 			old_relnum++;
 			continue;
 		}
@@ -480,9 +557,17 @@ get_rel_infos(ClusterInfo *cluster, DbInfo *dbinfo)
 	 * pg_largeobject contains user data that does not appear in pg_dump
 	 * output, so we have to copy that system table.  It's easiest to do that
 	 * by treating it as a user table.
-	 * 
-	 * We ignore partitioned tables, as they do not need to transfer files and indexes, 
+	 *
+	 * Upstream ignores partitioned tables, as they do not need to transfer files and indexes,
 	 * as well as create toast tables starting from version 12.
+	 *
+	 * However, we diverge from this logic by dumping partitioned tables
+	 * (both from Greengage 6 and Greengage 7), because it is impossible
+	 * to determine whether a table from Greengage 6 would be considered
+	 * partitioned or not without accessing relkind of the same
+	 * table in the target cluster. The reason for this being that
+	 * pg_partition and pg_partition_rule relations are absent on
+	 * the segments.
 	 */
 	snprintf(query + strlen(query), sizeof(query) - strlen(query),
 			 "WITH regular_heap (reloid, indtable, toastheap) AS ( "


### PR DESCRIPTION
TOAST tables are not created for partitioned tables 
starting from Greengage 7, but pg_dump still created
them during migration, resulting in a failure to
upgrade. 

Have pg_dump omit those values and pg_upgrade 
ignore them during file transfer to avoid the problem.
Also, simplify logic for TOAST tables over AOCO
relations and add an explanatory comment telling
why file transfer logic for partitioned tables diverges 
from the original code. 

This patch is done as a part of fixing cross-version
pg_upgrade test errors.