### PR TITLE
GG-530: Fix resource group auxiliary tools for cgroup v2 tests

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
@@ -127,7 +127,7 @@ $$ LANGUAGE plpython3u;
 CREATE FUNCTION
 
 0: CREATE OR REPLACE FUNCTION check_cgroup_io_max(groupname text, tablespace_name text, parameters text) RETURNS BOOL AS $$ import ctypes import os 
-postgres = ctypes.CDLL(None) get_bdi_of_path = postgres['get_bdi_of_path'] get_tablespace_path = postgres['get_tablespace_path'] get_tablespace_oid = postgres['get_tablespace_oid'] 
+postgres = ctypes.CDLL(None) get_bdi_of_path = postgres['get_bdi_of_path'] get_tablespace_path = postgres['get_tablespace_path'] get_tablespace_path.restype = ctypes.c_char_p get_tablespace_oid = postgres['get_tablespace_oid'] 
 # get group oid sql = "select groupid from gp_toolkit.gp_resgroup_config where groupname = '%s'" % groupname result = plpy.execute(sql) groupid = result[0]['groupid'] 
 cgroup_path = "/sys/fs/cgroup/gpdb/%d" % groupid 
 # get path of tablespace spcoid = get_tablespace_oid(tablespace_name.encode('utf-8'), False) location = ctypes.cast(get_tablespace_path(spcoid), ctypes.c_char_p).value 

--- a/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
@@ -131,7 +131,7 @@ postgres = ctypes.CDLL(None) get_bdi_of_path = postgres['get_bdi_of_path'] get_t
 # get group oid sql = "select groupid from gp_toolkit.gp_resgroup_config where groupname = '%s'" % groupname result = plpy.execute(sql) groupid = result[0]['groupid'] 
 cgroup_path = "/sys/fs/cgroup/gpdb/%d" % groupid 
 # get path of tablespace spcoid = get_tablespace_oid(tablespace_name.encode('utf-8'), False) location = get_tablespace_path(spcoid) 
-if location == "": return False 
+if not location: return False 
 bdi = get_bdi_of_path(location) major = os.major(bdi) minor = os.minor(bdi) 
 match_string = "{}:{} {}".format(major, minor, parameters) match = False with open(os.path.join(cgroup_path, "io.max")) as f: for line in f.readlines(): line = line.strip() if match_string == line: match = True break 
 return match 

--- a/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
@@ -130,7 +130,7 @@ CREATE FUNCTION
 postgres = ctypes.CDLL(None) get_bdi_of_path = postgres['get_bdi_of_path'] get_tablespace_path = postgres['get_tablespace_path'] get_tablespace_path.restype = ctypes.c_char_p get_tablespace_oid = postgres['get_tablespace_oid'] 
 # get group oid sql = "select groupid from gp_toolkit.gp_resgroup_config where groupname = '%s'" % groupname result = plpy.execute(sql) groupid = result[0]['groupid'] 
 cgroup_path = "/sys/fs/cgroup/gpdb/%d" % groupid 
-# get path of tablespace spcoid = get_tablespace_oid(tablespace_name.encode('utf-8'), False) location = ctypes.cast(get_tablespace_path(spcoid), ctypes.c_char_p).value 
+# get path of tablespace spcoid = get_tablespace_oid(tablespace_name.encode('utf-8'), False) location = get_tablespace_path(spcoid) 
 if location == "": return False 
 bdi = get_bdi_of_path(location) major = os.major(bdi) minor = os.minor(bdi) 
 match_string = "{}:{} {}".format(major, minor, parameters) match = False with open(os.path.join(cgroup_path, "io.max")) as f: for line in f.readlines(): line = line.strip() if match_string == line: match = True break 

--- a/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
@@ -294,7 +294,7 @@ $$ LANGUAGE plpython3u;
     spcoid = get_tablespace_oid(tablespace_name.encode('utf-8'), False)
     location = get_tablespace_path(spcoid)
 
-    if location == "":
+    if not location:
         return False
 
     bdi = get_bdi_of_path(location)

--- a/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
@@ -292,7 +292,7 @@ $$ LANGUAGE plpython3u;
 
     # get path of tablespace
     spcoid = get_tablespace_oid(tablespace_name.encode('utf-8'), False)
-    location = ctypes.cast(get_tablespace_path(spcoid), ctypes.c_char_p).value
+    location = get_tablespace_path(spcoid)
 
     if location == "":
         return False

--- a/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
@@ -280,6 +280,7 @@ $$ LANGUAGE plpython3u;
     postgres = ctypes.CDLL(None)
     get_bdi_of_path = postgres['get_bdi_of_path']
     get_tablespace_path = postgres['get_tablespace_path']
+    get_tablespace_path.restype = ctypes.c_char_p
     get_tablespace_oid = postgres['get_tablespace_oid']
 
     # get group oid


### PR DESCRIPTION
Calling check_cgroup_io_max() could cause SIGSEGV because ctypes used the
default int return type for get_tablespace_path(), but the C function returns
char *.

Set get_tablespace_path.restype to ctypes.c_char_p.
