### PR TITLE
Fix ggrebalance tool for Python 3.7

### DIFF
--- a/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/ggrebalance_modules/rebalance_schema.py
@@ -562,35 +562,32 @@ AS total_duration FROM cte_total""")
                                 f"SELECT stat_name, stat_value FROM {self.schema_name}.{self.rebalance_progress_view}")
             if not result.is_rollback:
                 for stat_name, stat_value in cursor:
-                    match stat_name:
-                        case self.STAT_NAME_1_1_TABLES_SHRUNK:
-                            result.tables_shrunk = stat_value
-                        case self.STAT_NAME_2_1_BYTES_PROCESSED:
-                            result.bytes_processed = stat_value
-                        case self.STAT_NAME_3_1_ESTIMATED_SHRINK_RATE:
-                            result.shrink_rate = stat_value
+                    if stat_name == self.STAT_NAME_1_1_TABLES_SHRUNK:
+                        result.tables_shrunk = stat_value
+                    elif stat_name == self.STAT_NAME_2_1_BYTES_PROCESSED:
+                        result.bytes_processed = stat_value
+                    elif stat_name == self.STAT_NAME_3_1_ESTIMATED_SHRINK_RATE:
+                        result.shrink_rate = stat_value
 
                 result.shrink_total_time = self.getShrinkTotalTime()
             else:
                 for stat_name, stat_value in cursor:
-                    match stat_name:
-                        case self.STAT_NAME_1_1_TABLES_ROLLED_BACK:
-                            result.tables_rolled_back = stat_value
-                        case self.STAT_NAME_2_1_BYTES_PROCESSED:
-                            result.bytes_processed = stat_value
-                        case self.STAT_NAME_3_1_ESTIMATED_SHRINK_RATE:
-                            result.rollback_rate = stat_value
+                    if stat_name == self.STAT_NAME_1_1_TABLES_ROLLED_BACK:
+                        result.tables_rolled_back = stat_value
+                    elif stat_name == self.STAT_NAME_2_1_BYTES_PROCESSED:
+                        result.bytes_processed = stat_value
+                    elif stat_name == self.STAT_NAME_3_1_ESTIMATED_SHRINK_RATE:
+                        result.rollback_rate = stat_value
 
                 cursor = dbconn.query(self.conn,
                                 f"SELECT stat_name, stat_value FROM {self.schema_name}.{self.rebalance_progress_view_history}")
                 for stat_name, stat_value in cursor:
-                    match stat_name:
-                        case self.STAT_NAME_1_1_TABLES_SHRUNK:
-                            result.tables_shrunk = stat_value
-                        case self.STAT_NAME_3_1_ESTIMATED_SHRINK_RATE:
-                            result.shrink_rate = stat_value
-                        case self.STAT_NAME_SHRINK_TOTAL_TIME:
-                            result.shrink_total_time = stat_value
+                    if stat_name == self.STAT_NAME_1_1_TABLES_SHRUNK:
+                        result.tables_shrunk = stat_value
+                    elif stat_name == self.STAT_NAME_3_1_ESTIMATED_SHRINK_RATE:
+                        result.shrink_rate = stat_value
+                    elif stat_name == self.STAT_NAME_SHRINK_TOTAL_TIME:
+                        result.shrink_total_time = stat_value
 
                 result.rollback_total_time = self.getShrinkTotalTime(is_rollback = True)
 

--- a/gpMgmt/bin/ggrebalance_modules/solver.py
+++ b/gpMgmt/bin/ggrebalance_modules/solver.py
@@ -92,8 +92,8 @@ class GreedySolver:
                 raise ValueError("Cannot follow spread mirroring strategy")
         
         # Best known solution
-        self.best_primary_mapping: List[HostId] | None = None
-        self.best_mirror_mapping: List[HostId] | None = None
+        self.best_primary_mapping: Union[List[HostId], None] = None
+        self.best_mirror_mapping: Union[List[HostId], None] = None
         self.best_cost = None
 
     def solve(self) -> Tuple[Solution, Cost]:
@@ -320,7 +320,7 @@ class GreedySolver:
         group_size = len(segs)
         assigned_p_hosts = set(phost_to_mhost.keys())
 
-        best_mirror_host: HostId | None = None
+        best_mirror_host: Union[HostId, None] = None
 
         # Priority 1: Most used original mirror host (if has capacity)
         if mirror_uses:


### PR DESCRIPTION
Fix ggrebalance tool for Python 3.7

Problem description:
ggrebalance tool failed to work on systems with Python3 version less than 3.10,
while we need to support Python3 versions starting from 3.7.3.

Root cause:
ggrebalance tool used 'match/case' construction, which appeared only starting
from Python version 3.10.

Fix:
Refactor code to use 'if/elif' instead of 'match/case'.
Plus, variable declarations with a type hint and an initial value (which are
also not supported in 3.7 version) are reworked to use 'Union'.