### PR TITLE
Allow user to cancel ggrebalance if it hangs on catalog lock

### DIFF
--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -6,6 +6,7 @@
 from transitions import Machine
 from contextlib import closing
 from typing import Any
+from queue import Queue
 
 try:
     from gppylib.commands.unix import *
@@ -195,6 +196,7 @@ class GGShrink:
         self.options = options
         self.gpEnv = gpEnv
         self.conn = conn
+        self.cancel_conn = None
         self.shutdown_requested = False
         self.workers_for_tables_rebalance = None
         self.tables_rebalance_failed = False
@@ -280,10 +282,12 @@ class GGShrink:
 
             # get default num segments
             dbconn.execSQL(self.conn, 'BEGIN')
-            dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
+            self.logger.info('Locking catalog...')
+            self.execSqlInThread(self.conn, 'SELECT gp_expand_lock_catalog()')
             row = dbconn.queryRow(self.conn, 'SELECT gp_toolkit.gp_rebalance_numsegments_is_set()')
             numsegments_is_set = bool(row[0])
             dbconn.execSQL(self.conn, 'END')
+            self.logger.info('Unlocked catalog')
 
             if numsegments_is_set:
                 self.logger.warning('Current numsegments is not equal to default value.')
@@ -296,15 +300,36 @@ class GGShrink:
             if (numsegments_is_set and
                 interactive_check_yesno(self.options.interactive, None, '\nReset numsegments to default?', default = 'Y')):
                 dbconn.execSQL(self.conn, 'BEGIN')
-                dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
+                self.logger.info('Locking catalog...')
+                self.execSqlInThread(self.conn, 'SELECT gp_expand_lock_catalog()')
                 dbconn.execSQL(self.conn, 'SELECT gp_toolkit.gp_reset_rebalance_numsegments()')
                 dbconn.execSQL(self.conn, 'COMMIT')
+                self.logger.info('Unlocked catalog')
                 self.logger.info('Reset numsegments to default is done.')
 
         if os.path.exists(self.gparray_dump_file):
             os.remove(self.gparray_dump_file)
 
         return True
+
+    def execSqlInThread(self, conn: dbconn.Connection, sql_cmd: str) -> None:
+        # TODO: comments why we need it
+        self.cancel_conn = conn
+        result_queue = Queue()
+        def exec_sql():
+            try:
+                dbconn.execSQL(conn, sql_cmd)
+                result_queue.put((0, None))
+            except Exception as e:
+                self.logger.error(f"Error when performing query '{sql_cmd}': {str(e)}")
+                result_queue.put((1, e))
+        thread = threading.Thread(target=exec_sql)
+        thread.start()
+        thread.join()
+        return_value, return_exception = result_queue.get()
+        if return_value != 0:
+            raise return_exception
+        self.cancel_conn = None
 
     def state_is_final(self, state: str) -> bool:
         return state == self.states_main_shrink_flow[-1]
@@ -362,8 +387,9 @@ class GGShrink:
     @wrap_func_with_faults
     def on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED(self) -> None:
         dbconn.execSQL(self.conn, 'BEGIN')
-        dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
-        dbconn.execSQL(self.conn, 'CHECKPOINT')
+        self.logger.info('Locking catalog...')
+        self.execSqlInThread(self.conn, 'SELECT gp_expand_lock_catalog()')
+        self.execSqlInThread(self.conn, 'CHECKPOINT')
         dbconn.execSQL(self.conn, f'SELECT gp_toolkit.gp_set_rebalance_numsegments({self.shrink_plan.getTargetSegmentCount()})')
 
         self.gparray.dumpToFile(self.gparray_dump_file)
@@ -372,6 +398,7 @@ class GGShrink:
         self.rebalance_schema.rebalanceSchema(self.shrink_plan.getTargetSegmentCount())
 
         dbconn.execSQL(self.conn, 'COMMIT')
+        self.logger.info('Unlocked catalog')
 
         self.trigger('move_to_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_DONE')
 
@@ -408,12 +435,14 @@ class GGShrink:
 
         ## Shrink catalog
         dbconn.execSQL(self.conn, 'BEGIN')
-        dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
+        self.logger.info('Locking catalog...')
+        self.execSqlInThread(self.conn, 'SELECT gp_expand_lock_catalog()')
         dbconn.execSQL(self.conn, f'DELETE FROM gp_segment_configuration WHERE content >= {self.shrink_plan.getTargetSegmentCount()}')
-        dbconn.execSQL(self.conn, 'CHECKPOINT')
+        self.execSqlInThread(self.conn, 'CHECKPOINT')
         dbconn.execSQL(self.conn, 'SELECT gp_expand_bump_version()')
         dbconn.execSQL(self.conn, 'SELECT gp_toolkit.gp_reset_rebalance_numsegments()')
         dbconn.execSQL(self.conn, 'COMMIT')
+        self.logger.info('Unlocked catalog')
 
         self.trigger('move_to_STATE_SHRINK_CATALOG_DONE')
 
@@ -490,12 +519,14 @@ class GGShrink:
     def on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START(self) -> None:
         self.rebalance_schema.backupShrinkProgress()
         dbconn.execSQL(self.conn, 'BEGIN')
