### PR TITLE
CI-5837: Bump Package CI to v44 for 7.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -152,7 +152,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v40
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v44
     with:
       version: 7
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
##  Bump Package CI to v44 to get structured deb install test reporting

### Problem

After a deb package is built and tested in CI, there is no visibility
into what was actually installed: package version, dependencies, and
description are only available by downloading the artifact manually.

### Solution

Replaces the inline bash `test-docker`job in `greengage-reusable-package`
with a composite action `tests/install/deb` that:

- downloads the deb artifact
- imports the Greengage GPG key on the runner and bind-mounts it
  into the container
- adds the Greengage apt repository with OS version auto-detection
- installs all `.deb` files from the artifact
- runs configurable verify commands
- generates a per-package installation report via `dpkg -s` and
  writes it to the GitHub Actions job summary — the developer can
  see directly in the PR/workflow UI what package version, dependencies,
  and description will be visible to the end user after installation,
  without downloading any artifacts manually
- uploads the full installation report as a workflow artifact for
  later reference

Also, remove `test_lima` input from the workflow as it was unused.

Task: [CI-5835](https://tracker.yandex.ru/CI-5835)