### PR TITLE
GG-514: Improve autocomplete for RESOURCE QUEUE

### DIFF
--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -320,55 +320,11 @@ do { \
 } while (0)
 
 /* Macro to suggest unused options in bracket clause. */
-/* Looks through all tokens until it finds an opening bracket, */
-/* removing used options from suggestion list */
-/* and clearing up list from empty strings. */
 #define COMPLETE_WITH_UNUSED_OPTIONS(...) \
 do { \
 	const char* list[] = { __VA_ARGS__, NULL }; \
-\
-	int i = 0; \
-\
-	while(i < previous_words_count && \
-			!ends_with(previous_words[i], '(')) \
-	{ \
-		int cur_prev_wd_len = strlen(previous_words[i]); \
-		int j = 0; \
-\
-		while(list[j] != NULL) \
-		{ \
-			if(pg_strncasecmp(previous_words[i], list[j], \
-							  cur_prev_wd_len) == 0) \
-			{ \
-				list[j] = ""; \
-			} \
-\
-			j += 1; \
-		} \
-\
-		i += 1; \
-	} \
-\
-	i = 0; \
-	int j = 0; \
-\
-	while(list[j] != NULL) \
-	{ \
-		if(list[j][0] != '\0') \
-		{ \
-			list[i] = list[j]; \
-			if(i != j) \
-			{ \
-				list[j] = ""; \
-			} \
-\
-			i += 1; \
-		} \
-\
-		j += 1; \
-	} \
-\
-	list[i] = NULL; \
+	remove_used_options_from_list(list, (const char* const*)previous_words, \
+								  previous_words_count); \
 \
 	COMPLETE_WITH_LIST(list); \
 } while(0)
@@ -1214,6 +1170,10 @@ static char *escape_string(const char *text);
 static PGresult *exec_query(const char *query);
 
 static char **get_previous_words(int point, char **buffer, int *nwords);
+
+static int remove_used_options_from_list(const char** list,
+										 const char* const* previous_words,
+										 const int previous_words_count);
 
 static char *get_guctype(const char *varname);
 
@@ -4793,6 +4753,63 @@ get_previous_words(int point, char **buffer, int *nwords)
 
 	*nwords = words_found;
 	return previous_words;
+}
+
+/* Looks through all tokens in open bracket clause, */
+/* removing used options from suggestion list */
+/* and clearing up list from empty strings. */
+int
+remove_used_options_from_list(const char** list,
+							  const char* const* previous_words,
+							  const int previous_words_count)
+{
+	int removed_count = 0;
+	int i = 0;
+	int j = 0;
+
+	while(i < previous_words_count && !ends_with(previous_words[i], '('))
+	{
+		int cur_prev_wd_len = strlen(previous_words[i]);
+		j = 0;
+
+		while(list[j] != NULL)
+		{
+			if(pg_strncasecmp(previous_words[i], list[j],
+							  cur_prev_wd_len) == 0)
+			{
+				list[j] = "";
+
+				removed_count++;
+			}
+
+			j++;
+		}
+
+		i++;
+	}
+
+	i = 0;
+	j = 0;
+
+	const char* tmp;
+
+	while(list[j] != NULL)
+	{
+		if(list[j][0] != '\0')
+		{
+			tmp = list[i];
+			list[i] = list[j];
+			list[j] = tmp;
+
+			i++;
+		}
+
+		j++;
+	}
+
+	list[i] = NULL;
+
+	return removed_count;
 }
 
 /*

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2569,39 +2569,10 @@ psql_completion(const char *text, int start, int end)
 			!HeadMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny, "(" ,"(*") &&
 			!HeadMatches("CREATE", "TRUSTED", "PROTOCOL", MatchAny, "(*)")))
 	{
-		/* Find options that were used and complete with ones that hadn't */
 		if (ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
-		{
-			const char* create_protocol_options_list[] = {"readfunc =",
-								"writefunc =", "validatorfunc =", NULL};
-
-			int i = 0;
-
-			while(i < previous_words_count &&
-				  !ends_with(previous_words[i], '('))
-			{
-				int cur_prev_wd_len = strlen(previous_words[i]);
-				if(pg_strncasecmp(previous_words[i], "readfunc",
-								  cur_prev_wd_len) == 0)
-				{
-					create_protocol_options_list[0] = "";
-				}
-				else if(pg_strncasecmp(previous_words[i], "writefunc",
-									   cur_prev_wd_len) == 0)
-				{
-					create_protocol_options_list[1] = "";
-				}
-				else if(pg_strncasecmp(previous_words[i], "validatorfunc",
-									   cur_prev_wd_len) == 0)
-				{
-					create_protocol_options_list[2] = "";
-				}
-
-				i += 1;
-			}
-
-			COMPLETE_WITH_LIST(create_protocol_options_list);
-		}
+			COMPLETE_WITH_UNUSED_OPTIONS("readfunc", "writefunc", "validatorfunc");
+		else if(TailMatches("readfunc|writefunc|validatorfunc"))
+			COMPLETE_WITH("=");
 		else if(TailMatches("readfunc", "="))
 			COMPLETE_WITH_QUERY(Query_for_list_of_extprotocol_readfuncs);
 		else if(TailMatches("writefunc", "="))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2761,9 +2761,10 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH_LIST(list_CREATERESOURCEGROUP);
 	}
 
