### PR TITLE
GG-520: Improve autocomplete for EXTERNAL TABLE

### DIFF
--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2979,6 +2979,9 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH("WEB", "TABLE");
 	else if(Matches("DROP", "EXTERNAL", "WEB"))
 		COMPLETE_WITH("TABLE");
+	else if(Matches("DROP", "EXTERNAL", "TABLE") ||
+			Matches("DROP", "EXTERNAL", "WEB", "TABLE"))
+		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_external_tables, NULL);
 
 	/* help completing some of the variants */
 	else if (Matches("DROP", "AGGREGATE|FUNCTION|PROCEDURE|ROUTINE", MatchAny))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1657,28 +1657,28 @@ psql_completion(const char *text, int start, int end)
 	}
 
 	/* ALTER EXTERNAL TABLE */
-	else if(Matches("ALTER", "EXTERNAL"))
+	else if (Matches("ALTER", "EXTERNAL"))
 		COMPLETE_WITH("TABLE");
-	else if(Matches("ALTER", "EXTERNAL", "TABLE"))
+	else if (Matches("ALTER", "EXTERNAL", "TABLE"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_external_tables, NULL);
-	else if(Matches("ALTER", "EXTERNAL", "TABLE", MatchAny))
+	else if (Matches("ALTER", "EXTERNAL", "TABLE", MatchAny))
 		COMPLETE_WITH("ADD", "DROP", "ALTER", "OWNER TO");
-	else if(Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "ADD"))
+	else if (Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "ADD"))
 		COMPLETE_WITH("COLUMN");
 
 	/* ALTER EXTERNAL TABLE <name> ALTER|DROP */
-	else if(Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "ALTER|DROP"))
+	else if (Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "ALTER|DROP"))
 		COMPLETE_WITH_ATTR(prev2_wd, " UNION SELECT 'COLUMN'");
-	else if(Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "ALTER|DROP", "COLUMN"))
+	else if (Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "ALTER|DROP", "COLUMN"))
 		COMPLETE_WITH_ATTR(prev3_wd, "");
 
 	/* ALTER EXTERNAL TABLE <name> ALTER <colname> TYPE */
-	else if(Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "ALTER", MatchAny) ||
+	else if (Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "ALTER", MatchAny) ||
 			Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "ALTER", "COLUMN", MatchAny))
 		COMPLETE_WITH("TYPE");
 
 	/* ALTER EXTERNAL TABLE <name> DROP <colname> */
-	else if(Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "DROP", MatchAny) ||
+	else if (Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "DROP", MatchAny) ||
 			Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "DROP", "COLUMN", MatchAny))
 		COMPLETE_WITH("RESTRICT", "CASCADE");
 
@@ -2354,91 +2354,91 @@ psql_completion(const char *text, int start, int end)
 	}
 
 	/* CREATE ... EXTERNAL ... TABLE */
-	else if(TailMatches("CREATE", "READABLE|WRITABLE"))
+	else if (TailMatches("CREATE", "READABLE|WRITABLE"))
 		COMPLETE_WITH("EXTERNAL");
