### PR TITLE
GG-519: Improve autocomplete for CREATE FUNCTION

### DIFF
--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2538,14 +2538,16 @@ psql_completion(const char *text, int start, int end)
 			COMPLETE_WITH("DISTRIBUTED");
 	}
 
-	else if(Matches("CREATE", "FUNCTION", MatchAny))
+	else if (Matches("CREATE", "FUNCTION", MatchAny))
 		COMPLETE_WITH("(");
-	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)"))
+	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)"))
 		COMPLETE_WITH("RETURNS");
-	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS"))
+	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_datatypes,
 								   " UNION SELECT 'TABLE ('");
-	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny) ||
+	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE"))
+		COMPLETE_WITH("(");
+	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAnyExcept("TABLE")) ||
 			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)"))
 		COMPLETE_WITH("AS", "LANGUAGE", "TRANSFORM FOR TYPE", "WINDOW",
 					  "IMMUTABLE", "STABLE", "VOLATILE", "NOT LEAKPROOF",
@@ -2556,20 +2558,20 @@ psql_completion(const char *text, int start, int end)
 
 	/* Completing individual options */
 	/* They're this big to avoid false completions by function code */
-	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "TRANSFORM", "FOR", "TYPE") ||
+	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "TRANSFORM", "FOR", "TYPE") ||
 			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "TRANSFORM", "FOR", "TYPE"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_datatypes, NULL);
-	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "PARALLEL") ||
+	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "PARALLEL") ||
 			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "PARALLEL"))
 		COMPLETE_WITH("UNSAFE", "RESTRICTED", "SAFE");
 	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "EXECUTE", "ON") ||
 			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "EXECUTE", "ON"))
 		COMPLETE_WITH("ANY", "COORDINATOR", "ALL SEGMENTS", "INITPLAN");
-	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "LANGUAGE") ||
+	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "LANGUAGE") ||
 			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "LANGUAGE"))
 		COMPLETE_WITH_QUERY(Query_for_list_of_languages
 							" UNION SELECT 'internal'");
-	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "SECURITY") ||
+	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "SECURITY") ||
 			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "SECURITY") ||
 			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "EXTERNAL", "SECURITY") ||
 			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "EXTERNAL", "SECURITY"))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2312,6 +2312,38 @@ psql_completion(const char *text, int start, int end)
 		TailMatches("DISTRIBUTED"))
 		COMPLETE_WITH("BY (", "RANDOMLY");
 
+	else if(Matches("CREATE", "FUNCTION", MatchAny))
+		COMPLETE_WITH("(");
+	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)"))
+		COMPLETE_WITH("RETURNS", "RETURNS TABLE (");
+	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS"))
+		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_datatypes,
+								   " UNION SELECT 'TABLE ('");
+	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny) ||
+			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)"))
+		COMPLETE_WITH("AS", "LANGUAGE", "TRANSFORM", "WINDOW", "IMMUTABLE",
+					  "STABLE", "VOLATILE", "NOT LEAKPROOF", "LEAKPROOF",
+					  "CALLED ON NULL INPUT", "RETURNS NULL ON NULL INPUT",
+					  "STRICT", "EXTERNAL", "SECURITY INVOKER",
+					  "SECURITY DEFINER", "EXECUTE ON", "PARALLEL",
+					  "COST", "ROWS", "SUPPORT", "SET", "WITH");
+
+	else if(HeadMatches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny) ||
+			HeadMatches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)"))
+	{
+		if(TailMatches("EXTERNAL"))
+			COMPLETE_WITH("SECURITY INVOKER", "SECURITY DEFINER");
+		else if(TailMatches("SECURITY"))
+			COMPLETE_WITH("INVOKER", "DEFINER");
+		else if(TailMatches("EXECUTE", "ON"))
+			COMPLETE_WITH("ANY", "COORDINATOR", "ALL SEGMENTS", "INITPLAN");
+		else if(TailMatches("PARALLEL"))
+			COMPLETE_WITH("UNSAFE", "RESTRICTED", "SAFE");
+		else if(TailMatches("LANGUAGE"))
+			COMPLETE_WITH("C", "SQL", "INTERNAL");
+	}
+
+
 	/* CREATE FOREIGN */
 	else if (Matches("CREATE", "FOREIGN"))
 		COMPLETE_WITH("DATA WRAPPER", "TABLE");

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2325,7 +2325,7 @@ psql_completion(const char *text, int start, int end)
 					  "STABLE", "VOLATILE", "NOT LEAKPROOF", "LEAKPROOF",
 					  "CALLED ON NULL INPUT", "RETURNS NULL ON NULL INPUT",
 					  "STRICT", "EXTERNAL", "SECURITY", "EXECUTE ON",
