### PR TITLE
GG-516: Improve autocomplete for PROTOCOL

### DIFF
--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2502,8 +2502,53 @@ psql_completion(const char *text, int start, int end)
 			(!HeadMatches("CREATE", "PROTOCOL", MatchAny, "(*)") ||
 			!HeadMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny, "(*)")))
 	{
-		if (ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
-			COMPLETE_WITH("readfunc =", "writefunc =", "validatorfunc =");
+		/* Find options that were used and complete with ones that hadn't */
+			if (ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
+		{
+			/* Mask for used options: */
+			/* (1 << 0) for readfunc */
+			/* (1 << 1) for writefunc */
+			/* (1 << 2) for validatorfunc */
+			int used_functions_mask = 0;
+
+			int i = 0;
+
+			while(i < previous_words_count &&
+				  !ends_with(previous_words[i], '('))
+			{
+				int cur_prev_wd_len = strlen(previous_words[i]);
+				if(pg_strncasecmp(previous_words[i], "readfunc",
+								  cur_prev_wd_len) == 0)
+				{
+					used_functions_mask |= (1 << 0);
+				}
+				else if(pg_strncasecmp(previous_words[i], "writefunc",
+									   cur_prev_wd_len) == 0)
+				{
+					used_functions_mask |= (1 << 1);
+				}
+				else if(pg_strncasecmp(previous_words[i], "validatorfunc",
+									   cur_prev_wd_len) == 0)
+				{
+					used_functions_mask |= (1 << 2);
+				}
+
+				i += 1;
+			}
+
+			const char* create_protocol_options_list[] = {"readfunc =",
+								"writefunc =", "validatorfunc =", NULL};
+
+			i = 0;
+
+			for(; i <= 2; i++)
+			{
+				if(used_functions_mask & (1 << i))
+					create_protocol_options_list[i] = "";
+			}
+
+			COMPLETE_WITH_LIST(create_protocol_options_list);
+		}
 		else if(TailMatches("readfunc", "="))
 			COMPLETE_WITH_QUERY(Query_for_list_of_extprotocol_readfuncs);
 		else if(TailMatches("writefunc", "="))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2493,15 +2493,22 @@ psql_completion(const char *text, int start, int end)
 	else if(TailMatches("CREATE", "PROTOCOL", MatchAny) ||
 			TailMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny))
 		COMPLETE_WITH("(");
-	else if(TailMatches("CREATE", "PROTOCOL", MatchAny, "(") ||
-			TailMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny, "("))
-		COMPLETE_WITH("readfunc =", "writefunc =", "validatorfunc =");
-	else if(TailMatches("readfunc", "="))
-		COMPLETE_WITH_QUERY(Query_for_list_of_extprotocol_readfuncs);
-	else if(TailMatches("writefunc", "="))
-		COMPLETE_WITH_QUERY(Query_for_list_of_extprotocol_writefuncs);
-	else if(TailMatches("validatorfunc", "="))
-		COMPLETE_WITH_QUERY(Query_for_list_of_extprotocol_validatorfuncs);
+	else if((HeadMatches("CREATE", "PROTOCOL", MatchAny, "(*") ||
+			 HeadMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny, "(*")) &&
+			(!HeadMatches("CREATE", "PROTOCOL", MatchAny, "(*)") ||
+			!HeadMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny, "(*)")))
+	{
+		if (ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
+			COMPLETE_WITH("readfunc =", "writefunc =", "validatorfunc =");
+		else if(TailMatches("readfunc", "="))
+			COMPLETE_WITH_QUERY(Query_for_list_of_extprotocol_readfuncs);
+		else if(TailMatches("writefunc", "="))
+			COMPLETE_WITH_QUERY(Query_for_list_of_extprotocol_writefuncs);
+		else if(TailMatches("validatorfunc", "="))
+			COMPLETE_WITH_QUERY(Query_for_list_of_extprotocol_validatorfuncs);
+		else if(TailMatches("readfunc|writefunc|validatorfunc", "=", MatchAny))
+			COMPLETE_WITH(",", ")");
+	}
 
 /* CREATE PUBLICATION */
 	else if (Matches("CREATE", "PUBLICATION", MatchAny))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -45,6 +45,8 @@
 
 #include "catalog/pg_am_d.h"
 #include "catalog/pg_class_d.h"
+#include "catalog/pg_language_d.h"
+#include "catalog/pg_proc_d.h"
 
 #include "libpq-fe.h"
 #include "pqexpbuffer.h"
@@ -826,8 +828,8 @@ static const SchemaQuery Query_for_list_of_statistics = {
 " SELECT pg_catalog.quote_ident(proname)" \
 "   FROM pg_catalog.pg_proc as p" \
 "  WHERE p.prorettype = 'integer'::regtype" \
-"  AND p.provolatile IN ('s', 'v')" \
-"  AND p.prolang = 13" \
+"  AND p.provolatile IN (" CppAsString2(PROVOLATILE_STABLE) ", " CppAsString2(PROVOLATILE_VOLATILE) ")" \
+"  AND p.prolang = " CppAsString2(ClanguageId) \
 "  AND p.pronargs = 0" \
 "  AND substring(pg_catalog.quote_ident(proname),1,%d)='%s'"
 
@@ -837,8 +839,8 @@ static const SchemaQuery Query_for_list_of_statistics = {
 " SELECT pg_catalog.quote_ident(proname)" \
 "   FROM pg_catalog.pg_proc as p" \
 "  WHERE p.prorettype = 'void'::regtype" \
-"  AND p.provolatile IN ('s', 'v')" \
-"  AND p.prolang = 13" \
+"  AND p.provolatile IN (" CppAsString2(PROVOLATILE_STABLE) ", " CppAsString2(PROVOLATILE_VOLATILE) ")" \
+"  AND p.prolang = " CppAsString2(ClanguageId) \
 "  AND p.pronargs = 0"\
 "  AND substring(pg_catalog.quote_ident(proname),1,%d)='%s'"
 

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1021,6 +1021,7 @@ static const pgsql_thing_t words_after_create[] = {
 	{"PARSER", Query_for_list_of_ts_parsers, NULL, NULL, THING_NO_SHOW},
 	{"POLICY", NULL, NULL, NULL},
 	{"PROCEDURE", NULL, NULL, Query_for_list_of_procedures},
+	{"PROTOCOL", NULL},
 	{"PUBLICATION", NULL, Query_for_list_of_publications},
 	{"RESOURCE", NULL},
 	{"ROLE", Query_for_list_of_roles},

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -822,6 +822,22 @@ static const SchemaQuery Query_for_list_of_statistics = {
 "   FROM pg_catalog.pg_extprotocol"\
 "  WHERE substring(pg_catalog.quote_ident(ptcname),1,%d)='%s'"
 
+#define Query_for_list_of_extprotocol_readfuncs \
+" SELECT pg_catalog.quote_ident(proname)"\
+"   FROM pg_catalog.pg_proc as p" \
+"  WHERE p.prorettype = 'integer'::regtype" \
+"  AND p.pronargs = 0"\
+"  AND substring(pg_catalog.quote_ident(proname),1,%d)='%s'"
+
+#define Query_for_list_of_extprotocol_writefuncs Query_for_list_of_extprotocol_readfuncs
+
+#define Query_for_list_of_extprotocol_validatorfuncs \
+" SELECT pg_catalog.quote_ident(proname)"\
+"   FROM pg_catalog.pg_proc as p" \
+"  WHERE p.prorettype = 'void'::regtype" \
+"  AND p.pronargs = 0"\
+"  AND substring(pg_catalog.quote_ident(proname),1,%d)='%s'"
+
 #define Query_for_list_of_fdws \
 " SELECT pg_catalog.quote_ident(fdwname) "\
 "   FROM pg_catalog.pg_foreign_data_wrapper "\
@@ -2471,12 +2487,21 @@ psql_completion(const char *text, int start, int end)
 /* CREATE PROTOCOL*/
 	else if(Matches("CREATE", "TRUSTED"))
 		COMPLETE_WITH("PROTOCOL");
-	else if(Matches("CREATE", "TRUSTED", "PROTOCOL"))
+	else if(TailMatches("CREATE", "PROTOCOL") ||
+			TailMatches("CREATE", "TRUSTED", "PROTOCOL"))
 		COMPLETE_WITH_QUERY(Query_for_list_of_extprotocols);
-	else if(TailMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny))
+	else if(TailMatches("CREATE", "PROTOCOL", MatchAny) ||
+			TailMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny))
 		COMPLETE_WITH("(");
-	else if(TailMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny, "("))
-		COMPLETE_WITH("readfunc='", "writefunc='", "validatorfunc='");
+	else if(TailMatches("CREATE", "PROTOCOL", MatchAny, "(") ||
+			TailMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny, "("))
+		COMPLETE_WITH("readfunc =", "writefunc =", "validatorfunc =");
+	else if(TailMatches("readfunc", "="))
+		COMPLETE_WITH_QUERY(Query_for_list_of_extprotocol_readfuncs);
+	else if(TailMatches("writefunc", "="))
+		COMPLETE_WITH_QUERY(Query_for_list_of_extprotocol_writefuncs);
+	else if(TailMatches("validatorfunc", "="))
+		COMPLETE_WITH_QUERY(Query_for_list_of_extprotocol_validatorfuncs);
 
 /* CREATE PUBLICATION */
 	else if (Matches("CREATE", "PUBLICATION", MatchAny))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2504,12 +2504,14 @@ psql_completion(const char *text, int start, int end)
 			TailMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny))
 		COMPLETE_WITH("(");
 	else if((HeadMatches("CREATE", "PROTOCOL", MatchAny, "(*") &&
+			!HeadMatches("CREATE", "PROTOCOL", MatchAny, "(", "(*") &&
 			!HeadMatches("CREATE", "PROTOCOL", MatchAny, "(*)")) ||
 			(HeadMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny, "(*") &&
+			!HeadMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny, "(" ,"(*") &&
 			!HeadMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny, "(*)")))
 	{
 		/* Find options that were used and complete with ones that hadn't */
-			if (ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
+		if (ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
 		{
 			const char* create_protocol_options_list[] = {"readfunc =",
 								"writefunc =", "validatorfunc =", NULL};

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2505,11 +2505,8 @@ psql_completion(const char *text, int start, int end)
 		/* Find options that were used and complete with ones that hadn't */
 			if (ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
 		{
-			/* Mask for used options: */
-			/* (1 << 0) for readfunc */
-			/* (1 << 1) for writefunc */
-			/* (1 << 2) for validatorfunc */
-			int used_functions_mask = 0;
+			const char* create_protocol_options_list[] = {"readfunc =",
+								"writefunc =", "validatorfunc =", NULL};
 
 			int i = 0;
 
@@ -2520,31 +2517,20 @@ psql_completion(const char *text, int start, int end)
 				if(pg_strncasecmp(previous_words[i], "readfunc",
 								  cur_prev_wd_len) == 0)
 				{
-					used_functions_mask |= (1 << 0);
+					create_protocol_options_list[0] = "";
 				}
 				else if(pg_strncasecmp(previous_words[i], "writefunc",
 									   cur_prev_wd_len) == 0)
 				{
-					used_functions_mask |= (1 << 1);
+					create_protocol_options_list[1] = "";
 				}
 				else if(pg_strncasecmp(previous_words[i], "validatorfunc",
 									   cur_prev_wd_len) == 0)
 				{
-					used_functions_mask |= (1 << 2);
+					create_protocol_options_list[2] = "";
 				}
 
 				i += 1;
-			}
-
-			const char* create_protocol_options_list[] = {"readfunc =",
-								"writefunc =", "validatorfunc =", NULL};
-
-			i = 0;
-
-			for(; i <= 2; i++)
-			{
-				if(used_functions_mask & (1 << i))
-					create_protocol_options_list[i] = "";
 			}
 
 			COMPLETE_WITH_LIST(create_protocol_options_list);

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -827,6 +827,7 @@ static const SchemaQuery Query_for_list_of_statistics = {
 "   FROM pg_catalog.pg_proc as p" \
 "  WHERE p.prorettype = 'integer'::regtype" \
 "  AND p.provolatile IN ('s', 'v')" \
+"  AND p.prolang = 13" \
 "  AND p.pronargs = 0" \
 "  AND substring(pg_catalog.quote_ident(proname),1,%d)='%s'"
 
@@ -837,6 +838,7 @@ static const SchemaQuery Query_for_list_of_statistics = {
 "   FROM pg_catalog.pg_proc as p" \
 "  WHERE p.prorettype = 'void'::regtype" \
 "  AND p.provolatile IN ('s', 'v')" \
+"  AND p.prolang = 13" \
 "  AND p.pronargs = 0"\
 "  AND substring(pg_catalog.quote_ident(proname),1,%d)='%s'"
 

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2501,9 +2501,9 @@ psql_completion(const char *text, int start, int end)
 	else if(TailMatches("CREATE", "PROTOCOL", MatchAny) ||
 			TailMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny))
 		COMPLETE_WITH("(");
-	else if((HeadMatches("CREATE", "PROTOCOL", MatchAny, "(*") ||
-			 HeadMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny, "(*")) &&
-			(!HeadMatches("CREATE", "PROTOCOL", MatchAny, "(*)") ||
+	else if((HeadMatches("CREATE", "PROTOCOL", MatchAny, "(*") &&
+			!HeadMatches("CREATE", "PROTOCOL", MatchAny, "(*)")) ||
+			(HeadMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny, "(*") &&
 			!HeadMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny, "(*)")))
 	{
 		/* Find options that were used and complete with ones that hadn't */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -817,6 +817,11 @@ static const SchemaQuery Query_for_list_of_statistics = {
 "SELECT pg_catalog.quote_ident(tmplname) FROM pg_catalog.pg_ts_template "\
 " WHERE substring(pg_catalog.quote_ident(tmplname),1,%d)='%s'"
 
+#define Query_for_list_of_extprotocols \
+" SELECT pg_catalog.quote_ident(ptcname) "\
+"   FROM pg_catalog.pg_extprotocol"\
+"  WHERE substring(pg_catalog.quote_ident(ptcname),1,%d)='%s'"
+
 #define Query_for_list_of_fdws \
 " SELECT pg_catalog.quote_ident(fdwname) "\
 "   FROM pg_catalog.pg_foreign_data_wrapper "\
@@ -1021,7 +1026,7 @@ static const pgsql_thing_t words_after_create[] = {
 	{"PARSER", Query_for_list_of_ts_parsers, NULL, NULL, THING_NO_SHOW},
 	{"POLICY", NULL, NULL, NULL},
 	{"PROCEDURE", NULL, NULL, Query_for_list_of_procedures},
-	{"PROTOCOL", NULL},
+	{"PROTOCOL", Query_for_list_of_extprotocols, NULL},
 	{"PUBLICATION", NULL, Query_for_list_of_publications},
 	{"RESOURCE", NULL},
 	{"ROLE", Query_for_list_of_roles},
@@ -1043,6 +1048,7 @@ static const pgsql_thing_t words_after_create[] = {
 	{"TEXT SEARCH", NULL, NULL, NULL},
 	{"TRANSFORM", NULL, NULL, NULL},
 	{"TRIGGER", "SELECT pg_catalog.quote_ident(tgname) FROM pg_catalog.pg_trigger WHERE substring(pg_catalog.quote_ident(tgname),1,%d)='%s' AND NOT tgisinternal"},
+	{"TRUSTED", NULL},
 	{"TYPE", NULL, NULL, &Query_for_list_of_datatypes},
 	{"UNIQUE", NULL, NULL, NULL, THING_NO_DROP | THING_NO_ALTER},	/* for CREATE UNIQUE
 																	 * INDEX ... */
@@ -1543,6 +1549,9 @@ psql_completion(const char *text, int start, int end)
 		else
 			COMPLETE_WITH_FUNCTION_ARG(prev2_wd);
 	}
+	/* ALTER PROTOCOL */
+	else if(Matches("ALTER", "PROTOCOL", MatchAny))
+		COMPLETE_WITH("OWNER TO", "RENAME TO");
 	/* ALTER PUBLICATION <name> */
 	else if (Matches("ALTER", "PUBLICATION", MatchAny))
 		COMPLETE_WITH("ADD TABLE", "DROP TABLE", "OWNER TO", "RENAME TO", "SET");
@@ -2459,6 +2468,15 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("CREATE", "POLICY", MatchAny, "ON", MatchAny, "AS", MatchAny, "USING"))
 		COMPLETE_WITH("(");
 
+/* CREATE PROTOCOL*/
+	else if(Matches("CREATE", "TRUSTED"))
+		COMPLETE_WITH("PROTOCOL");
+	else if(Matches("CREATE", "TRUSTED", "PROTOCOL"))
+		COMPLETE_WITH_QUERY(Query_for_list_of_extprotocols);
+	else if(TailMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny))
+		COMPLETE_WITH("(");
+	else if(TailMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny, "("))
+		COMPLETE_WITH("readfunc='", "writefunc='", "validatorfunc='");
 
 /* CREATE PUBLICATION */
 	else if (Matches("CREATE", "PUBLICATION", MatchAny))
@@ -3086,6 +3104,7 @@ psql_completion(const char *text, int start, int end)
 									   " UNION SELECT 'LANGUAGE'"
 									   " UNION SELECT 'LARGE OBJECT'"
 									   " UNION SELECT 'PROCEDURE'"
+									   " UNION SELECT 'PROTOCOL'"
 									   " UNION SELECT 'ROUTINE'"
 									   " UNION SELECT 'SCHEMA'"
 									   " UNION SELECT 'SEQUENCE'"
@@ -3120,6 +3139,8 @@ psql_completion(const char *text, int start, int end)
 			COMPLETE_WITH_QUERY(Query_for_list_of_languages);
 		else if (TailMatches("PROCEDURE"))
 			COMPLETE_WITH_VERSIONED_SCHEMA_QUERY(Query_for_list_of_procedures, NULL);
+		else if(TailMatches("PROTOCOL"))
+			COMPLETE_WITH_QUERY(Query_for_list_of_extprotocols);
 		else if (TailMatches("ROUTINE"))
 			COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_routines, NULL);
 		else if (TailMatches("SCHEMA"))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -818,23 +818,25 @@ static const SchemaQuery Query_for_list_of_statistics = {
 " WHERE substring(pg_catalog.quote_ident(tmplname),1,%d)='%s'"
 
 #define Query_for_list_of_extprotocols \
-" SELECT pg_catalog.quote_ident(ptcname) "\
-"   FROM pg_catalog.pg_extprotocol"\
+" SELECT pg_catalog.quote_ident(ptcname) " \
+"   FROM pg_catalog.pg_extprotocol" \
 "  WHERE substring(pg_catalog.quote_ident(ptcname),1,%d)='%s'"
 
 #define Query_for_list_of_extprotocol_readfuncs \
-" SELECT pg_catalog.quote_ident(proname)"\
+" SELECT pg_catalog.quote_ident(proname)" \
 "   FROM pg_catalog.pg_proc as p" \
 "  WHERE p.prorettype = 'integer'::regtype" \
-"  AND p.pronargs = 0"\
+"  AND p.provolatile IN ('s', 'v')" \
+"  AND p.pronargs = 0" \
 "  AND substring(pg_catalog.quote_ident(proname),1,%d)='%s'"
 
 #define Query_for_list_of_extprotocol_writefuncs Query_for_list_of_extprotocol_readfuncs
 
 #define Query_for_list_of_extprotocol_validatorfuncs \
-" SELECT pg_catalog.quote_ident(proname)"\
+" SELECT pg_catalog.quote_ident(proname)" \
 "   FROM pg_catalog.pg_proc as p" \
 "  WHERE p.prorettype = 'void'::regtype" \
+"  AND p.provolatile IN ('s', 'v')" \
 "  AND p.pronargs = 0"\
 "  AND substring(pg_catalog.quote_ident(proname),1,%d)='%s'"
 


### PR DESCRIPTION
Some commands and keywords for PROTOCOL hadn't autocompletion support in psql.

Add PROTOCOL keyword to CREATE/ALTER/DROP.
Add protocols list suggestion to CREATE/ALTER/DROP.
Add PROTOCOL keyword to GRANT/REVOKE.
Add protocols list suggestion to GRANT/REVOKE.
Add CREATE PROTOCOL functions suggestions with filtering for already
entered params.