-	/* ALTER/CREATE/DROP RESOURCE QUEUE */
+/* ALTER/CREATE/DROP RESOURCE QUEUE */
 	else if(TailMatches("CREATE|ALTER|DROP", "RESOURCE", "QUEUE"))
 		COMPLETE_WITH_QUERY(Query_for_list_of_resqueues);
+
 	else if(TailMatches("CREATE", "RESOURCE", "QUEUE", MatchAny))
 		COMPLETE_WITH("ACTIVE THRESHOLD", "COST THRESHOLD", "IGNORE THRESHOLD",
 			"OVERCOMMIT", "NOOVERCOMMIT", "WITH (");

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2754,7 +2754,7 @@ psql_completion(const char *text, int start, int end)
 	/* CREATE RESOURCE GROUP <name> */
 	else if (TailMatches("CREATE", "RESOURCE", "GROUP", MatchAny))
 		COMPLETE_WITH("WITH (");
-  /* RESOURCE GROUP <name> WITH ( / SET */
+  	/* RESOURCE GROUP <name> WITH ( / SET */
 	else if (TailMatches("RESOURCE", "GROUP", MatchAny, "WITH", "(") ||
 			 TailMatches("RESOURCE", "GROUP", MatchAny, "SET"))
 		COMPLETE_WITH("CONCURRENCY", "CPU_MAX_PERCENT", "CPU_WEIGHT", "CPUSET",

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -319,7 +319,8 @@ do { \
 
 /* Macro to suggest unused options in bracket clause. */
 /* Looks through all tokens until it finds an opening bracket, */
-/* removing used options from suggestion list. */
+/* removing used options from suggestion list */
+/* and clearing up list from empty strings. */
 #define COMPLETE_WITH_UNUSED_OPTIONS(...) \
 do { \
 	const char* list[] = { __VA_ARGS__, NULL }; \
@@ -345,6 +346,27 @@ do { \
 \
 		i += 1; \
 	} \
+\
+	i = 0; \
+	int j = 0; \
+\
+	while(list[j] != NULL) \
+	{ \
+		if(list[j][0] != '\0') \
+		{ \
+			list[i] = list[j]; \
+			if(i != j) \
+			{ \
+				list[j] = ""; \
+			} \
+\
+			i += 1; \
+		} \
+\
+		j += 1; \
+	} \
+\
+	list[i] = NULL; \
 \
 	COMPLETE_WITH_LIST(list); \
 } while(0)

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1171,7 +1171,7 @@ static PGresult *exec_query(const char *query);
 
 static char **get_previous_words(int point, char **buffer, int *nwords);
 
-static int remove_used_options_from_list(const char** list,
+static void remove_used_options_from_list(const char** list,
 										 const char* const* previous_words,
 										 const int previous_words_count);
 
@@ -4758,12 +4758,11 @@ get_previous_words(int point, char **buffer, int *nwords)
 /* Looks through all tokens in open bracket clause, */
 /* removing used options from suggestion list */
 /* and clearing up list from empty strings. */
-int
+void
 remove_used_options_from_list(const char** list,
 							  const char* const* previous_words,
 							  const int previous_words_count)
 {
-	int removed_count = 0;
 	int i = 0;
 	int j = 0;
 
@@ -4778,8 +4777,6 @@ remove_used_options_from_list(const char** list,
 							  cur_prev_wd_len) == 0)
 			{
 				list[j] = "";
-
-				removed_count++;
 			}
 
 			j++;
@@ -4808,8 +4805,6 @@ remove_used_options_from_list(const char** list,
 	}
 
 	list[i] = NULL;
-
-	return removed_count;
 }
 
 /*

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2790,8 +2790,10 @@ psql_completion(const char *text, int start, int end)
 	else if(TailMatches("ALTER", "RESOURCE", "QUEUE", MatchAny))
 		COMPLETE_WITH("ACTIVE THRESHOLD", "COST THRESHOLD", "IGNORE THRESHOLD",
 			"OVERCOMMIT", "NOOVERCOMMIT", "WITH (", "WITHOUT (");
-	else if(HeadMatches("CREATE|ALTER", "RESOURCE", "QUEUE", MatchAny, "WITH|WITHOUT", "(*") &&
-		   !HeadMatches("CREATE|ALTER", "RESOURCE", "QUEUE", MatchAny, "WITH|WITHOUT", "(*)"))
+	else if((HeadMatches("CREATE", "RESOURCE", "QUEUE", MatchAny, "WITH", "(*") &&
+			!HeadMatches("CREATE", "RESOURCE", "QUEUE", MatchAny, "WITH", "(*)")) || 
+			(HeadMatches("ALTER", "RESOURCE", "QUEUE", MatchAny, "WITH|WITHOUT", "(*") &&
+			!HeadMatches("ALTER", "RESOURCE", "QUEUE", MatchAny, "WITH|WITHOUT", "(*)")))
 	{
 		if(ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
 			COMPLETE_WITH("ACTIVE_STATEMENTS", "MEMORY_LIMIT", "MAX_COST", "COST_OVERCOMMIT", "MIN_COST", "PRIORITY");

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -317,6 +317,38 @@ do { \
 	matches = completion_matches(text, complete_from_query); \
 } while (0)
 
+/* Macro to suggest unused options in bracket clause. */
+/* Looks through all tokens until it finds an opening bracket, */
+/* removing used options from suggestion list. */
+#define COMPLETE_WITH_UNUSED_OPTIONS(...) \
+do { \
+	const char* list[] = { __VA_ARGS__, NULL }; \
+\
+	int i = 0; \
+\
+	while(i < previous_words_count && \
+			!ends_with(previous_words[i], '(')) \
+	{ \
+		int cur_prev_wd_len = strlen(previous_words[i]); \
+		int j = 0; \
+\
+		while(list[j] != NULL) \
+		{ \
+			if(pg_strncasecmp(previous_words[i], list[j], \
+							  cur_prev_wd_len) == 0) \
+			{ \
+				list[j] = ""; \
+			} \
+\
+			j += 1; \
+		} \
+\
+		i += 1; \
+	} \
+\
+	COMPLETE_WITH_LIST(list); \
+} while(0)
+
 /*
  * Assembly instructions for schema queries
  */
@@ -2794,7 +2826,7 @@ psql_completion(const char *text, int start, int end)
 			!HeadMatches("ALTER", "RESOURCE", "QUEUE", MatchAny, "WITH|WITHOUT", "(*)")))
 	{
 		if(ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
-			COMPLETE_WITH("ACTIVE_STATEMENTS", "MEMORY_LIMIT", "MAX_COST", "COST_OVERCOMMIT", "MIN_COST", "PRIORITY");
+			COMPLETE_WITH_UNUSED_OPTIONS("ACTIVE_STATEMENTS", "MEMORY_LIMIT", "MAX_COST", "COST_OVERCOMMIT", "MIN_COST", "PRIORITY");
 		else if(TailMatches("ACTIVE_STATEMENTS|MEMORY_LIMIT|MAX_COST|COST_OVERCOMMIT|MIN_COST|PRIORITY"))
 			COMPLETE_WITH("=");
 		else if(TailMatches("COST_OVERCOMMIT", "="))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2754,7 +2754,7 @@ psql_completion(const char *text, int start, int end)
 	/* CREATE RESOURCE GROUP <name> */
 	else if (TailMatches("CREATE", "RESOURCE", "GROUP", MatchAny))
 		COMPLETE_WITH("WITH (");
-  	/* RESOURCE GROUP <name> WITH ( / SET */
+	/* RESOURCE GROUP <name> WITH ( / SET */
 	else if (TailMatches("RESOURCE", "GROUP", MatchAny, "WITH", "(") ||
 			 TailMatches("RESOURCE", "GROUP", MatchAny, "SET"))
 		COMPLETE_WITH("CONCURRENCY", "CPU_MAX_PERCENT", "CPU_WEIGHT", "CPUSET",

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2903,10 +2903,10 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH("WITH (");
 	else if(TailMatches("ALTER", "RESOURCE", "QUEUE", MatchAny))
 		COMPLETE_WITH("WITH (", "WITHOUT (");
-	else if((HeadMatches("CREATE", "RESOURCE", "QUEUE", MatchAny, "WITH", "(*") &&
-			!HeadMatches("CREATE", "RESOURCE", "QUEUE", MatchAny, "WITH", "(*)")) || 
-			(HeadMatches("ALTER", "RESOURCE", "QUEUE", MatchAny, "WITH|WITHOUT", "(*") &&
-			!HeadMatches("ALTER", "RESOURCE", "QUEUE", MatchAny, "WITH|WITHOUT", "(*)")))
+	else if(TailMatches("ALTER", "RESOURCE", "QUEUE", MatchAny, "WITH"))
+		COMPLETE_WITH("(");
+	else if(HeadMatches("ALTER|CREATE", "RESOURCE", "QUEUE", MatchAny, "WITH", "(*") &&
+		   !HeadMatches("ALTER|CREATE", "RESOURCE", "QUEUE", MatchAny, "WITH", "(*)"))
 	{
 		if(ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
 			COMPLETE_WITH_UNUSED_OPTIONS("ACTIVE_STATEMENTS", "MEMORY_LIMIT", "MAX_COST", "COST_OVERCOMMIT", "MIN_COST", "PRIORITY");
@@ -2917,6 +2917,14 @@ psql_completion(const char *text, int start, int end)
 		else if(TailMatches("PRIORITY", "="))
 			COMPLETE_WITH("MIN", "LOW", "MEDIUM", "HIGH", "MAX");
 		else if(TailMatches(MatchAny, "=", MatchAny))
+			COMPLETE_WITH(",", ")");
+	}
+	else if(HeadMatches("ALTER", "RESOURCE", "QUEUE", MatchAny, "WITHOUT", "(*") &&
+		   !HeadMatches("ALTER", "RESOURCE", "QUEUE", MatchAny, "WITHOUT", "(*)"))
+	{
+		if(ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
+			COMPLETE_WITH_UNUSED_OPTIONS("ACTIVE_STATEMENTS", "MEMORY_LIMIT", "MAX_COST", "COST_OVERCOMMIT", "MIN_COST", "PRIORITY");
+		else if(TailMatches("ACTIVE_STATEMENTS|MEMORY_LIMIT|MAX_COST|COST_OVERCOMMIT|MIN_COST|PRIORITY"))
 			COMPLETE_WITH(",", ")");
 	}
 

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2771,8 +2771,14 @@ psql_completion(const char *text, int start, int end)
 	else if(TailMatches("ALTER", "RESOURCE", "QUEUE", MatchAny))
 		COMPLETE_WITH("ACTIVE THRESHOLD", "COST THRESHOLD", "IGNORE THRESHOLD",
 			"OVERCOMMIT", "NOOVERCOMMIT", "WITH (", "WITHOUT (");
-	else if(TailMatches("CREATE|ALTER", "RESOURCE", "QUEUE", MatchAny, "WITH|WITHOUT", "("))
-		COMPLETE_WITH("ACTIVE_STATEMENTS", "MEMORY_LIMIT", "MAX_COST", "COST_OVERCOMMIT", "MIN_COST", "PRIORITY");
+	else if(HeadMatches("CREATE|ALTER", "RESOURCE", "QUEUE", MatchAny, "WITH|WITHOUT", "(*") &&
+		   !HeadMatches("CREATE|ALTER", "RESOURCE", "QUEUE", MatchAny, "WITH|WITHOUT", "(*)"))
+	{
+		if(ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
+			COMPLETE_WITH("ACTIVE_STATEMENTS", "MEMORY_LIMIT", "MAX_COST", "COST_OVERCOMMIT", "MIN_COST", "PRIORITY");
+		else if(TailMatches("ACTIVE_STATEMENTS|MEMORY_LIMIT|MAX_COST|COST_OVERCOMMIT|MIN_COST|PRIORITY"))
+			COMPLETE_WITH("=");
+	}
 
 
 /* CREATE VIEW --- is allowed inside CREATE SCHEMA, so use TailMatches */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2781,15 +2781,13 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH("max");
 
 /* ALTER/CREATE/DROP RESOURCE QUEUE */
-	else if(TailMatches("CREATE|ALTER|DROP", "RESOURCE", "QUEUE"))
+	else if(TailMatches("ALTER|DROP", "RESOURCE", "QUEUE"))
 		COMPLETE_WITH_QUERY(Query_for_list_of_resqueues);
 
 	else if(TailMatches("CREATE", "RESOURCE", "QUEUE", MatchAny))
-		COMPLETE_WITH("ACTIVE THRESHOLD", "COST THRESHOLD", "IGNORE THRESHOLD",
-			"OVERCOMMIT", "NOOVERCOMMIT", "WITH (");
+		COMPLETE_WITH("WITH (");
 	else if(TailMatches("ALTER", "RESOURCE", "QUEUE", MatchAny))
-		COMPLETE_WITH("ACTIVE THRESHOLD", "COST THRESHOLD", "IGNORE THRESHOLD",
-			"OVERCOMMIT", "NOOVERCOMMIT", "WITH (", "WITHOUT (");
+		COMPLETE_WITH("WITH (", "WITHOUT (");
 	else if((HeadMatches("CREATE", "RESOURCE", "QUEUE", MatchAny, "WITH", "(*") &&
 			!HeadMatches("CREATE", "RESOURCE", "QUEUE", MatchAny, "WITH", "(*)")) || 
 			(HeadMatches("ALTER", "RESOURCE", "QUEUE", MatchAny, "WITH|WITHOUT", "(*") &&
@@ -2799,6 +2797,12 @@ psql_completion(const char *text, int start, int end)
 			COMPLETE_WITH("ACTIVE_STATEMENTS", "MEMORY_LIMIT", "MAX_COST", "COST_OVERCOMMIT", "MIN_COST", "PRIORITY");
 		else if(TailMatches("ACTIVE_STATEMENTS|MEMORY_LIMIT|MAX_COST|COST_OVERCOMMIT|MIN_COST|PRIORITY"))
 			COMPLETE_WITH("=");
+		else if(TailMatches("COST_OVERCOMMIT", "="))
+			COMPLETE_WITH("TRUE", "FALSE");
+		else if(TailMatches("PRIORITY", "="))
+			COMPLETE_WITH("MIN", "LOW", "MEDIUM", "HIGH", "MAX");
+		else if(TailMatches(MatchAny, "=", MatchAny))
+			COMPLETE_WITH(",", ")");
 	}
 
 /* CREATE VIEW --- is allowed inside CREATE SCHEMA, so use TailMatches */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -714,6 +714,11 @@ static const SchemaQuery Query_for_list_of_statistics = {
 "   FROM pg_catalog.pg_resgroup "\
 "  WHERE substring(pg_catalog.quote_ident(rsgname),1,%d)='%s'"
 
+#define Query_for_list_of_resqueues \
+" SELECT pg_catalog.quote_ident(rsqname) "\
+"   FROM pg_catalog.pg_resqueue "\
+"  WHERE substring(pg_catalog.quote_ident(rsqname),1,%d)='%s'"
+
 #define Query_for_list_of_roles \
 " SELECT pg_catalog.quote_ident(rolname) "\
 "   FROM pg_catalog.pg_roles "\
@@ -2755,6 +2760,18 @@ psql_completion(const char *text, int start, int end)
 
 		COMPLETE_WITH_LIST(list_CREATERESOURCEGROUP);
 	}
+
+	/* ALTER/CREATE/DROP RESOURCE QUEUE */
+	else if(TailMatches("CREATE|ALTER|DROP", "RESOURCE", "QUEUE"))
+		COMPLETE_WITH_QUERY(Query_for_list_of_resqueues);
+	else if(TailMatches("CREATE", "RESOURCE", "QUEUE", MatchAny))
+		COMPLETE_WITH("ACTIVE THRESHOLD", "COST THRESHOLD", "IGNORE THRESHOLD",
+			"OVERCOMMIT", "NOOVERCOMMIT", "WITH (");
+	else if(TailMatches("ALTER", "RESOURCE", "QUEUE", MatchAny))
+		COMPLETE_WITH("ACTIVE THRESHOLD", "COST THRESHOLD", "IGNORE THRESHOLD",
+			"OVERCOMMIT", "NOOVERCOMMIT", "WITH (", "WITHOUT (");
+	else if(TailMatches("CREATE|ALTER", "RESOURCE", "QUEUE", MatchAny, "WITH|WITHOUT", "("))
+		COMPLETE_WITH("ACTIVE_STATEMENTS", "MEMORY_LIMIT", "MAX_COST", "COST_OVERCOMMIT", "MIN_COST", "PRIORITY");
 
 
 /* CREATE VIEW --- is allowed inside CREATE SCHEMA, so use TailMatches */


### PR DESCRIPTION
Some commands for RESOURCE QUEUE lacked autocompletion support in psql.

Add queue list suggestion in ALTER/CREATE/DROP commands.
Add queue attributes suggestion in ALTER/CREATE commands.
Add multiple attributes support in ALTER/CREATE commands.

Add macro & function to remove already entered suggestions.
Replace code in CREATE PROTOCOL with this macro.