-					  "PARALLEL", "COST", "ROWS", "SUPPORT", "SET", "WITH");
+					  "PARALLEL", "COST", "ROWS", "SUPPORT", "SET", "WITH (");
 
 	else if(HeadMatches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny) ||
 			HeadMatches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)"))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2357,31 +2357,33 @@ psql_completion(const char *text, int start, int end)
 								   " UNION SELECT 'TABLE ('");
 	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny) ||
 			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)"))
-		COMPLETE_WITH("AS", "LANGUAGE", "TRANSFORM", "WINDOW", "IMMUTABLE",
-					  "STABLE", "VOLATILE", "NOT LEAKPROOF", "LEAKPROOF",
-					  "CALLED ON NULL INPUT", "RETURNS NULL ON NULL INPUT",
-					  "STRICT", "EXTERNAL", "SECURITY", "EXECUTE ON",
-					  "PARALLEL", "COST", "ROWS", "SUPPORT", "SET", "WITH (");
+		COMPLETE_WITH("AS", "LANGUAGE", "TRANSFORM FOR TYPE", "WINDOW",
+					  "IMMUTABLE", "STABLE", "VOLATILE", "NOT LEAKPROOF",
+					  "LEAKPROOF", "CALLED ON NULL INPUT",
+					  "RETURNS NULL ON NULL INPUT", "STRICT",
+					  "EXTERNAL SECURITY", "SECURITY", "EXECUTE ON", "PARALLEL",
+					  "COST", "ROWS", "SUPPORT", "SET", "WITH (DESCRIBE =");
 
-	else if(HeadMatches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny) ||
-			HeadMatches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)"))
-	{
-		if(TailMatches("EXTERNAL"))
-			COMPLETE_WITH("SECURITY");
-		else if(TailMatches("SECURITY"))
-			COMPLETE_WITH("INVOKER", "DEFINER");
-		else if(TailMatches("TRANSFORM"))
-			COMPLETE_WITH("FOR TYPE");
-		else if(TailMatches("FOR", "TYPE"))
-			COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_datatypes, NULL);
-		else if(TailMatches("EXECUTE", "ON"))
-			COMPLETE_WITH("ANY", "COORDINATOR", "ALL SEGMENTS", "INITPLAN");
-		else if(TailMatches("PARALLEL"))
-			COMPLETE_WITH("UNSAFE", "RESTRICTED", "SAFE");
-		else if(TailMatches("LANGUAGE"))
-			COMPLETE_WITH_QUERY(Query_for_list_of_languages
-								" UNION SELECT 'internal'");
-	}
+	/* Completing individual options */
+	/* They're this big to avoid false completions by function code */
+	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "TRANSFORM", "FOR", "TYPE") ||
+			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "TRANSFORM", "FOR", "TYPE"))
+		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_datatypes, NULL);
+	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "PARALLEL") ||
+			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "PARALLEL"))
+		COMPLETE_WITH("UNSAFE", "RESTRICTED", "SAFE");
+	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "EXECUTE", "ON") ||
+			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "EXECUTE", "ON"))
+		COMPLETE_WITH("ANY", "COORDINATOR", "ALL SEGMENTS", "INITPLAN");
+	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "LANGUAGE") ||
+			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "LANGUAGE"))
+		COMPLETE_WITH_QUERY(Query_for_list_of_languages
+							" UNION SELECT 'internal'");
+	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "SECURITY") ||
+			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "SECURITY") ||
+			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "EXTERNAL", "SECURITY") ||
+			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "EXTERNAL", "SECURITY"))
+		COMPLETE_WITH("INVOKER", "DEFINER");
 
 
 	/* CREATE FOREIGN */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2539,8 +2539,14 @@ psql_completion(const char *text, int start, int end)
 			COMPLETE_WITH("DISTRIBUTED");
 	}
 
+	/* CREATE OR REPLACE ... */
+	else if (Matches("CREATE", "OR"))
+		COMPLETE_WITH("REPLACE");
 	else if (Matches("CREATE", "OR", "REPLACE"))
-		COMPLETE_WITH("FUNCTION");
+		COMPLETE_WITH("FUNCTION", "AGGREGATE", "LANGUAGE", "PROCEDURE", "RULE",
+					  "TRANSFORM FOR", "VIEW");
+
+	/* CREATE FUNCTION ... */
 	else if (Matches("CREATE", "FUNCTION", MatchAny) ||
 			 Matches("CREATE", "OR", "REPLACE", "FUNCTION", MatchAny))
 		COMPLETE_WITH("(");

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2315,7 +2315,7 @@ psql_completion(const char *text, int start, int end)
 	else if(Matches("CREATE", "FUNCTION", MatchAny))
 		COMPLETE_WITH("(");
 	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)"))
