### PR TITLE
GG-543: Check for missing support function for partitions before upgrade

### DIFF
--- a/src/bin/pg_upgrade/greengage/check_gp.c
+++ b/src/bin/pg_upgrade/greengage/check_gp.c
@@ -17,6 +17,7 @@
 #include "pg_upgrade_greengage.h"
 #include "catalog/pg_magic_oid.h"
 #include "catalog/pg_class_d.h"
+#include "access/nbtree.h"
 
 #define RELSTORAGE_EXTERNAL	'x'
 
@@ -34,6 +35,7 @@ static void check_views_with_removed_types(void);
 static void check_for_disallowed_pg_operator(void);
 static void check_views_with_changed_function_signatures(void);
 static void check_execute_on_master_functions(void);
+static void check_for_missing_support_function_for_partitions(void);
 
 /*
  *	check_greengage
@@ -60,6 +62,7 @@ check_greengage(void)
 	check_for_disallowed_pg_operator();
 	check_views_with_changed_function_signatures();
 	check_execute_on_master_functions();
+	check_for_missing_support_function_for_partitions();
 }
 
 /*
@@ -1339,6 +1342,107 @@ check_execute_on_master_functions()
 			"| Starting from Greengage 7, such functions should always\n"
 			"| return SETOF rows.\n"
 			"| A list of the problem functions is in the file:\n\t%s\n\n", output_path);
+	}
+
+	check_ok();
+}
+
+static void
+check_for_missing_support_function_for_partitions()
+{
+	if (GET_MAJOR_VERSION(old_cluster.major_version) > 904)
+		return;
+
+	char  output_path[MAXPGPATH];
+	FILE *script = NULL;
+	bool  found = false;
+
+	prep_status("Checking for missing support function for partitions");
+
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir, "parititons_with_missing_support_function.txt");
+
+	for (int dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
+	{
+		PGresult *res;
+		int		  ntups;
+		int		  rowno;
+		DbInfo	 *active_db = &old_cluster.dbarr.dbs[dbnum];
+		PGconn	 *conn;
+		int		  i_relname;
+		int		  i_opcname;
+		int		  i_opfname;
+
+		conn = connectToServer(&old_cluster, active_db->db_name);
+
+		/* track_counts is disables for the same reason as above */
+		PQclear(executeQueryOrDie(conn, "SET track_counts TO off;"));
+		res = executeQueryOrDie(conn,
+								"SELECT rel.relname, opc.opcname, opf.opfname"
+								"	FROM pg_partition par"
+								"	JOIN pg_class     rel ON par.parrelid = rel.oid"
+								"	JOIN pg_opclass   opc ON opc.oid = ANY(par.parclass)"
+								"	JOIN pg_opfamily  opf ON opc.opcfamily = opf.oid"
+								"	WHERE par.oid >= %d AND NOT EXISTS ("
+								"		SELECT 1 FROM pg_amproc amproc"
+								"		WHERE amproc.amprocnum = %d"
+								"		AND amproc.amprocfamily = opf.oid"
+								"		AND amproc.amproclefttype = opc.opcintype"
+								"		AND amproc.amprocrighttype = opc.opcintype);",
+								FirstNormalObjectId, BTORDER_PROC);
+		PQclear(executeQueryOrDie(conn, "RESET track_counts;"));
+
+		ntups = PQntuples(res);
+		if (ntups == 0)
+		{
+			PQclear(res);
+			PQfinish(conn);
+			continue;
+		}
+		found = true;
+
+		if (!script)
+		{
+			/*
+			 * This is the first database that has affected functions,
+			 * try to open the output file
+			 */
+			script = fopen(output_path, "w");
+			if (!script)
+				pg_fatal("could not open file \"%s\": %s\n",
+					output_path, strerror(errno));
+		}
+
+		fprintf(script, "Database: %s\n", active_db->db_name);
+
+		i_relname = PQfnumber(res, "relname");
+		i_opcname = PQfnumber(res, "opcname");
+		i_opfname = PQfnumber(res, "opfname");
+		for (rowno = 0; rowno < ntups; rowno++)
+		{
+			fprintf(script, "Partitioned table: %s, opclass: %s, opfamily: %s\n",
+					PQgetvalue(res, rowno, i_relname),
+					PQgetvalue(res, rowno, i_opcname),
+					PQgetvalue(res, rowno, i_opfname));
+		}
+
+		PQclear(res);
+		PQfinish(conn);
+	}
+
+	if (script)
+		fclose(script);
+
+	if (found)
+	{
+		pg_log(PG_REPORT, "fatal\n");
+		gp_fatal_log(
+			"| Your installation contains tables partitioned by\n"
+			"| types without required support routines.\n"
+			"| Starting from Greengage 7, each type specified in\n"
+			"| PARTITION BY LIST clause should define support\n"
+			"| routine number 1 in its opfamily.\n"
+			"| A list of the problem objects is in the file:\n\t%s\n\n", output_path);
 	}
 
 	check_ok();


### PR DESCRIPTION
Starting from Greengage 7, each type specified in 
PARTITION BY LIST clause should define support
routine number 1 in its opfamily.

Check for such cases before performing upgrade.

This patch is done as a part of fixing cross-version
pg_upgrade test errors.