### PR TITLE
CI-5769: Make deb artifact and cache names OS-specific 7.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -146,15 +146,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target_os: [ubuntu]
+        include:
+          - target_os: ubuntu
     permissions:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v28
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v38
     with:
       version: 7
       target_os: ${{ matrix.target_os }}
-      test_docker: ubuntu:22.04 # Docker Image  (e.g., ubuntu:22.04, ubuntu:noble) for deploy test. Skip if empty
+      target_os_version: ${{ matrix.target_os_version }}
+      test_docker: ${{ matrix.target_os }}:${{ matrix.target_os_version || '22.04' }}
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -152,7 +152,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v38
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v40
     with:
       version: 7
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
## Make deb artifact and cache names OS-specific 7.x (#470)

ci(package): adapt package matrix for OS-specific artifact naming
- convert matrix from list to include format
- add target_os_version to matrix and pass it to reusable workflow
- derive test_docker from matrix (target_os:target_os_version || 22.04)

- bump greengage-reusable-package to v40
  - append target_os+target_os_version to artifact names and cache keys
  - fix: make sigar listing optional in deb install test

Task: [CI-5769](https://tracker.yandex.ru/CI-5769)