-		COMPLETE_WITH("RETURNS", "RETURNS TABLE (");
+		COMPLETE_WITH("RETURNS");
 	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_datatypes,
 								   " UNION SELECT 'TABLE ('");
@@ -2324,23 +2324,27 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH("AS", "LANGUAGE", "TRANSFORM", "WINDOW", "IMMUTABLE",
 					  "STABLE", "VOLATILE", "NOT LEAKPROOF", "LEAKPROOF",
 					  "CALLED ON NULL INPUT", "RETURNS NULL ON NULL INPUT",
-					  "STRICT", "EXTERNAL", "SECURITY INVOKER",
-					  "SECURITY DEFINER", "EXECUTE ON", "PARALLEL",
-					  "COST", "ROWS", "SUPPORT", "SET", "WITH");
+					  "STRICT", "EXTERNAL", "SECURITY", "EXECUTE ON",
+					  "PARALLEL", "COST", "ROWS", "SUPPORT", "SET", "WITH");
 
 	else if(HeadMatches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny) ||
 			HeadMatches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)"))
 	{
 		if(TailMatches("EXTERNAL"))
-			COMPLETE_WITH("SECURITY INVOKER", "SECURITY DEFINER");
+			COMPLETE_WITH("SECURITY");
 		else if(TailMatches("SECURITY"))
 			COMPLETE_WITH("INVOKER", "DEFINER");
+		else if(TailMatches("TRANSFORM"))
+			COMPLETE_WITH("FOR TYPE");
+		else if(TailMatches("FOR", "TYPE"))
+			COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_datatypes, NULL);
 		else if(TailMatches("EXECUTE", "ON"))
 			COMPLETE_WITH("ANY", "COORDINATOR", "ALL SEGMENTS", "INITPLAN");
 		else if(TailMatches("PARALLEL"))
 			COMPLETE_WITH("UNSAFE", "RESTRICTED", "SAFE");
 		else if(TailMatches("LANGUAGE"))
-			COMPLETE_WITH("C", "SQL", "INTERNAL");
+			COMPLETE_WITH_QUERY(Query_for_list_of_languages
+								" UNION SELECT 'internal'");
 	}
 
 

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1079,6 +1079,7 @@ static const pgsql_thing_t words_after_create[] = {
 	{"MATERIALIZED VIEW", NULL, NULL, &Query_for_list_of_matviews},
 	{"OPERATOR", NULL, NULL, NULL}, /* Querying for this is probably not such
 									 * a good idea. */
+	{"OR REPLACE", NULL}, /* for CREATE OR REPLACE FUNCTION ... */
 	{"OWNED", NULL, NULL, NULL, THING_NO_CREATE | THING_NO_ALTER},	/* for DROP OWNED BY ... */
 	{"PARSER", Query_for_list_of_ts_parsers, NULL, NULL, THING_NO_SHOW},
 	{"POLICY", NULL, NULL, NULL},
@@ -2538,17 +2539,25 @@ psql_completion(const char *text, int start, int end)
 			COMPLETE_WITH("DISTRIBUTED");
 	}
 
-	else if (Matches("CREATE", "FUNCTION", MatchAny))
+	else if (Matches("CREATE", "OR", "REPLACE"))
+		COMPLETE_WITH("FUNCTION");
+	else if (Matches("CREATE", "FUNCTION", MatchAny) ||
+			 Matches("CREATE", "OR", "REPLACE", "FUNCTION", MatchAny))
 		COMPLETE_WITH("(");
-	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)"))
+	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)") ||
+			 Matches("CREATE", "OR", "REPLACE", "FUNCTION", MatchAny, "(*)"))
 		COMPLETE_WITH("RETURNS");
-	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS"))
+	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS") ||
+			 Matches("CREATE", "OR", "REPLACE", "FUNCTION", MatchAny, "(*)", "RETURNS"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_datatypes,
 								   " UNION SELECT 'TABLE ('");
-	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE"))
+	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE") ||
+			 Matches("CREATE", "OR", "REPLACE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE"))
 		COMPLETE_WITH("(");