-	else if(TailMatches("CREATE", "EXTERNAL") ||
+	else if (TailMatches("CREATE", "EXTERNAL") ||
 			TailMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL"))
 		COMPLETE_WITH("WEB", "TEMP", "TEMPORARY", "TABLE");
-	else if(TailMatches("CREATE", "EXTERNAL", "WEB") ||
+	else if (TailMatches("CREATE", "EXTERNAL", "WEB") ||
 			TailMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL", "WEB"))
 		COMPLETE_WITH("TEMP", "TEMPORARY", "TABLE");
-	else if(TailMatches("CREATE", "EXTERNAL", "TEMP|TEMPORARY") ||
+	else if (TailMatches("CREATE", "EXTERNAL", "TEMP|TEMPORARY") ||
 			TailMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL", "TEMP|TEMPORARY") ||
 			TailMatches("CREATE", "EXTERNAL", "WEB", "TEMP|TEMPORARY") ||
 			TailMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL", "WEB", "TEMP|TEMPORARY"))
 		COMPLETE_WITH("TABLE");
 
 	/* CREATE ... EXTERNAL ... TABLE */
-	else if((HeadMatches("CREATE", "EXTERNAL") ||
+	else if ((HeadMatches("CREATE", "EXTERNAL") ||
 			HeadMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL")) &&
 			TailMatches("TABLE"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_external_tables, NULL);
 	/* CREATE ... EXTERNAL ... TABLE ... */
-	else if((HeadMatches("CREATE", "EXTERNAL") ||
+	else if ((HeadMatches("CREATE", "EXTERNAL") ||
 			HeadMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL")) &&
 			TailMatches("TABLE", MatchAny))
 		COMPLETE_WITH("(");
 	/* CREATE ... EXTERNAL ... FORMAT */
-	else if((HeadMatches("CREATE", "EXTERNAL") ||
+	else if ((HeadMatches("CREATE", "EXTERNAL") ||
 			HeadMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL")) &&
 			TailMatches("FORMAT"))
 		COMPLETE_WITH("'TEXT'", "'CSV'", "'CUSTOM'");
 
 	/* CREATE [READABLE] EXTERNAL ... LOG ERRORS */
-	else if((HeadMatches("CREATE", "EXTERNAL") ||
+	else if ((HeadMatches("CREATE", "EXTERNAL") ||
 			HeadMatches("CREATE", "READABLE", "EXTERNAL")) &&
 			TailMatches("LOG", "ERRORS"))
 		COMPLETE_WITH("PERSISTENTLY", "SEGMENT REJECT LIMIT");
-	else if((HeadMatches("CREATE", "EXTERNAL") ||
+	else if ((HeadMatches("CREATE", "EXTERNAL") ||
 			HeadMatches("CREATE", "READABLE", "EXTERNAL")) &&
 			TailMatches("PERSISTENTLY"))
 		COMPLETE_WITH("SEGMENT REJECT LIMIT");
-	else if((HeadMatches("CREATE", "EXTERNAL") ||
+	else if ((HeadMatches("CREATE", "EXTERNAL") ||
 			HeadMatches("CREATE", "READABLE", "EXTERNAL")) &&
 			TailMatches("SEGMENT", "REJECT", "LIMIT", MatchAny))
 		COMPLETE_WITH("ROWS", "PERCENT");
 
 	/* CREATE [READABLE] EXTERNAL WEB ... */
-	else if(HeadMatches("CREATE", "EXTERNAL", "WEB", "TABLE") ||
+	else if (HeadMatches("CREATE", "EXTERNAL", "WEB", "TABLE") ||
 			HeadMatches("CREATE", "READABLE", "EXTERNAL", "WEB", "TABLE") ||
 			HeadMatches("CREATE", "EXTERNAL", "WEB", "TEMP|TEMPORARY", "TABLE") ||
 			HeadMatches("CREATE", "READABLE", "EXTERNAL", "WEB", "TEMP|TEMPORARY", "TABLE"))
 	{
-		if(TailMatches("TABLE", MatchAny, "(*)"))
+		if (TailMatches("TABLE", MatchAny, "(*)"))
 			COMPLETE_WITH_SUPPRESS_APPEND("LOCATION ('", "EXECUTE '");
-		else if(TailMatches("EXECUTE", "'*'"))
+		else if (TailMatches("EXECUTE", "'*'"))
 			COMPLETE_WITH("FORMAT", "ON");
-		else if(TailMatches("EXECUTE", "'*'", "ON"))
+		else if (TailMatches("EXECUTE", "'*'", "ON"))
 			COMPLETE_WITH("ALL", "COORDINATOR", "HOST", "SEGMENT");
-		else if(TailMatches("LOCATION", "(*)") ||
+		else if (TailMatches("LOCATION", "(*)") ||
 				TailMatches("EXECUTE", "'*'", "ON", MatchAnyExcept("HOST|SEGMENT")) ||
 				TailMatches("EXECUTE", "'*'", "ON", MatchAny, MatchAnyExcept("FORMAT")))
 			COMPLETE_WITH("FORMAT");
-		else if(TailMatches("FORMAT", MatchAny) ||
+		else if (TailMatches("FORMAT", MatchAny) ||
 				TailMatches("FORMAT", MatchAny, "(*)"))
 			COMPLETE_WITH("OPTIONS (", "ENCODING '", "LOG ERRORS", "SEGMENT REJECT LIMIT");
-		else if(TailMatches("OPTIONS", "(*)"))
+		else if (TailMatches("OPTIONS", "(*)"))
 			COMPLETE_WITH("ENCODING '", "LOG ERRORS", "SEGMENT REJECT LIMIT");
-		else if(TailMatches("ENCODING", "'*'"))
+		else if (TailMatches("ENCODING", "'*'"))
 			COMPLETE_WITH("LOG ERRORS", "SEGMENT REJECT LIMIT");
 	}
 
 	/* CREATE [READABLE] EXTERNAL ... */
-	else if(HeadMatches("CREATE", "EXTERNAL", "TABLE") ||
+	else if (HeadMatches("CREATE", "EXTERNAL", "TABLE") ||
 			HeadMatches("CREATE", "READABLE", "EXTERNAL", "TABLE") ||
 			HeadMatches("CREATE", "EXTERNAL", "TEMP|TEMPORARY", "TABLE") ||
 			HeadMatches("CREATE", "READABLE", "EXTERNAL", "TEMP|TEMPORARY", "TABLE"))
 	{
-		if(TailMatches("TABLE", MatchAny, "(*)"))
+		if (TailMatches("TABLE", MatchAny, "(*)"))
 			COMPLETE_WITH_SUPPRESS_APPEND("LOCATION ('");
-		else if(TailMatches("LOCATION", "(*)"))
+		else if (TailMatches("LOCATION", "(*)"))
 			COMPLETE_WITH("FORMAT");
-		else if(TailMatches("FORMAT", MatchAny) ||
+		else if (TailMatches("FORMAT", MatchAny) ||
 				TailMatches("FORMAT", MatchAny, "(*)"))
 			COMPLETE_WITH("OPTIONS (", "ENCODING '", "LOG ERRORS", "SEGMENT REJECT LIMIT");
-		else if(TailMatches("OPTIONS", "(*)"))
+		else if (TailMatches("OPTIONS", "(*)"))
 			COMPLETE_WITH("ENCODING '", "LOG ERRORS", "SEGMENT REJECT LIMIT");
-		else if(TailMatches("ENCODING", "'*'"))
+		else if (TailMatches("ENCODING", "'*'"))
 			COMPLETE_WITH("LOG ERRORS", "SEGMENT REJECT LIMIT");
 	}
 
@@ -2448,38 +2448,38 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH("BY (", "RANDOMLY");
 
 	/* CREATE WRITABLE EXTERNAL WEB ... */
-	else if(HeadMatches("CREATE", "WRITABLE", "EXTERNAL", "WEB", "TABLE") ||
+	else if (HeadMatches("CREATE", "WRITABLE", "EXTERNAL", "WEB", "TABLE") ||
 			HeadMatches("CREATE", "WRITABLE", "EXTERNAL", "WEB", "TEMP|TEMPORARY", "TABLE"))
 	{
-		if(TailMatches("TABLE", MatchAny, "(*)"))
+		if (TailMatches("TABLE", MatchAny, "(*)"))
 			COMPLETE_WITH_SUPPRESS_APPEND("EXECUTE '");
-		else if(TailMatches("EXECUTE", "'*'"))
+		else if (TailMatches("EXECUTE", "'*'"))
 			COMPLETE_WITH("FORMAT", "ON ALL");
-		else if(TailMatches("EXECUTE", "'*'", "ON", "ALL"))
+		else if (TailMatches("EXECUTE", "'*'", "ON", "ALL"))
 			COMPLETE_WITH("FORMAT");
-		else if(TailMatches("FORMAT", MatchAny) ||
+		else if (TailMatches("FORMAT", MatchAny) ||
 				TailMatches("FORMAT", MatchAny, "(*)"))
 			COMPLETE_WITH("OPTIONS (", "ENCODING '", "DISTRIBUTED");
-		else if(TailMatches("OPTIONS", "(*)"))
+		else if (TailMatches("OPTIONS", "(*)"))
 			COMPLETE_WITH("ENCODING '", "DISTRIBUTED");
-		else if(TailMatches("ENCODING", "'*'"))
+		else if (TailMatches("ENCODING", "'*'"))
 			COMPLETE_WITH("DISTRIBUTED");
 	}
 
 	/* CREATE WRITABLE EXTERNAL ... */
-	else if(HeadMatches("CREATE", "WRITABLE", "EXTERNAL", "TABLE") ||
+	else if (HeadMatches("CREATE", "WRITABLE", "EXTERNAL", "TABLE") ||
 			HeadMatches("CREATE", "WRITABLE", "EXTERNAL", "TEMP|TEMPORARY", "TABLE"))
 	{
-		if(TailMatches("TABLE", MatchAny, "(*)"))
+		if (TailMatches("TABLE", MatchAny, "(*)"))
 			COMPLETE_WITH_SUPPRESS_APPEND("LOCATION ('");
-		else if(TailMatches("LOCATION", "(*)"))
+		else if (TailMatches("LOCATION", "(*)"))
 			COMPLETE_WITH("FORMAT");
-		else if(TailMatches("FORMAT", MatchAny) ||
+		else if (TailMatches("FORMAT", MatchAny) ||
 				TailMatches("FORMAT", MatchAny, "(*)"))
 			COMPLETE_WITH("OPTIONS (", "ENCODING '", "DISTRIBUTED");
-		else if(TailMatches("OPTIONS", "(*)"))
+		else if (TailMatches("OPTIONS", "(*)"))
 			COMPLETE_WITH("ENCODING '", "DISTRIBUTED");
-		else if(TailMatches("ENCODING", "'*'"))
+		else if (TailMatches("ENCODING", "'*'"))
 			COMPLETE_WITH("DISTRIBUTED");
 	}
 
@@ -3027,14 +3027,14 @@ psql_completion(const char *text, int start, int end)
 			 Matches("DROP", "TEXT", "SEARCH", "CONFIGURATION|DICTIONARY|PARSER|TEMPLATE", MatchAny))
 		COMPLETE_WITH("CASCADE", "RESTRICT");
 
-	else if(Matches("DROP", "EXTERNAL"))
+	else if (Matches("DROP", "EXTERNAL"))
 		COMPLETE_WITH("WEB", "TABLE");
-	else if(Matches("DROP", "EXTERNAL", "WEB"))
+	else if (Matches("DROP", "EXTERNAL", "WEB"))
 		COMPLETE_WITH("TABLE");
-	else if(Matches("DROP", "EXTERNAL", "TABLE") ||
-			Matches("DROP", "EXTERNAL", "TABLE", "IF", "EXISTS") ||
-			Matches("DROP", "EXTERNAL", "WEB", "TABLE") ||
-			Matches("DROP", "EXTERNAL", "WEB", "TABLE", "IF", "EXISTS"))
+	else if (Matches("DROP", "EXTERNAL", "TABLE") ||
+			 Matches("DROP", "EXTERNAL", "TABLE", "IF", "EXISTS") ||
+			 Matches("DROP", "EXTERNAL", "WEB", "TABLE") ||
+			 Matches("DROP", "EXTERNAL", "WEB", "TABLE", "IF", "EXISTS"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_external_tables, NULL);
 
 	/* help completing some of the variants */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2399,8 +2399,10 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH("ROWS", "PERCENT");
 
 	/* CREATE [READABLE] EXTERNAL WEB ... */
-	else if(HeadMatches("CREATE", "EXTERNAL", "WEB") ||
-			HeadMatches("CREATE", "READABLE", "EXTERNAL", "WEB"))
+	else if(HeadMatches("CREATE", "EXTERNAL", "WEB", "TABLE") ||
+			HeadMatches("CREATE", "READABLE", "EXTERNAL", "WEB", "TABLE") ||
+			HeadMatches("CREATE", "EXTERNAL", "WEB", "TEMP|TEMPORARY", "TABLE") ||
+			HeadMatches("CREATE", "READABLE", "EXTERNAL", "WEB", "TEMP|TEMPORARY", "TABLE"))
 	{
 		if(TailMatches("TABLE", MatchAny, "(*)"))
 			COMPLETE_WITH_SUPPRESS_APPEND("LOCATION ('", "EXECUTE '");
@@ -2422,8 +2424,10 @@ psql_completion(const char *text, int start, int end)
 	}
 
 	/* CREATE [READABLE] EXTERNAL ... */
-	else if(HeadMatches("CREATE", "EXTERNAL") ||
-			HeadMatches("CREATE", "READABLE", "EXTERNAL"))
+	else if(HeadMatches("CREATE", "EXTERNAL", "TABLE") ||
+			HeadMatches("CREATE", "READABLE", "EXTERNAL", "TABLE") ||
+			HeadMatches("CREATE", "EXTERNAL", "TEMP|TEMPORARY", "TABLE") ||
+			HeadMatches("CREATE", "READABLE", "EXTERNAL", "TEMP|TEMPORARY", "TABLE"))
 	{
 		if(TailMatches("TABLE", MatchAny, "(*)"))
 			COMPLETE_WITH_SUPPRESS_APPEND("LOCATION ('");
@@ -2444,7 +2448,8 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH("BY (", "RANDOMLY");
 
 	/* CREATE WRITABLE EXTERNAL WEB ... */
-	else if(HeadMatches("CREATE", "WRITABLE", "EXTERNAL", "WEB"))
+	else if(HeadMatches("CREATE", "WRITABLE", "EXTERNAL", "WEB", "TABLE") ||
+			HeadMatches("CREATE", "WRITABLE", "EXTERNAL", "WEB", "TEMP|TEMPORARY", "TABLE"))
 	{
 		if(TailMatches("TABLE", MatchAny, "(*)"))
 			COMPLETE_WITH_SUPPRESS_APPEND("EXECUTE '");
@@ -2462,7 +2467,8 @@ psql_completion(const char *text, int start, int end)
 	}
 
 	/* CREATE WRITABLE EXTERNAL ... */
-	else if(HeadMatches("CREATE", "WRITABLE", "EXTERNAL"))
+	else if(HeadMatches("CREATE", "WRITABLE", "EXTERNAL", "TABLE") ||
+			HeadMatches("CREATE", "WRITABLE", "EXTERNAL", "TEMP|TEMPORARY", "TABLE"))
 	{
 		if(TailMatches("TABLE", MatchAny, "(*)"))
 			COMPLETE_WITH_SUPPRESS_APPEND("LOCATION ('");

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2392,7 +2392,13 @@ psql_completion(const char *text, int start, int end)
 	{
 		if(TailMatches("TABLE", MatchAny, "(*)"))
 			COMPLETE_WITH("LOCATION ('", "EXECUTE");
-		else if(TailMatches("LOCATION", "(*)") || TailMatches("EXECUTE", "'*'"))
+		else if(TailMatches("EXECUTE", "'*'"))
+			COMPLETE_WITH("FORMAT", "ON");
+		else if(TailMatches("EXECUTE", "'*'", "ON"))
+			COMPLETE_WITH("ALL", "COORDINATOR", "HOST", "SEGMENT");
+		else if(TailMatches("LOCATION", "(*)") ||
+				TailMatches("EXECUTE", "'*'", "ON", MatchAnyExcept("HOST|SEGMENT")) ||
+				TailMatches("EXECUTE", "'*'", "ON", MatchAny, MatchAnyExcept("FORMAT")))
 			COMPLETE_WITH("FORMAT");
 		else if(TailMatches("FORMAT", MatchAny) ||
 				TailMatches("FORMAT", MatchAny, "(*)"))
@@ -2431,6 +2437,8 @@ psql_completion(const char *text, int start, int end)
 		if(TailMatches("TABLE", MatchAny, "(*)"))
 			COMPLETE_WITH("EXECUTE");
 		else if(TailMatches("EXECUTE", "'*'"))
+			COMPLETE_WITH("FORMAT", "ON ALL");
+		else if(TailMatches("EXECUTE", "'*'", "ON", "ALL"))
 			COMPLETE_WITH("FORMAT");
 		else if(TailMatches("FORMAT", MatchAny) ||
 				TailMatches("FORMAT", MatchAny, "(*)"))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -236,6 +236,18 @@ do { \
 	COMPLETE_WITH_LIST(list); \
 } while (0)
 
+#ifdef HAVE_RL_COMPLETION_APPEND_CHARACTER
+	#define COMPLETE_WITH_SUPPRESS_APPEND(...) \
+	do { \
+		rl_completion_append_character = '\0'; \
+\
+		static const char *const list[] = { __VA_ARGS__, NULL }; \
+		COMPLETE_WITH_LIST(list); \
+	} while (0)
+#else
+	#define COMPLETE_WITH_SUPPRESS_APPEND(...) COMPLETE_WITH(__VA_ARGS__)
+#endif
+
 #define COMPLETE_WITH_CS(...) \
 do { \
 	static const char *const list[] = { __VA_ARGS__, NULL }; \
@@ -1476,6 +1488,7 @@ psql_completion(const char *text, int start, int end)
 
 #ifdef HAVE_RL_COMPLETION_APPEND_CHARACTER
 	rl_completion_append_character = ' ';
+	rl_completion_suppress_append = 0;
 #endif
 
 	/* Clear a few things. */
@@ -2391,7 +2404,7 @@ psql_completion(const char *text, int start, int end)
 			HeadMatches("CREATE", "READABLE", "EXTERNAL", "WEB"))
 	{
 		if(TailMatches("TABLE", MatchAny, "(*)"))
-			COMPLETE_WITH("LOCATION ('", "EXECUTE");
+			COMPLETE_WITH_SUPPRESS_APPEND("LOCATION ('", "EXECUTE '");
 		else if(TailMatches("EXECUTE", "'*'"))
 			COMPLETE_WITH("FORMAT", "ON");
 		else if(TailMatches("EXECUTE", "'*'", "ON"))
@@ -2414,7 +2427,7 @@ psql_completion(const char *text, int start, int end)
 			HeadMatches("CREATE", "READABLE", "EXTERNAL"))
 	{
 		if(TailMatches("TABLE", MatchAny, "(*)"))
-			COMPLETE_WITH("LOCATION ('");
+			COMPLETE_WITH_SUPPRESS_APPEND("LOCATION ('");
 		else if(TailMatches("LOCATION", "(*)"))
 			COMPLETE_WITH("FORMAT");
 		else if(TailMatches("FORMAT", MatchAny) ||
@@ -2435,7 +2448,7 @@ psql_completion(const char *text, int start, int end)
 	else if(HeadMatches("CREATE", "WRITABLE", "EXTERNAL", "WEB"))
 	{
 		if(TailMatches("TABLE", MatchAny, "(*)"))
-			COMPLETE_WITH("EXECUTE");
+			COMPLETE_WITH_SUPPRESS_APPEND("EXECUTE '");
 		else if(TailMatches("EXECUTE", "'*'"))
 			COMPLETE_WITH("FORMAT", "ON ALL");
 		else if(TailMatches("EXECUTE", "'*'", "ON", "ALL"))
@@ -2453,7 +2466,7 @@ psql_completion(const char *text, int start, int end)
 	else if(HeadMatches("CREATE", "WRITABLE", "EXTERNAL"))
 	{
 		if(TailMatches("TABLE", MatchAny, "(*)"))
-			COMPLETE_WITH("LOCATION ('");
+			COMPLETE_WITH_SUPPRESS_APPEND("LOCATION ('");
 		else if(TailMatches("LOCATION", "(*)"))
 			COMPLETE_WITH("FORMAT");
 		else if(TailMatches("FORMAT", MatchAny) ||

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2346,14 +2346,14 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH("EXTERNAL");
 	else if(TailMatches("CREATE", "EXTERNAL") ||
 			TailMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL"))
-		COMPLETE_WITH("WEB", "TEMP", "TABLE");
+		COMPLETE_WITH("WEB", "TEMP", "TEMPORARY", "TABLE");
 	else if(TailMatches("CREATE", "EXTERNAL", "WEB") ||
 			TailMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL", "WEB"))
-		COMPLETE_WITH("TEMP", "TABLE");
-	else if(TailMatches("CREATE", "EXTERNAL", "TEMP") ||
-			TailMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL", "TEMP") ||
-			TailMatches("CREATE", "EXTERNAL", "WEB", "TEMP") ||
-			TailMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL", "WEB", "TEMP"))
+		COMPLETE_WITH("TEMP", "TEMPORARY", "TABLE");
+	else if(TailMatches("CREATE", "EXTERNAL", "TEMP|TEMPORARY") ||
+			TailMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL", "TEMP|TEMPORARY") ||
+			TailMatches("CREATE", "EXTERNAL", "WEB", "TEMP|TEMPORARY") ||
+			TailMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL", "WEB", "TEMP|TEMPORARY"))
 		COMPLETE_WITH("TABLE");
 
 	/* CREATE ... EXTERNAL ... TABLE */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1022,7 +1022,7 @@ static const pgsql_thing_t words_after_create[] = {
 	{"POLICY", NULL, NULL, NULL},
 	{"PROCEDURE", NULL, NULL, Query_for_list_of_procedures},
 	{"PUBLICATION", NULL, Query_for_list_of_publications},
-	{"READABLE", NULL, NULL, NULL, THING_NO_ALTER}, /* for CREATE READABLE EXTERNAL .. TABLE */
+	{"READABLE", NULL, NULL, NULL, THING_NO_ALTER | THING_NO_DROP}, /* for CREATE READABLE EXTERNAL .. TABLE */
 	{"RESOURCE", NULL},
 	{"ROLE", Query_for_list_of_roles},
 	{"ROUTINE", NULL, NULL, &Query_for_list_of_routines, THING_NO_CREATE},
@@ -1051,7 +1051,7 @@ static const pgsql_thing_t words_after_create[] = {
 	{"USER", Query_for_list_of_roles " UNION SELECT 'MAPPING FOR'"},
 	{"USER MAPPING FOR", NULL, NULL, NULL},
 	{"VIEW", NULL, NULL, &Query_for_list_of_views},
-	{"WRITABLE", NULL, NULL, NULL, THING_NO_ALTER}, /* for CREATE WRITABLE EXTERNAL .. TABLE */
+	{"WRITABLE", NULL, NULL, NULL, THING_NO_ALTER | THING_NO_DROP}, /* for CREATE WRITABLE EXTERNAL .. TABLE */
 	{NULL}						/* end of list */
 };
 

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2322,13 +2322,106 @@ psql_completion(const char *text, int start, int end)
 			TailMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL", "WEB", "TEMP"))
 		COMPLETE_WITH("TABLE");
 
+	/* CREATE ... EXTERNAL ... TABLE */
+	else if((HeadMatches("CREATE", "EXTERNAL") ||
+			HeadMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL")) &&
+			TailMatches("TABLE"))
+		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_tables, NULL);
+	/* CREATE ... EXTERNAL ... TABLE ... */
+	else if((HeadMatches("CREATE", "EXTERNAL") ||
+			HeadMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL")) &&
+			TailMatches("TABLE", MatchAny))
+		COMPLETE_WITH("(");
+	/* CREATE ... EXTERNAL ... FORMAT */
+	else if((HeadMatches("CREATE", "EXTERNAL") ||
+			HeadMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL")) &&
+			TailMatches("FORMAT"))
+		COMPLETE_WITH("'TEXT'", "'CSV'", "'CUSTOM'");
 
-	/* Distribution rules for CREATE WRITABLE EXTERNAL tables, 
-	beacause they interfere with CREATE TABLE distribution rules 
-	(REPLICATED is not allowed) */
+	/* CREATE [READABLE] EXTERNAL ... LOG ERRORS */
+	else if((HeadMatches("CREATE", "EXTERNAL") ||
+			HeadMatches("CREATE", "READABLE", "EXTERNAL")) &&
+			TailMatches("LOG", "ERRORS"))
+		COMPLETE_WITH("PERSISTENTLY", "SEGMENT REJECT LIMIT");
+	else if((HeadMatches("CREATE", "EXTERNAL") ||
+			HeadMatches("CREATE", "READABLE", "EXTERNAL")) &&
+			TailMatches("PERSISTENTLY"))
+		COMPLETE_WITH("SEGMENT REJECT LIMIT");
+	else if((HeadMatches("CREATE", "EXTERNAL") ||
+			HeadMatches("CREATE", "READABLE", "EXTERNAL")) &&
+			TailMatches("SEGMENT", "REJECT", "LIMIT", MatchAny))
+		COMPLETE_WITH("ROWS", "PERCENT");
+
+	/* CREATE [READABLE] EXTERNAL WEB ... */
+	else if(HeadMatches("CREATE", "EXTERNAL", "WEB") ||
+			HeadMatches("CREATE", "READABLE", "EXTERNAL", "WEB"))
+	{
+		if(TailMatches("TABLE", MatchAny, "(*)"))
+			COMPLETE_WITH("LOCATION ('", "EXECUTE");
+		else if(TailMatches("LOCATION", "(*)") || TailMatches("EXECUTE", "'*'"))
+			COMPLETE_WITH("FORMAT");
+		else if(TailMatches("FORMAT", MatchAny) ||
+				TailMatches("FORMAT", MatchAny, "(*)"))
+			COMPLETE_WITH("OPTIONS (", "ENCODING '", "LOG ERRORS", "SEGMENT REJECT LIMIT");
+		else if(TailMatches("OPTIONS", "(*)"))
+			COMPLETE_WITH("ENCODING '", "LOG ERRORS", "SEGMENT REJECT LIMIT");
+		else if(TailMatches("ENCODING", "'*'"))
+			COMPLETE_WITH("LOG ERRORS", "SEGMENT REJECT LIMIT");
+	}
+
+	/* CREATE [READABLE] EXTERNAL ... */
+	else if(HeadMatches("CREATE", "EXTERNAL") ||
+			HeadMatches("CREATE", "READABLE", "EXTERNAL"))
+	{
+		if(TailMatches("TABLE", MatchAny, "(*)"))
+			COMPLETE_WITH("LOCATION ('");
+		else if(TailMatches("LOCATION", "(*)"))
+			COMPLETE_WITH("FORMAT");
+		else if(TailMatches("FORMAT", MatchAny) ||
+				TailMatches("FORMAT", MatchAny, "(*)"))
+			COMPLETE_WITH("OPTIONS (", "ENCODING '", "LOG ERRORS", "SEGMENT REJECT LIMIT");
+		else if(TailMatches("OPTIONS", "(*)"))
+			COMPLETE_WITH("ENCODING '", "LOG ERRORS", "SEGMENT REJECT LIMIT");
+		else if(TailMatches("ENCODING", "'*'"))
+			COMPLETE_WITH("LOG ERRORS", "SEGMENT REJECT LIMIT");
+	}
+
+	/* CREATE WRITABLE EXTERNAL ... DISTRIBUTED */
 	else if (HeadMatches("CREATE", "WRITABLE", "EXTERNAL") &&
 		TailMatches("DISTRIBUTED"))
 		COMPLETE_WITH("BY (", "RANDOMLY");
+
+	/* CREATE WRITABLE EXTERNAL WEB ... */
+	else if(HeadMatches("CREATE", "WRITABLE", "EXTERNAL", "WEB"))
+	{
+		if(TailMatches("TABLE", MatchAny, "(*)"))
+			COMPLETE_WITH("EXECUTE");
+		else if(TailMatches("EXECUTE", "'*'"))
+			COMPLETE_WITH("FORMAT");
+		else if(TailMatches("FORMAT", MatchAny) ||
+				TailMatches("FORMAT", MatchAny, "(*)"))
+			COMPLETE_WITH("OPTIONS (", "ENCODING '", "DISTRIBUTED");
+		else if(TailMatches("OPTIONS", "(*)"))
+			COMPLETE_WITH("ENCODING '", "DISTRIBUTED");
+		else if(TailMatches("ENCODING", "'*'"))
+			COMPLETE_WITH("DISTRIBUTED");
+	}
+
+	/* CREATE WRITABLE EXTERNAL ... */
+	else if(HeadMatches("CREATE", "WRITABLE", "EXTERNAL"))
+	{
+		if(TailMatches("TABLE", MatchAny, "(*)"))
+			COMPLETE_WITH("LOCATION ('");
+		else if(TailMatches("LOCATION", "(*)"))
+			COMPLETE_WITH("FORMAT");
+		else if(TailMatches("FORMAT", MatchAny) ||
+				TailMatches("FORMAT", MatchAny, "(*)"))
+			COMPLETE_WITH("OPTIONS (", "ENCODING '", "DISTRIBUTED");
+		else if(TailMatches("OPTIONS", "(*)"))
+			COMPLETE_WITH("ENCODING '", "DISTRIBUTED");
+		else if(TailMatches("ENCODING", "'*'"))
+			COMPLETE_WITH("DISTRIBUTED");
+	}
 
 	/* CREATE FOREIGN */
 	else if (Matches("CREATE", "FOREIGN"))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -3014,7 +3014,9 @@ psql_completion(const char *text, int start, int end)
 	else if(Matches("DROP", "EXTERNAL", "WEB"))
 		COMPLETE_WITH("TABLE");
 	else if(Matches("DROP", "EXTERNAL", "TABLE") ||
-			Matches("DROP", "EXTERNAL", "WEB", "TABLE"))
+			Matches("DROP", "EXTERNAL", "TABLE", "IF", "EXISTS") ||
+			Matches("DROP", "EXTERNAL", "WEB", "TABLE") ||
+			Matches("DROP", "EXTERNAL", "WEB", "TABLE", "IF", "EXISTS"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_external_tables, NULL);
 
 	/* help completing some of the variants */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -428,6 +428,14 @@ static const SchemaQuery Query_for_list_of_foreign_tables = {
 	.result = "pg_catalog.quote_ident(c.relname)",
 };
 
+static const SchemaQuery Query_for_list_of_external_tables = {
+	.catname = "pg_catalog.pg_class c, pg_catalog.pg_exttable e",
+	.selcondition = "c.oid = e.reloid",
+	.viscondition = "pg_catalog.pg_table_is_visible(c.oid)",
+	.namespace = "c.relnamespace",
+	.result = "pg_catalog.quote_ident(c.relname)",
+};
+
 static const SchemaQuery Query_for_list_of_tables = {
 	.catname = "pg_catalog.pg_class c",
 	.selcondition =
@@ -2326,7 +2334,7 @@ psql_completion(const char *text, int start, int end)
 	else if((HeadMatches("CREATE", "EXTERNAL") ||
 			HeadMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL")) &&
 			TailMatches("TABLE"))
-		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_tables, NULL);
+		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_external_tables, NULL);
 	/* CREATE ... EXTERNAL ... TABLE ... */
 	else if((HeadMatches("CREATE", "EXTERNAL") ||
 			HeadMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL")) &&

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2868,9 +2868,16 @@ psql_completion(const char *text, int start, int end)
 			  ends_with(prev_wd, ')')) ||
 			 Matches("DROP", "EVENT", "TRIGGER", MatchAny) ||
 			 Matches("DROP", "FOREIGN", "DATA", "WRAPPER", MatchAny) ||
+			 Matches("DROP", "EXTERNAL", "TABLE", MatchAny) ||
+			 Matches("DROP", "EXTERNAL", "WEB", "TABLE", MatchAny) ||
 			 Matches("DROP", "FOREIGN", "TABLE", MatchAny) ||
 			 Matches("DROP", "TEXT", "SEARCH", "CONFIGURATION|DICTIONARY|PARSER|TEMPLATE", MatchAny))
 		COMPLETE_WITH("CASCADE", "RESTRICT");
+
+	else if(Matches("DROP", "EXTERNAL"))
+		COMPLETE_WITH("WEB", "TABLE");
+	else if(Matches("DROP", "EXTERNAL", "WEB"))
+		COMPLETE_WITH("TABLE");
 
 	/* help completing some of the variants */
 	else if (Matches("DROP", "AGGREGATE|FUNCTION|PROCEDURE|ROUTINE", MatchAny))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1007,6 +1007,7 @@ static const pgsql_thing_t words_after_create[] = {
 	{"EVENT TRIGGER", NULL, NULL, NULL},
 	{"EXTENSION", Query_for_list_of_extensions},
 	{"EXTERNAL TABLE", NULL, NULL, NULL},
+	{"EXTERNAL WEB TABLE", NULL, NULL, NULL},
 	{"FOREIGN DATA WRAPPER", NULL, NULL, NULL},
 	{"FOREIGN TABLE", NULL, NULL, NULL},
 	{"FUNCTION", NULL, NULL, Query_for_list_of_functions},
@@ -2304,6 +2305,9 @@ psql_completion(const char *text, int start, int end)
 		completion_info_charp = prev2_wd;
 		COMPLETE_WITH_QUERY(Query_for_list_of_available_extension_versions);
 	}
+
+	else if(HeadMatches("ALTER|CREATE|DROP", "EXTERNAL"))
+		COMPLETE_WITH("WEB TABLE", "TABLE");
 
 	/* Distribution rules for CREATE WRITABLE EXTERNAL tables, 
 	beacause they interfere with CREATE TABLE distribution rules 

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1006,8 +1006,7 @@ static const pgsql_thing_t words_after_create[] = {
 	{"DOMAIN", NULL, NULL, &Query_for_list_of_domains},
 	{"EVENT TRIGGER", NULL, NULL, NULL},
 	{"EXTENSION", Query_for_list_of_extensions},
-	{"EXTERNAL TABLE", NULL, NULL, NULL},
-	{"EXTERNAL WEB TABLE", NULL, NULL, NULL},
+	{"EXTERNAL", NULL, NULL, NULL}, /* for ALTER|CREATE|DROP EXTERNAL ... TABLE */
 	{"FOREIGN DATA WRAPPER", NULL, NULL, NULL},
 	{"FOREIGN TABLE", NULL, NULL, NULL},
 	{"FUNCTION", NULL, NULL, Query_for_list_of_functions},
@@ -1023,6 +1022,7 @@ static const pgsql_thing_t words_after_create[] = {
 	{"POLICY", NULL, NULL, NULL},
 	{"PROCEDURE", NULL, NULL, Query_for_list_of_procedures},
 	{"PUBLICATION", NULL, Query_for_list_of_publications},
+	{"READABLE", NULL, NULL, NULL, THING_NO_ALTER}, /* for CREATE READABLE EXTERNAL .. TABLE */
 	{"RESOURCE", NULL},
 	{"ROLE", Query_for_list_of_roles},
 	{"ROUTINE", NULL, NULL, &Query_for_list_of_routines, THING_NO_CREATE},
@@ -1051,6 +1051,7 @@ static const pgsql_thing_t words_after_create[] = {
 	{"USER", Query_for_list_of_roles " UNION SELECT 'MAPPING FOR'"},
 	{"USER MAPPING FOR", NULL, NULL, NULL},
 	{"VIEW", NULL, NULL, &Query_for_list_of_views},
+	{"WRITABLE", NULL, NULL, NULL, THING_NO_ALTER}, /* for CREATE WRITABLE EXTERNAL .. TABLE */
 	{NULL}						/* end of list */
 };
 
@@ -2306,8 +2307,21 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH_QUERY(Query_for_list_of_available_extension_versions);
 	}
 
-	else if(HeadMatches("ALTER|CREATE|DROP", "EXTERNAL"))
-		COMPLETE_WITH("WEB TABLE", "TABLE");
+	/* CREATE ... EXTERNAL ... TABLE */
+	else if(TailMatches("CREATE", "READABLE|WRITABLE"))
+		COMPLETE_WITH("EXTERNAL");
+	else if(TailMatches("CREATE", "EXTERNAL") ||
+			TailMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL"))
+		COMPLETE_WITH("WEB", "TEMP", "TABLE");
+	else if(TailMatches("CREATE", "EXTERNAL", "WEB") ||
+			TailMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL", "WEB"))
+		COMPLETE_WITH("TEMP", "TABLE");
+	else if(TailMatches("CREATE", "EXTERNAL", "TEMP") ||
+			TailMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL", "TEMP") ||
+			TailMatches("CREATE", "EXTERNAL", "WEB", "TEMP") ||
+			TailMatches("CREATE", "READABLE|WRITABLE", "EXTERNAL", "WEB", "TEMP"))
+		COMPLETE_WITH("TABLE");
+
 
 	/* Distribution rules for CREATE WRITABLE EXTERNAL tables, 
 	beacause they interfere with CREATE TABLE distribution rules 

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1644,6 +1644,32 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH_QUERY(Query_for_list_of_available_extension_versions);
 	}
 
+	/* ALTER EXTERNAL TABLE */
+	else if(Matches("ALTER", "EXTERNAL"))
+		COMPLETE_WITH("TABLE");
+	else if(Matches("ALTER", "EXTERNAL", "TABLE"))
+		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_external_tables, NULL);
+	else if(Matches("ALTER", "EXTERNAL", "TABLE", MatchAny))
+		COMPLETE_WITH("ADD", "DROP", "ALTER", "OWNER TO");
+	else if(Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "ADD"))
+		COMPLETE_WITH("COLUMN");
+
+	/* ALTER EXTERNAL TABLE <name> ALTER|DROP */
+	else if(Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "ALTER|DROP"))
+		COMPLETE_WITH_ATTR(prev2_wd, " UNION SELECT 'COLUMN'");
+	else if(Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "ALTER|DROP", "COLUMN"))
+		COMPLETE_WITH_ATTR(prev3_wd, "");
+
+	/* ALTER EXTERNAL TABLE <name> ALTER <colname> TYPE */
+	else if(Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "ALTER", MatchAny) ||
+			Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "ALTER", "COLUMN", MatchAny))
+		COMPLETE_WITH("TYPE");
+
+	/* ALTER EXTERNAL TABLE <name> DROP <colname> */
+	else if(Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "DROP", MatchAny) ||
+			Matches("ALTER", "EXTERNAL", "TABLE", MatchAny, "DROP", "COLUMN", MatchAny))
+		COMPLETE_WITH("RESTRICT", "CASCADE");
+
 	/* ALTER FOREIGN */
 	else if (Matches("ALTER", "FOREIGN"))
 		COMPLETE_WITH("DATA WRAPPER", "TABLE");

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1488,7 +1488,6 @@ psql_completion(const char *text, int start, int end)
 
 #ifdef HAVE_RL_COMPLETION_APPEND_CHARACTER
 	rl_completion_append_character = ' ';
-	rl_completion_suppress_append = 0;
 #endif
 
 	/* Clear a few things. */


### PR DESCRIPTION
Some commands for EXTERNAL TABLE lacked autocomplete support in psql.

Add query to get list of external tables.
Add EXTERNAL/WRITABLE/READABLE keywords autocomplete.
Add options autocomplete for CREATE EXTERNAL TABLE.
Add autocomplete for ALTER EXTERNAL TABLE.
Add autocomplete for DROP EXTERNAL TABLE.

Also, add macro to suppress printing separation character in special cases.