-        dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
+        self.logger.info('Locking catalog...')
+        self.execSqlInThread(self.conn, 'SELECT gp_expand_lock_catalog()')
         dbconn.execSQL(self.conn, 'SELECT gp_toolkit.gp_reset_rebalance_numsegments()')
         # Store state here in case we fail before we enter 'on_every_state()'
         # because after COMMIT we are on a one-way road of rollback.
         self.rebalance_schema.storeShrinkState(self.state)
         dbconn.execSQL(self.conn, 'COMMIT')
+        self.logger.info('Unlocked catalog')
 
         self.trigger('move_to_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE')
 
@@ -860,6 +891,9 @@ class GGShrink:
         return self.dumped_gparray.get_segment_count() != self.gparray.get_segment_count()
 
     def shutdown(self) -> None:
+        if self.cancel_conn != None:
+            self.cancel_conn.cancel()
+
         if self.workers_for_tables_rebalance != None:
             self.workers_for_tables_rebalance.haltWork()
             self.workers_for_tables_rebalance.joinWorkers()

--- a/gpMgmt/bin/ggrebalance_modules/shrink.py
+++ b/gpMgmt/bin/ggrebalance_modules/shrink.py
@@ -28,6 +28,7 @@ except ImportError as e:
 
 class GGShrink:
     timeout = SEGMENT_STOP_TIMEOUT_DEFAULT
+    MSG_SHRINK_INTERRUPTED = 'Shrink was interrupted'
 
     states = [
         'STATE_START',
@@ -267,8 +268,8 @@ class GGShrink:
 
     def on_every_state(self) -> None:
         if self.shutdown_requested:
-            self.logger.info('Shrink was interrupted')
-            raise Exception('Shrink was interrupted')
+            self.logger.info(self.MSG_SHRINK_INTERRUPTED)
+            raise Exception(self.MSG_SHRINK_INTERRUPTED)
 
         assert self.state in self.states + self.states_main_shrink_flow + self.states_rollback_flow
 
@@ -313,7 +314,11 @@ class GGShrink:
         return True
 
     def execSqlInThread(self, conn: dbconn.Connection, sql_cmd: str) -> None:
-        # TODO: comments why we need it
+        # During the long operation of a C-function (like the DB driver),
+        # if it is executed from the main thread, the signal handler will be executed only when
+        # the low-level function is complete. Therefore, we execute queries that can be blocked,
+        # or just potentially long-running queries, in a separate thread in order to allow
+        # immediate invocation of the signal handler and cancelation of the query.
         self.cancel_conn = conn
         result_queue = Queue()
         def exec_sql():
@@ -328,6 +333,12 @@ class GGShrink:
         thread.join()
         return_value, return_exception = result_queue.get()
         if return_value != 0:
+            # If the query failed due to the user request, log and raise the same
+            # exception as done because of the 'shutdown_requested' flag for the behavior consistency reasons.
+            if str(return_exception).find('canceling statement due to user request') != -1:
+                self.logger.info(self.MSG_SHRINK_INTERRUPTED)
+                raise Exception(self.MSG_SHRINK_INTERRUPTED)
+            # Otherwise, pass the original exception.
             raise return_exception
         self.cancel_conn = None
 

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
@@ -129,8 +129,14 @@ Feature: ggrebalance behave tests
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And the user connects to "test_db_1" with named connection "test_connection"
-         And the user executes "BEGIN; LOCK TABLE test_schema_1.test_table_1 IN ACCESS EXCLUSIVE MODE;" with named connection "test_connection"
+         And the user executes "BEGIN; TRUNCATE test_schema_1.test_table_1;" with named connection "test_connection"
         When the user asynchronously runs "ggrebalance -x 4 -n 1 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'" and the process is saved
+        Then the user asynchronously sets up to end ggrebalance process when "Locking catalog" is printed in the ggrebalance logs
+         And the async process finished with a return code of 1
+         And ggrebalance should print "Shrink was interrupted" to logfile with latest timestamp
+         And the user executes "ROLLBACK;" with named connection "test_connection"
+         And the user executes "BEGIN; LOCK TABLE test_schema_1.test_table_1 IN ACCESS EXCLUSIVE MODE;" with named connection "test_connection"
+        When the user asynchronously runs "ggrebalance -n 1" and the process is saved
         Then the user asynchronously sets up to end ggrebalance process when "Start table rebalance for \"test_db_1\".\"test_schema_1\".\"test_table_1\" to 4 segments" is printed in the ggrebalance logs
          And the async process finished with a return code of 1
          And ggrebalance should print "Failed to process the db object "test_db_1"."test_schema_1"."test_table_1" for 2 attempts" to logfile with latest timestamp


### PR DESCRIPTION
Allow user to cancel ggrebalance if it hangs on catalog lock

Problem description:
If there was an open transaction which blocked catalog locking (performed via
'SELECT gp_expand_lock_catalog()'), ggrebalance hanged after its schema
creation, and the user was not able to interrupt it with a signal.

Root cause:
During the long operation of a C-function (like the DB driver), if it is
executed from the main thread, the signal handler will be executed only when
the low-level function is complete.
So, we were waiting inside the driver function on 'gp_expand_lock_catalog()'
till the lock was released on the DB side, and only after that was the signal
handler invoked.

Solution:
Execute all potentially long queries (like catalog locking or checkpoints) from
a separate thread. Therefore, the main thread is able to invoke the signal
handler and cancel the pending operation.
Plus, add more logging when locking and unlocking the catalog, so the user gets
more useful hints about why the tool is blocked for a valid reason.