-	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAnyExcept("TABLE")) ||
-			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)"))
+	else if ((HeadMatches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS") ||
+			  HeadMatches("CREATE", "OR", "REPLACE", "FUNCTION", MatchAny, "(*)", "RETURNS")) &&
+			 (TailMatches("FUNCTION", MatchAny, "(*)", "RETURNS", MatchAnyExcept("TABLE")) ||
+			  TailMatches("FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)")))
 		COMPLETE_WITH("AS", "LANGUAGE", "TRANSFORM FOR TYPE", "WINDOW",
 					  "IMMUTABLE", "STABLE", "VOLATILE", "NOT LEAKPROOF",
 					  "LEAKPROOF", "CALLED ON NULL INPUT",
@@ -2558,23 +2567,33 @@ psql_completion(const char *text, int start, int end)
 
 	/* Completing individual options */
 	/* They're this big to avoid false completions by function code */
-	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "TRANSFORM", "FOR", "TYPE") ||
-			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "TRANSFORM", "FOR", "TYPE"))
+	else if ((HeadMatches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS") ||
+			  HeadMatches("CREATE", "OR", "REPLACE", "FUNCTION", MatchAny, "(*)", "RETURNS")) &&
+			 (TailMatches("FUNCTION", MatchAny, "(*)", "RETURNS", MatchAnyExcept("TABLE"), "TRANSFORM", "FOR", "TYPE") ||
+			  TailMatches("FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "TRANSFORM", "FOR", "TYPE")))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_datatypes, NULL);
-	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "PARALLEL") ||
-			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "PARALLEL"))
+	else if ((HeadMatches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS") ||
+			  HeadMatches("CREATE", "OR", "REPLACE", "FUNCTION", MatchAny, "(*)", "RETURNS")) &&
+			 (TailMatches("FUNCTION", MatchAny, "(*)", "RETURNS", MatchAnyExcept("TABLE"), "PARALLEL") ||
+			  TailMatches("FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "PARALLEL")))
 		COMPLETE_WITH("UNSAFE", "RESTRICTED", "SAFE");
-	else if(Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "EXECUTE", "ON") ||
-			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "EXECUTE", "ON"))
+	else if ((HeadMatches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS") ||
+			  HeadMatches("CREATE", "OR", "REPLACE", "FUNCTION", MatchAny, "(*)", "RETURNS")) &&
+			 (TailMatches("FUNCTION", MatchAny, "(*)", "RETURNS", MatchAnyExcept("TABLE"), "EXECUTE", "ON") ||
+			  TailMatches("FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "EXECUTE", "ON")))
 		COMPLETE_WITH("ANY", "COORDINATOR", "ALL SEGMENTS", "INITPLAN");
-	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "LANGUAGE") ||
-			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "LANGUAGE"))
+	else if ((HeadMatches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS") ||
+			  HeadMatches("CREATE", "OR", "REPLACE", "FUNCTION", MatchAny, "(*)", "RETURNS")) &&
+			 (TailMatches("FUNCTION", MatchAny, "(*)", "RETURNS", MatchAnyExcept("TABLE"), "LANGUAGE") ||
+			  TailMatches("FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "LANGUAGE")))
 		COMPLETE_WITH_QUERY(Query_for_list_of_languages
 							" UNION SELECT 'internal'");
-	else if (Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "SECURITY") ||
-			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "SECURITY") ||
-			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", MatchAny, "EXTERNAL", "SECURITY") ||
-			Matches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "EXTERNAL", "SECURITY"))
+	else if ((HeadMatches("CREATE", "FUNCTION", MatchAny, "(*)", "RETURNS") ||
+			  HeadMatches("CREATE", "OR", "REPLACE", "FUNCTION", MatchAny, "(*)", "RETURNS")) &&
+			 (TailMatches("FUNCTION", MatchAny, "(*)", "RETURNS", MatchAnyExcept("TABLE"), "SECURITY") ||
+			  TailMatches("FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "SECURITY") ||
+			  TailMatches("FUNCTION", MatchAny, "(*)", "RETURNS", MatchAnyExcept("TABLE"), "EXTERNAL", "SECURITY") ||
+			  TailMatches("FUNCTION", MatchAny, "(*)", "RETURNS", "TABLE", "(*)", "EXTERNAL", "SECURITY")))
 		COMPLETE_WITH("INVOKER", "DEFINER");
 
 	/* CREATE FOREIGN */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2501,8 +2501,8 @@ psql_completion(const char *text, int start, int end)
 	else if (HeadMatches("CREATE", "WRITABLE", "EXTERNAL") &&
 		TailMatches("DISTRIBUTED"))
 		COMPLETE_WITH("BY (", "RANDOMLY");
-  
-  	/* CREATE WRITABLE EXTERNAL WEB ... */
+
+	/* CREATE WRITABLE EXTERNAL WEB ... */
 	else if (HeadMatches("CREATE", "WRITABLE", "EXTERNAL", "WEB", "TABLE") ||
 			HeadMatches("CREATE", "WRITABLE", "EXTERNAL", "WEB", "TEMP|TEMPORARY", "TABLE"))
 	{


### PR DESCRIPTION
Some options for CREATE FUNCTION lacked autocomplete support in psql.

Add autocomplete for CREATE FUNCTION.
Add options suggestions for CREATE FUNCTION.
Add suggestions after OR REPLACE. 

Don't address autocomplete for multiple consecutive options.