### PR TITLE
Fix assert if vacuum is done in parallel with the cluster shrink

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17817,7 +17817,8 @@ ATExecShrinkTable(Relation rel, GpPolicy *policy)
 		gp_segment_number_for_table_shrink = 0;
 		optimizer = saveOptimizerGucValue;
 	}
-	else if (Gp_role == GP_ROLE_EXECUTE && GpPolicyIsPartitioned(policy) &&
+	else if (Gp_role == GP_ROLE_EXECUTE &&
+		   (GpPolicyIsPartitioned(policy) || GpPolicyIsReplicated(policy)) &&
 		   GpIdentity.segindex >= policy->numsegments)
 	{
 		/*

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -3156,7 +3156,12 @@ vac_update_relstats_from_list(VacuumStatsContext *stats_context)
 
 		if (GpPolicyIsReplicated(rel->rd_cdbpolicy))
 		{
-			Assert(stats->count == rel->rd_cdbpolicy->numsegments);
+			Assert(stats->count >= rel->rd_cdbpolicy->numsegments);
+			elogif(stats->count > rel->rd_cdbpolicy->numsegments, WARNING,
+				   "Numsegments for relation \"%s\".\"%s\" is less than stats "
+				   "dispatch results count. Valid situation only during cluster shrink.",
+				   get_namespace_name(get_rel_namespace(stats->relid)),
+				   get_rel_name(stats->relid));
 
 			stats->rel_pages = stats->rel_pages / rel->rd_cdbpolicy->numsegments;
 			stats->rel_tuples = stats->rel_tuples / rel->rd_cdbpolicy->numsegments;

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -3157,11 +3157,11 @@ vac_update_relstats_from_list(VacuumStatsContext *stats_context)
 		if (GpPolicyIsReplicated(rel->rd_cdbpolicy))
 		{
 			Assert(stats->count >= rel->rd_cdbpolicy->numsegments);
-			elogif(stats->count > rel->rd_cdbpolicy->numsegments, WARNING,
-				   "Numsegments for relation \"%s\".\"%s\" is less than stats "
-				   "dispatch results count. Valid situation only during cluster shrink.",
-				   get_namespace_name(get_rel_namespace(stats->relid)),
-				   get_rel_name(stats->relid));
+			ereportif(stats->count > rel->rd_cdbpolicy->numsegments, WARNING,
+					  (errmsg("Numsegments for relation \"%s\".\"%s\" is less than stats "
+							  "dispatch results count. Valid situation only during cluster shrink.",
+							  get_namespace_name(get_rel_namespace(stats->relid)),
+							  get_rel_name(stats->relid))));
 
 			stats->rel_pages = stats->rel_pages / rel->rd_cdbpolicy->numsegments;
 			stats->rel_tuples = stats->rel_tuples / rel->rd_cdbpolicy->numsegments;

--- a/src/test/regress/expected/alter_rebalance.out
+++ b/src/test/regress/expected/alter_rebalance.out
@@ -1737,6 +1737,119 @@ select *, gp_segment_id from multi_part_table_distr_hashed order by a, b, c;
  40 | 03-05-2023 | test1 |             1
 (120 rows)
 
+-- Check vacuum on the tables
+vacuum table_distr_hashed;
+vacuum table_distr_hashed_ao_row;
+vacuum table_distr_hashed_ao_col;
+vacuum table_distr_random;
+vacuum table_distr_random_ao_row;
+vacuum table_distr_random_ao_col;
+vacuum table_distr_replicated;
+WARNING:  Numsegments for relation "public"."table_distr_replicated" is less than stats dispatch results count. Valid situation only during cluster shrink.
+vacuum table_distr_replicated_ao_row;
+WARNING:  Numsegments for relation "public"."table_distr_replicated_ao_row" is less than stats dispatch results count. Valid situation only during cluster shrink.
+vacuum table_distr_replicated_ao_col;
+WARNING:  Numsegments for relation "public"."table_distr_replicated_ao_col" is less than stats dispatch results count. Valid situation only during cluster shrink.
+vacuum part_range_table_distr_hashed;
+vacuum part_range_table_distr_random;
+vacuum part_list_table_distr_hashed;
+vacuum part_list_table_distr_random;
+vacuum multi_part_table_distr_hashed;
+-- Check reltuples statistics after vacuum
+select reltuples from pg_class where oid = 'table_distr_hashed'::regclass;
+ reltuples 
+-----------
+        40
+(1 row)
+
+select reltuples from pg_class where oid = 'table_distr_hashed_ao_row'::regclass;
+ reltuples 
+-----------
+        40
+(1 row)
+
+select reltuples from pg_class where oid = 'table_distr_hashed_ao_col'::regclass;
+ reltuples 
+-----------
+        40
+(1 row)
+
+select reltuples from pg_class where oid = 'table_distr_random'::regclass;
+ reltuples 
+-----------
+        40
+(1 row)
+
+select reltuples from pg_class where oid = 'table_distr_random_ao_row'::regclass;
+ reltuples 
+-----------
+        40
+(1 row)
+
+select reltuples from pg_class where oid = 'table_distr_random_ao_col'::regclass;
+ reltuples 
+-----------
+        40
+(1 row)
+
+select reltuples from pg_class where oid = 'table_distr_replicated'::regclass;
+ reltuples 
+-----------
+        40
+(1 row)
+
+select reltuples from pg_class where oid = 'table_distr_replicated_ao_row'::regclass;
+ reltuples 
+-----------
+        40
+(1 row)
+
+select reltuples from pg_class where oid = 'table_distr_replicated_ao_col'::regclass;
+ reltuples 
+-----------
+        40
+(1 row)
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('part_range_table_distr_hashed') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+ total_estimated_rows 
+----------------------
+                  120
+(1 row)
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('part_range_table_distr_random') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+ total_estimated_rows 
+----------------------
+                  120
+(1 row)
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('part_list_table_distr_hashed') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+ total_estimated_rows 
+----------------------
+                  120
+(1 row)
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('part_list_table_distr_random') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+ total_estimated_rows 
+----------------------
+                  120
+(1 row)
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('multi_part_table_distr_hashed') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+ total_estimated_rows 
+----------------------
+                  120
+(1 row)
+
 -- And do some cleanup
 drop table table_distr_hashed;
 drop table table_distr_hashed_ao_row;
@@ -3464,6 +3577,119 @@ select *, gp_segment_id from new_multi_part_table_distr_hashed order by a, b, c;
  40 | 02-05-2023 | test2 |             1
  40 | 03-05-2023 | test1 |             1
 (120 rows)
+
+-- Check vacuum on the tables
+vacuum new_table_distr_hashed;
+vacuum new_table_distr_hashed_ao_row;
+vacuum new_table_distr_hashed_ao_col;
+vacuum new_table_distr_random;
+vacuum new_table_distr_random_ao_row;
+vacuum new_table_distr_random_ao_col;
+vacuum new_table_distr_replicated;
+WARNING:  Numsegments for relation "public"."new_table_distr_replicated" is less than stats dispatch results count. Valid situation only during cluster shrink.
+vacuum new_table_distr_replicated_ao_row;
+WARNING:  Numsegments for relation "public"."new_table_distr_replicated_ao_row" is less than stats dispatch results count. Valid situation only during cluster shrink.
+vacuum new_table_distr_replicated_ao_col;
+WARNING:  Numsegments for relation "public"."new_table_distr_replicated_ao_col" is less than stats dispatch results count. Valid situation only during cluster shrink.
+vacuum new_part_range_table_distr_hashed;
+vacuum new_part_range_table_distr_random;
+vacuum new_part_list_table_distr_hashed;
+vacuum new_part_list_table_distr_random;
+vacuum new_multi_part_table_distr_hashed;
+-- Check reltuples statistics after vacuum
+select reltuples from pg_class where oid = 'new_table_distr_hashed'::regclass;
+ reltuples 
+-----------
+        40
+(1 row)
+
+select reltuples from pg_class where oid = 'new_table_distr_hashed_ao_row'::regclass;
+ reltuples 
+-----------
+        40
+(1 row)
+
+select reltuples from pg_class where oid = 'new_table_distr_hashed_ao_col'::regclass;
+ reltuples 
+-----------
+        40
+(1 row)
+
+select reltuples from pg_class where oid = 'new_table_distr_random'::regclass;
+ reltuples 
+-----------
+        40
+(1 row)
+
+select reltuples from pg_class where oid = 'new_table_distr_random_ao_row'::regclass;
+ reltuples 
+-----------
+        40
+(1 row)
+
+select reltuples from pg_class where oid = 'new_table_distr_random_ao_col'::regclass;
+ reltuples 
+-----------
+        40
+(1 row)
+
+select reltuples from pg_class where oid = 'new_table_distr_replicated'::regclass;
+ reltuples 
+-----------
+        20
+(1 row)
+
+select reltuples from pg_class where oid = 'new_table_distr_replicated_ao_row'::regclass;
+ reltuples 
+-----------
+        20
+(1 row)
+
+select reltuples from pg_class where oid = 'new_table_distr_replicated_ao_col'::regclass;
+ reltuples 
+-----------
+        20
+(1 row)
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('new_part_range_table_distr_hashed') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+ total_estimated_rows 
+----------------------
+                  120
+(1 row)
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('new_part_range_table_distr_random') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+ total_estimated_rows 
+----------------------
+                  120
+(1 row)
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('new_part_list_table_distr_hashed') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+ total_estimated_rows 
+----------------------
+                  120
+(1 row)
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('new_part_list_table_distr_random') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+ total_estimated_rows 
+----------------------
+                  120
+(1 row)
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('new_multi_part_table_distr_hashed') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+ total_estimated_rows 
+----------------------
+                  120
+(1 row)
 
 -- And do some cleanup
 drop table new_table_distr_hashed;

--- a/src/test/regress/sql/alter_rebalance.sql
+++ b/src/test/regress/sql/alter_rebalance.sql
@@ -194,6 +194,60 @@ select *, (gp_segment_id < 2) as correct_segment_id from part_list_table_distr_r
 
 select *, gp_segment_id from multi_part_table_distr_hashed order by a, b, c;
 
+-- Check vacuum on the tables
+vacuum table_distr_hashed;
+vacuum table_distr_hashed_ao_row;
+vacuum table_distr_hashed_ao_col;
+
+vacuum table_distr_random;
+vacuum table_distr_random_ao_row;
+vacuum table_distr_random_ao_col;
+
+vacuum table_distr_replicated;
+vacuum table_distr_replicated_ao_row;
+vacuum table_distr_replicated_ao_col;
+
+vacuum part_range_table_distr_hashed;
+vacuum part_range_table_distr_random;
+
+vacuum part_list_table_distr_hashed;
+vacuum part_list_table_distr_random;
+
+vacuum multi_part_table_distr_hashed;
+
+-- Check reltuples statistics after vacuum
+select reltuples from pg_class where oid = 'table_distr_hashed'::regclass;
+select reltuples from pg_class where oid = 'table_distr_hashed_ao_row'::regclass;
+select reltuples from pg_class where oid = 'table_distr_hashed_ao_col'::regclass;
+
+select reltuples from pg_class where oid = 'table_distr_random'::regclass;
+select reltuples from pg_class where oid = 'table_distr_random_ao_row'::regclass;
+select reltuples from pg_class where oid = 'table_distr_random_ao_col'::regclass;
+
+select reltuples from pg_class where oid = 'table_distr_replicated'::regclass;
+select reltuples from pg_class where oid = 'table_distr_replicated_ao_row'::regclass;
+select reltuples from pg_class where oid = 'table_distr_replicated_ao_col'::regclass;
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('part_range_table_distr_hashed') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('part_range_table_distr_random') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('part_list_table_distr_hashed') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('part_list_table_distr_random') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('multi_part_table_distr_hashed') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+
 -- And do some cleanup
 drop table table_distr_hashed;
 drop table table_distr_hashed_ao_row;
@@ -389,6 +443,60 @@ select *, gp_segment_id from new_part_list_table_distr_hashed order by a, b;
 select *, (gp_segment_id < 2) as correct_segment_id from new_part_list_table_distr_random order by a, b;
 
 select *, gp_segment_id from new_multi_part_table_distr_hashed order by a, b, c;
+
+-- Check vacuum on the tables
+vacuum new_table_distr_hashed;
+vacuum new_table_distr_hashed_ao_row;
+vacuum new_table_distr_hashed_ao_col;
+
+vacuum new_table_distr_random;
+vacuum new_table_distr_random_ao_row;
+vacuum new_table_distr_random_ao_col;
+
+vacuum new_table_distr_replicated;
+vacuum new_table_distr_replicated_ao_row;
+vacuum new_table_distr_replicated_ao_col;
+
+vacuum new_part_range_table_distr_hashed;
+vacuum new_part_range_table_distr_random;
+
+vacuum new_part_list_table_distr_hashed;
+vacuum new_part_list_table_distr_random;
+
+vacuum new_multi_part_table_distr_hashed;
+
+-- Check reltuples statistics after vacuum
+select reltuples from pg_class where oid = 'new_table_distr_hashed'::regclass;
+select reltuples from pg_class where oid = 'new_table_distr_hashed_ao_row'::regclass;
+select reltuples from pg_class where oid = 'new_table_distr_hashed_ao_col'::regclass;
+
+select reltuples from pg_class where oid = 'new_table_distr_random'::regclass;
+select reltuples from pg_class where oid = 'new_table_distr_random_ao_row'::regclass;
+select reltuples from pg_class where oid = 'new_table_distr_random_ao_col'::regclass;
+
+select reltuples from pg_class where oid = 'new_table_distr_replicated'::regclass;
+select reltuples from pg_class where oid = 'new_table_distr_replicated_ao_row'::regclass;
+select reltuples from pg_class where oid = 'new_table_distr_replicated_ao_col'::regclass;
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('new_part_range_table_distr_hashed') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('new_part_range_table_distr_random') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('new_part_list_table_distr_hashed') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('new_part_list_table_distr_random') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
+
+select sum(c.reltuples) as total_estimated_rows
+from pg_partition_tree('new_multi_part_table_distr_hashed') pt
+join pg_class c on pt.relid::oid = c.oid where pt.isleaf = true;
 
 -- And do some cleanup
 drop table new_table_distr_hashed;


### PR DESCRIPTION
Fix assert if vacuum is done in parallel with the cluster shrink

Problem description:
Assert could happen if vacuum was done in parallel with the cluster shrink:
`FailedAssertion("!(stats->count == rel->rd_cdbpolicy->numsegments)"`.

Root cause:
Assert happened when vacuum processed the auxiliary tables of the ggrebalance
tool (contained in the 'ggrebalance' schema), that have replicated distribution
policy.
Assert could also happen with simpler steps:
    CREATE TABLE test_table (a int) DISTRIBUTED REPLICATED;
    ALTER TABLE test_table REBALANCE 1;
    VACUUM test_table;
The assert happened because it compared the number of stat dispatch results
with the numsegments of the table. The dispatch is done to all segments
regardless the actual numsegments of the table. Therefore, if the table was
shrunk, its numsegments was reduced, and the assert failed.

Fix:
1. Allow numsegments to be less then the number of dispatch results in the
assert, as that is an allowed situation during cluster shrink. But still emit
a warning for such a case, in order to highlight potential occasion not during
shrink.
2. During table rebalance, truncate table data for replicated tables in the
shrunk segments in order to get consistent relation statistics after vacuum for
cases:
 - the table was created on all segments and later shrunk via
'alter table rebalance' (meaning that there are some data on the shrunk
segments which can affect the statistics calculations);
 - the table was initially created on the reduced number of segments (meaning
there is no data on the shrunk segments).
