### PR TITLE
[GG-536] Adjust summary reporting code to make report more transparent.

### DIFF
--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
@@ -16,7 +16,7 @@ try:
     from gppylib.fault_injection import *
     from ggrebalance_modules.shrink import GGShrink
     from ggrebalance_modules.ggrebalance_sm import RebalanceSM
-    from ggrebalance_modules.rebalance_step import RebalanceStep
+    from ggrebalance_modules.rebalance_step import RebalanceStep, RebalanceStepMoveMirror
     from ggrebalance_modules.rebalance_commons import is_gparray_balanced
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greengage_path.sh.  Detail: ' + str(e))
@@ -219,17 +219,17 @@ class GGRebalanceMainSM:
             return
 
         segments_moved = 0
-        rolled_back_moves = []
-        cancelled_moves = []
+        rolled_back_steps = []
+        cancelled_steps = []
 
         for step in summary.executed_rebalance_steps:
             status = step.getStatus()
             if status == RebalanceStep.Status.CANCELLED:
-                cancelled_moves.append(step.getMove())
+                cancelled_steps.append(step)
             elif status == RebalanceStep.Status.DONE:
                 if step.isRollback():
-                    rolled_back_moves.append(step.getMove())
-                else:
+                    rolled_back_steps.append(step)
+                elif isinstance(step, RebalanceStepMoveMirror):
                     segments_moved += 1
             else:
                 raise Exception(f'Unexpected status for executed step: {str(step)}')
@@ -241,8 +241,8 @@ class GGRebalanceMainSM:
             self.logger.info('                                   REBALANCE                                   ')
             self.logger.info(self.summary_separator_str)
             self.logger.info(f'Segments moved:\t\t{segments_moved}')
-            self.logger.info(f'Rolled back moves:\t\t{len(rolled_back_moves)}')
-            self.logger.info(f'Cancelled moves:\t\t{len(cancelled_moves)}')
+            self.logger.info(f'Rolled back steps:\t\t{len(rolled_back_steps)}')
+            self.logger.info(f'Cancelled steps:\t\t{len(cancelled_steps)}')
 
         segments_down = []
         gp_array = configurationInterface.getConfigurationProvider().loadSystemConfig(useUtilityMode=False, verbose=False)
@@ -253,16 +253,16 @@ class GGRebalanceMainSM:
         balanced = is_gparray_balanced(gp_array)
 
         # we show warnings regardless the progress type set by user
-        show_warnings = len(segments_down) > 0 or len(cancelled_moves) > 0 or not balanced
+        show_warnings = len(segments_down) > 0 or len(cancelled_steps) > 0 or not balanced
         if show_warnings:
             self.logger.warning(self.summary_separator_str)
             self.logger.warning('                                   WARNINGS                                    ')
             self.logger.warning(self.summary_separator_str)
 
-            if len(cancelled_moves) > 0:
-                self.logger.warning('------------------------------- Cancelled moves  -------------------------------')
-                for move in cancelled_moves:
-                    self.logger.warning(str(move))
+            if len(cancelled_steps) > 0:
+                self.logger.warning('------------------------------- Cancelled steps  -------------------------------')
+                for step in cancelled_steps:
+                    self.logger.warning(str(str(step).partition("type: ")[2]))
 
             if len(segments_down) > 0:
                 self.logger.warning('Cluster might be not in fault tolerance mode!')
@@ -272,10 +272,10 @@ class GGRebalanceMainSM:
 
             if not balanced:
                 self.logger.warning('Cluster is left in unbalanced state')
-                if len(rolled_back_moves) > 0:
-                    self.logger.warning('------------------------------ Rolled back moves ---------------------------------')
-                    for move in rolled_back_moves:
-                        self.logger.warning(str(move))
+                if len(rolled_back_steps) > 0:
+                    self.logger.warning('------------------------------ Rolled back steps ---------------------------------')
+                    for step in rolled_back_steps:
+                        self.logger.warning(str(step).partition("type: ")[2])
                     self.logger.warning('You can review why segments were rolled back and retry rebalance later.')
 
     def print_full_summary(self) -> None:

--- a/gpMgmt/bin/ggrebalance_modules/test/test_unit_progress.py
+++ b/gpMgmt/bin/ggrebalance_modules/test/test_unit_progress.py
@@ -85,15 +85,14 @@ class TestPrintRebalanceSummary(GpTestCase):
      7.  cancelled_steps --> CANCELLED status
      8.  Unexpected status --> Exception raised before any output
      9.  Mixed statuses --> all three buckets filled simultaneously
-    10.  No warnings --> balanced cluster, nothing down, nothing cancelled
-    11.  Warning: cancelled steps --> section header + each step line
+    10.  No warnings --> two segments explicitly up, cluster balanced; summary table still printed
+    11.  Warning: cancelled steps --> per-step line logged in warnings section
     12.  Warning: segments down --> fault-tolerance message + each segment
     13.  Warning: unbalanced, no rolled-back steps
     14.  Warning: unbalanced WITH rolled-back steps --> retry message printed
     15.  All three warning branches fired in one call
     16.  PROGRESS_NO still fires warnings (warnings are independent of mode)
-    17.  loadSystemConfig called with exact keyword arguments
-    18.  Multiple down segments --> each one logged individually
+    17.  Multiple down segments --> each one logged individually and in order
     """
 
     # 1
@@ -135,19 +134,18 @@ class TestPrintRebalanceSummary(GpTestCase):
         sm = _make_sm()
         sm.rebalance_schema.getProgressType.return_value = (
             RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
-        mock_cfg.getConfigurationProvider.return_value \
-            .loadSystemConfig.return_value = _make_gp_array()
-
+        load_mock = mock_cfg.getConfigurationProvider.return_value.loadSystemConfig
+        load_mock.return_value = _make_gp_array()
         steps = [_mirror(RebalanceStep.Status.DONE),
                  _mirror(RebalanceStep.Status.DONE)]
         _call(sm, _make_summary(steps))
-
         sm.logger.info.assert_any_call(GGRebalanceMainSM.summary_separator_str)
         sm.logger.info.assert_any_call(
             '                                   REBALANCE                                   ')
         sm.logger.info.assert_any_call('Segments moved:\t\t2')
         sm.logger.info.assert_any_call('Rolled back steps:\t\t0')
         sm.logger.info.assert_any_call('Cancelled steps:\t\t0')
+        load_mock.assert_called_once_with(useUtilityMode=False, verbose=False)
 
     # 4
     @patch(f'{_MOD}.configurationInterface')
@@ -175,17 +173,17 @@ class TestPrintRebalanceSummary(GpTestCase):
             RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
         mock_cfg.getConfigurationProvider.return_value \
             .loadSystemConfig.return_value = _make_gp_array()
-
         steps = [
-            _mirror(RebalanceStep.Status.DONE, is_rollback=False),   # 1 moved
-            _mirror(RebalanceStep.Status.DONE, is_rollback=False),   # 1 moved
-            _mirror(RebalanceStep.Status.DONE, is_rollback=True),    # rollback --> NOT moved
-            _switchover1(RebalanceStep.Status.DONE, is_rollback=False),  # switchover --> NOT moved
-            _switchover2(RebalanceStep.Status.DONE, is_rollback=False),
+            _mirror(RebalanceStep.Status.DONE, is_rollback=False),  # counted as moved
+            _mirror(RebalanceStep.Status.DONE, is_rollback=False),  # counted as moved
+            _mirror(RebalanceStep.Status.DONE, is_rollback=True),   # NOT moved; rolled back
+            _switchover1(RebalanceStep.Status.DONE, is_rollback=False),  # NOT moved
+            _switchover2(RebalanceStep.Status.DONE, is_rollback=False),  # NOT moved
         ]
         _call(sm, _make_summary(steps))
-
         sm.logger.info.assert_any_call('Segments moved:\t\t2')
+        # The rolled-back mirror step must land in its own bucket, not disappear
+        sm.logger.info.assert_any_call('Rolled back steps:\t\t1')
 
     # 6
     @patch(f'{_MOD}.configurationInterface')
@@ -264,12 +262,13 @@ class TestPrintRebalanceSummary(GpTestCase):
         sm = _make_sm()
         sm.rebalance_schema.getProgressType.return_value = (
             RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
-        # Two segments, both up
+        # Two segments explicitly UP.
+        # This proves that segments being UP suppresses the
+        # fault-tolerance warning while the summary table is still emitted.
         mock_cfg.getConfigurationProvider.return_value \
             .loadSystemConfig.return_value = _make_gp_array(down_flags=[False, False])
-
         _call(sm, _make_summary([_mirror(RebalanceStep.Status.DONE)]))
-
+        sm.logger.info.assert_any_call('Segments moved:\t\t1')
         sm.logger.warning.assert_not_called()
 
     # 11
@@ -281,20 +280,11 @@ class TestPrintRebalanceSummary(GpTestCase):
             RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
         mock_cfg.getConfigurationProvider.return_value \
             .loadSystemConfig.return_value = _make_gp_array()
-
         c_step = _mirror(
             RebalanceStep.Status.CANCELLED,
             str_repr="Rebalance step, move_order=3 type: mirror move, content=1")
-
         _call(sm, _make_summary([c_step]))
-
-        sm.logger.warning.assert_any_call(GGRebalanceMainSM.summary_separator_str)
-        sm.logger.warning.assert_any_call(
-            '                                   WARNINGS                                    ')
-        sm.logger.warning.assert_any_call(
-            '------------------------------- Cancelled steps  -------------------------------')
-
-        expected_line = str(str(c_step).partition("type: ")[2])
+        expected_line = str(c_step).partition("type: ")[2]
         sm.logger.warning.assert_any_call(expected_line)
 
     # 12
@@ -304,7 +294,6 @@ class TestPrintRebalanceSummary(GpTestCase):
         sm = _make_sm()
         sm.rebalance_schema.getProgressType.return_value = (
             RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
-
         down_seg = MagicMock()
         down_seg.isSegmentDown.return_value = True
         down_seg.__str__.return_value = 'sdw2|content=1|role=m|status=d'
@@ -312,9 +301,7 @@ class TestPrintRebalanceSummary(GpTestCase):
         gp_array.getSegDbList.return_value = [down_seg]
         mock_cfg.getConfigurationProvider.return_value \
             .loadSystemConfig.return_value = gp_array
-
         _call(sm, _make_summary([_mirror(RebalanceStep.Status.DONE)]))
-
         sm.logger.warning.assert_any_call(
             'Cluster might be not in fault tolerance mode!')
         sm.logger.warning.assert_any_call(
@@ -375,7 +362,6 @@ class TestPrintRebalanceSummary(GpTestCase):
         sm = _make_sm()
         sm.rebalance_schema.getProgressType.return_value = (
             RebalanceSchema.ProgressType.PROGRESS_DETAILED)
-
         down_seg = MagicMock()
         down_seg.isSegmentDown.return_value = True
         down_seg.__str__.return_value = 'Segment(down=True)'
@@ -383,17 +369,20 @@ class TestPrintRebalanceSummary(GpTestCase):
         gp_array.getSegDbList.return_value = [down_seg]
         mock_cfg.getConfigurationProvider.return_value \
             .loadSystemConfig.return_value = gp_array
-
         rb = _mirror(RebalanceStep.Status.DONE, is_rollback=True,
                      str_repr="info type: rb detail")
         c = _mirror(RebalanceStep.Status.CANCELLED,
                     str_repr="info type: cancelled detail")
-
         _call(sm, _make_summary([rb, c]))
-
+        # Structural headers of the WARNINGS block — asserted only here
+        sm.logger.warning.assert_any_call(GGRebalanceMainSM.summary_separator_str)
+        sm.logger.warning.assert_any_call('                                   WARNINGS                                    ')
+        # Branch 1: fault tolerance (down segment)
         sm.logger.warning.assert_any_call('Cluster might be not in fault tolerance mode!')
+        # Branch 2: cancelled steps sub-header — asserted only here, not in #11
         sm.logger.warning.assert_any_call(
             '------------------------------- Cancelled steps  -------------------------------')
+        # Branch 3: unbalanced cluster + rolled-back steps sub-header
         sm.logger.warning.assert_any_call('Cluster is left in unbalanced state')
         sm.logger.warning.assert_any_call(
             '------------------------------ Rolled back steps ---------------------------------')
@@ -407,39 +396,37 @@ class TestPrintRebalanceSummary(GpTestCase):
         sm = _make_sm()
         sm.rebalance_schema.getProgressType.return_value = (
             RebalanceSchema.ProgressType.PROGRESS_NO)
+        # Down segment triggers the fault-tolerance branch
+        down_seg = MagicMock()
+        down_seg.isSegmentDown.return_value = True
+        down_seg.__str__.return_value = 'Segment(down=True)'
+        gp_array = MagicMock()
+        gp_array.getSegDbList.return_value = [down_seg]
         mock_cfg.getConfigurationProvider.return_value \
-            .loadSystemConfig.return_value = _make_gp_array()
-
-        _call(sm, _make_summary([_mirror(RebalanceStep.Status.DONE)]))
-
+            .loadSystemConfig.return_value = gp_array
+        # Cancelled step triggers the cancelled-steps branch
+        c_step = _mirror(
+            RebalanceStep.Status.CANCELLED,
+            str_repr="Rebalance step, move_order=1 type: mirror move, content=0")
+        _call(sm, _make_summary([c_step]))
+        # Info table suppressed
         sm.logger.info.assert_any_call(
             'Skip final rebalance summary report '
             '(specify "--simple-progress" or "--detailed-progress" to enable it).')
-
+        # All three warning branches still fire despite PROGRESS_NO
         sm.logger.warning.assert_any_call('Cluster is left in unbalanced state')
+        sm.logger.warning.assert_any_call('Cluster might be not in fault tolerance mode!')
+        sm.logger.warning.assert_any_call(str(down_seg))
+        expected_cancelled_line = str(c_step).partition("type: ")[2]
+        sm.logger.warning.assert_any_call(expected_cancelled_line)
 
     # 17
-    @patch(f'{_MOD}.configurationInterface')
-    @patch(f'{_MOD}.is_gparray_balanced', return_value=True)
-    def test_load_system_config_called_with_correct_kwargs(self, _bal, mock_cfg):
-        sm = _make_sm()
-        sm.rebalance_schema.getProgressType.return_value = (
-            RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
-        load_mock = mock_cfg.getConfigurationProvider.return_value.loadSystemConfig
-        load_mock.return_value = _make_gp_array()
-
-        _call(sm, _make_summary([_mirror(RebalanceStep.Status.DONE)]))
-
-        load_mock.assert_called_once_with(useUtilityMode=False, verbose=False)
-
-    # 18
     @patch(f'{_MOD}.configurationInterface')
     @patch(f'{_MOD}.is_gparray_balanced', return_value=True)
     def test_multiple_down_segments_each_logged(self, _bal, mock_cfg):
         sm = _make_sm()
         sm.rebalance_schema.getProgressType.return_value = (
             RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
-
         down_segs = []
         for i in range(3):
             seg = MagicMock()
@@ -450,11 +437,9 @@ class TestPrintRebalanceSummary(GpTestCase):
         gp_array.getSegDbList.return_value = down_segs
         mock_cfg.getConfigurationProvider.return_value \
             .loadSystemConfig.return_value = gp_array
-
         _call(sm, _make_summary([_mirror(RebalanceStep.Status.DONE)]))
-
-        for seg in down_segs:
-            sm.logger.warning.assert_any_call(str(seg))
+        sm.logger.warning.assert_has_calls(
+            [call(str(s)) for s in down_segs], any_order=False)
 
 
 if __name__ == '__main__':

--- a/gpMgmt/bin/ggrebalance_modules/test/test_unit_progress.py
+++ b/gpMgmt/bin/ggrebalance_modules/test/test_unit_progress.py
@@ -1,0 +1,461 @@
+#
+# Copyright (c) 2025-Present, Greengage Community
+#
+
+
+from gppylib.test.unit.gp_unittest import *
+from mock import *
+
+from ggrebalance_modules.ggrebalance_main_sm import GGRebalanceMainSM
+from ggrebalance_modules.rebalance_schema import RebalanceSchema
+from ggrebalance_modules.rebalance_step import (
+    RebalanceStep,
+    RebalanceStepMoveMirror,
+    RebalanceStepSwitchoverToMirror,
+    RebalanceStepSwitchoverToPrimary,
+)
+
+_MOD = 'ggrebalance_modules.ggrebalance_main_sm'
+
+def _make_step(step_cls, status, is_rollback=False, str_repr=None):
+    step = MagicMock(spec=step_cls)
+    step.getStatus.return_value = status
+    step.isRollback.return_value = is_rollback
+    if str_repr is None:
+        str_repr = f"Rebalance step: {step_cls.__name__}"
+    step.__str__.return_value = str_repr
+    return step
+
+
+def _mirror(status, is_rollback=False, str_repr=None):
+    return _make_step(RebalanceStepMoveMirror, status, is_rollback, str_repr)
+
+
+def _switchover1(status, is_rollback=False):
+    return _make_step(RebalanceStepSwitchoverToMirror, status, is_rollback)
+
+def _switchover2(status, is_rollback=False):
+    return _make_step(RebalanceStepSwitchoverToPrimary, status, is_rollback)
+
+
+def _make_sm():
+    sm = MagicMock()
+    sm.logger = Mock(spec=['info', 'warning', 'error', 'debug'])
+    sm.summary_separator_str = GGRebalanceMainSM.summary_separator_str
+    sm.rebalance_schema = MagicMock()
+    sm.rebalance_schema.ProgressType = RebalanceSchema.ProgressType
+    return sm
+
+
+def _make_summary(steps):
+    s = MagicMock()
+    s.executed_rebalance_steps = steps
+    return s
+
+
+def _make_gp_array(down_flags=None):
+    gp_array = MagicMock()
+    segs = []
+    for i, flag in enumerate(down_flags or []):
+        seg = MagicMock()
+        seg.isSegmentDown.return_value = flag
+        seg.__str__.return_value = f"Segment(content={i}, down={flag})"
+        segs.append(seg)
+    gp_array.getSegDbList.return_value = segs
+    return gp_array
+
+
+def _call(sm, summary):
+    """
+    Invoke the real method on a fake SM instance
+    """
+    GGRebalanceMainSM.print_rebalance_summary(sm, summary)
+
+
+class TestPrintRebalanceSummary(GpTestCase):
+    """
+    Unit tests for GGRebalanceMainSM.print_rebalance_summary.
+
+     1.  Empty step list --> early return, zero I/O
+     2.  PROGRESS_NO --> skip message logged; REBALANCE table suppressed
+     3.  PROGRESS_SIMPLE --> full summary table logged
+     4.  PROGRESS_DETAILED --> same as SIMPLE for rebalance section
+     5.  segments_moved --> only DONE non-rollback RebalanceStepMoveMirror counted
+     6.  rolled_back_steps --> any DONE + isRollback() step
+     7.  cancelled_steps --> CANCELLED status
+     8.  Unexpected status --> Exception raised before any output
+     9.  Mixed statuses --> all three buckets filled simultaneously
+    10.  No warnings --> balanced cluster, nothing down, nothing cancelled
+    11.  Warning: cancelled steps --> section header + each step line
+    12.  Warning: segments down --> fault-tolerance message + each segment
+    13.  Warning: unbalanced, no rolled-back steps
+    14.  Warning: unbalanced WITH rolled-back steps --> retry message printed
+    15.  All three warning branches fired in one call
+    16.  PROGRESS_NO still fires warnings (warnings are independent of mode)
+    17.  loadSystemConfig called with exact keyword arguments
+    18.  Multiple down segments --> each one logged individually
+    """
+
+    # 1
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=True)
+    def test_empty_steps_returns_early_no_logging(self, _bal, mock_cfg):
+        sm = _make_sm()
+        _call(sm, _make_summary([]))
+
+        sm.logger.info.assert_not_called()
+        sm.logger.warning.assert_not_called()
+
+        mock_cfg.getConfigurationProvider.assert_not_called()
+
+    # 2
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=True)
+    def test_progress_no_logs_skip_message_and_suppresses_table(self, _bal, mock_cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_NO)
+        mock_cfg.getConfigurationProvider.return_value \
+            .loadSystemConfig.return_value = _make_gp_array()
+
+        _call(sm, _make_summary([_mirror(RebalanceStep.Status.DONE)]))
+
+        sm.logger.info.assert_any_call(
+            'Skip final rebalance summary report '
+            '(specify "--simple-progress" or "--detailed-progress" to enable it).')
+        logged = [str(c) for c in sm.logger.info.call_args_list]
+        self.assertFalse(
+            any('REBALANCE' in m for m in logged),
+            "REBALANCE header must not appear in PROGRESS_NO mode")
+
+    # 3
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=True)
+    def test_progress_simple_logs_full_table(self, _bal, mock_cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
+        mock_cfg.getConfigurationProvider.return_value \
+            .loadSystemConfig.return_value = _make_gp_array()
+
+        steps = [_mirror(RebalanceStep.Status.DONE),
+                 _mirror(RebalanceStep.Status.DONE)]
+        _call(sm, _make_summary(steps))
+
+        sm.logger.info.assert_any_call(GGRebalanceMainSM.summary_separator_str)
+        sm.logger.info.assert_any_call(
+            '                                   REBALANCE                                   ')
+        sm.logger.info.assert_any_call('Segments moved:\t\t2')
+        sm.logger.info.assert_any_call('Rolled back steps:\t\t0')
+        sm.logger.info.assert_any_call('Cancelled steps:\t\t0')
+
+    # 4
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=True)
+    def test_progress_detailed_logs_full_table(self, _bal, mock_cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_DETAILED)
+        mock_cfg.getConfigurationProvider.return_value \
+            .loadSystemConfig.return_value = _make_gp_array()
+
+        _call(sm, _make_summary([_mirror(RebalanceStep.Status.DONE)]))
+
+        sm.logger.info.assert_any_call('Segments moved:\t\t1')
+        sm.logger.info.assert_any_call('Rolled back steps:\t\t0')
+        sm.logger.info.assert_any_call('Cancelled steps:\t\t0')
+        sm.logger.warning.assert_not_called()
+
+    # 5
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=True)
+    def test_segments_moved_excludes_rollback_and_switchovers(self, _bal, mock_cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
+        mock_cfg.getConfigurationProvider.return_value \
+            .loadSystemConfig.return_value = _make_gp_array()
+
+        steps = [
+            _mirror(RebalanceStep.Status.DONE, is_rollback=False),   # 1 moved
+            _mirror(RebalanceStep.Status.DONE, is_rollback=False),   # 1 moved
+            _mirror(RebalanceStep.Status.DONE, is_rollback=True),    # rollback --> NOT moved
+            _switchover1(RebalanceStep.Status.DONE, is_rollback=False),  # switchover --> NOT moved
+            _switchover2(RebalanceStep.Status.DONE, is_rollback=False),
+        ]
+        _call(sm, _make_summary(steps))
+
+        sm.logger.info.assert_any_call('Segments moved:\t\t2')
+
+    # 6
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=True)
+    def test_rolled_back_steps_counted_correctly(self, _bal, mock_cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
+        mock_cfg.getConfigurationProvider.return_value \
+            .loadSystemConfig.return_value = _make_gp_array()
+
+        steps = [_mirror(RebalanceStep.Status.DONE, is_rollback=True),
+                 _mirror(RebalanceStep.Status.DONE, is_rollback=True)]
+        _call(sm, _make_summary(steps))
+
+        sm.logger.info.assert_any_call('Rolled back steps:\t\t2')
+        sm.logger.info.assert_any_call('Segments moved:\t\t0')
+
+    # 7
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=True)
+    def test_cancelled_steps_counted_correctly(self, _bal, mock_cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
+        mock_cfg.getConfigurationProvider.return_value \
+            .loadSystemConfig.return_value = _make_gp_array()
+
+        steps = [_mirror(RebalanceStep.Status.CANCELLED) for _ in range(3)]
+        _call(sm, _make_summary(steps))
+
+        sm.logger.info.assert_any_call('Cancelled steps:\t\t3')
+
+    # 8
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=True)
+    def test_unexpected_status_raises_exception(self, _bal, _cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
+
+        bad = MagicMock()
+        bad.getStatus.return_value = RebalanceStep.Status.IN_PROGRESS
+        bad.__str__.return_value = 'step in progress'
+
+        with self.assertRaises(Exception) as ctx:
+            _call(sm, _make_summary([bad]))
+        self.assertIn('Unexpected status for executed step', str(ctx.exception))
+
+    # 9
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=True)
+    def test_mixed_statuses_all_buckets_filled(self, _bal, mock_cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
+        mock_cfg.getConfigurationProvider.return_value \
+            .loadSystemConfig.return_value = _make_gp_array()
+
+        steps = [
+            _mirror(RebalanceStep.Status.DONE, is_rollback=False),  # 1 moved
+            _mirror(RebalanceStep.Status.DONE, is_rollback=False),  # 1 moved
+            _mirror(RebalanceStep.Status.DONE, is_rollback=True),   # 1 rolled back
+            _mirror(RebalanceStep.Status.CANCELLED),                 # 1 cancelled
+        ]
+        _call(sm, _make_summary(steps))
+
+        sm.logger.info.assert_any_call('Segments moved:\t\t2')
+        sm.logger.info.assert_any_call('Rolled back steps:\t\t1')
+        sm.logger.info.assert_any_call('Cancelled steps:\t\t1')
+
+    # 10
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=True)
+    def test_no_warnings_when_cluster_healthy(self, _bal, mock_cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
+        # Two segments, both up
+        mock_cfg.getConfigurationProvider.return_value \
+            .loadSystemConfig.return_value = _make_gp_array(down_flags=[False, False])
+
+        _call(sm, _make_summary([_mirror(RebalanceStep.Status.DONE)]))
+
+        sm.logger.warning.assert_not_called()
+
+    # 11
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=True)
+    def test_warning_for_cancelled_steps(self, _bal, mock_cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
+        mock_cfg.getConfigurationProvider.return_value \
+            .loadSystemConfig.return_value = _make_gp_array()
+
+        c_step = _mirror(
+            RebalanceStep.Status.CANCELLED,
+            str_repr="Rebalance step, move_order=3 type: mirror move, content=1")
+
+        _call(sm, _make_summary([c_step]))
+
+        sm.logger.warning.assert_any_call(GGRebalanceMainSM.summary_separator_str)
+        sm.logger.warning.assert_any_call(
+            '                                   WARNINGS                                    ')
+        sm.logger.warning.assert_any_call(
+            '------------------------------- Cancelled steps  -------------------------------')
+
+        expected_line = str(str(c_step).partition("type: ")[2])
+        sm.logger.warning.assert_any_call(expected_line)
+
+    # 12
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=True)
+    def test_warning_for_segments_down(self, _bal, mock_cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
+
+        down_seg = MagicMock()
+        down_seg.isSegmentDown.return_value = True
+        down_seg.__str__.return_value = 'sdw2|content=1|role=m|status=d'
+        gp_array = MagicMock()
+        gp_array.getSegDbList.return_value = [down_seg]
+        mock_cfg.getConfigurationProvider.return_value \
+            .loadSystemConfig.return_value = gp_array
+
+        _call(sm, _make_summary([_mirror(RebalanceStep.Status.DONE)]))
+
+        sm.logger.warning.assert_any_call(
+            'Cluster might be not in fault tolerance mode!')
+        sm.logger.warning.assert_any_call(
+            'These segments should be started manually in order cluster '
+            'to become fault tolerant:')
+        sm.logger.warning.assert_any_call(str(down_seg))
+
+    # 13
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=False)
+    def test_warning_unbalanced_no_rolled_back_steps(self, _bal, mock_cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
+        mock_cfg.getConfigurationProvider.return_value \
+            .loadSystemConfig.return_value = _make_gp_array()
+
+        _call(sm, _make_summary([_mirror(RebalanceStep.Status.DONE,
+                                         is_rollback=False)]))
+
+        sm.logger.warning.assert_any_call('Cluster is left in unbalanced state')
+        all_warnings = [str(c) for c in sm.logger.warning.call_args_list]
+        self.assertFalse(
+            any('Rolled back steps' in w for w in all_warnings),
+            "Rolled-back-steps section must not appear when list is empty")
+        self.assertFalse(
+            any('retry rebalance later' in w for w in all_warnings))
+
+    # 14
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=False)
+    def test_warning_unbalanced_with_rolled_back_steps(self, _bal, mock_cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
+        mock_cfg.getConfigurationProvider.return_value \
+            .loadSystemConfig.return_value = _make_gp_array()
+
+        rb = _mirror(
+            RebalanceStep.Status.DONE,
+            is_rollback=True,
+            str_repr="Rebalance step, move_order=2 type: mirror move – rolled back")
+        _call(sm, _make_summary([rb]))
+
+        sm.logger.warning.assert_any_call('Cluster is left in unbalanced state')
+        sm.logger.warning.assert_any_call(
+            '------------------------------ Rolled back steps ---------------------------------')
+
+        expected_line = str(rb).partition("type: ")[2]
+        sm.logger.warning.assert_any_call(expected_line)
+        sm.logger.warning.assert_any_call(
+            'You can review why segments were rolled back and retry rebalance later.')
+
+    # 15
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=False)
+    def test_all_warning_branches_fire_together(self, _bal, mock_cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_DETAILED)
+
+        down_seg = MagicMock()
+        down_seg.isSegmentDown.return_value = True
+        down_seg.__str__.return_value = 'Segment(down=True)'
+        gp_array = MagicMock()
+        gp_array.getSegDbList.return_value = [down_seg]
+        mock_cfg.getConfigurationProvider.return_value \
+            .loadSystemConfig.return_value = gp_array
+
+        rb = _mirror(RebalanceStep.Status.DONE, is_rollback=True,
+                     str_repr="info type: rb detail")
+        c = _mirror(RebalanceStep.Status.CANCELLED,
+                    str_repr="info type: cancelled detail")
+
+        _call(sm, _make_summary([rb, c]))
+
+        sm.logger.warning.assert_any_call('Cluster might be not in fault tolerance mode!')
+        sm.logger.warning.assert_any_call(
+            '------------------------------- Cancelled steps  -------------------------------')
+        sm.logger.warning.assert_any_call('Cluster is left in unbalanced state')
+        sm.logger.warning.assert_any_call(
+            '------------------------------ Rolled back steps ---------------------------------')
+        sm.logger.warning.assert_any_call(
+            'You can review why segments were rolled back and retry rebalance later.')
+
+    # 16
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=False)
+    def test_progress_no_still_fires_warnings(self, _bal, mock_cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_NO)
+        mock_cfg.getConfigurationProvider.return_value \
+            .loadSystemConfig.return_value = _make_gp_array()
+
+        _call(sm, _make_summary([_mirror(RebalanceStep.Status.DONE)]))
+
+        sm.logger.info.assert_any_call(
+            'Skip final rebalance summary report '
+            '(specify "--simple-progress" or "--detailed-progress" to enable it).')
+
+        sm.logger.warning.assert_any_call('Cluster is left in unbalanced state')
+
+    # 17
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=True)
+    def test_load_system_config_called_with_correct_kwargs(self, _bal, mock_cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
+        load_mock = mock_cfg.getConfigurationProvider.return_value.loadSystemConfig
+        load_mock.return_value = _make_gp_array()
+
+        _call(sm, _make_summary([_mirror(RebalanceStep.Status.DONE)]))
+
+        load_mock.assert_called_once_with(useUtilityMode=False, verbose=False)
+
+    # 18
+    @patch(f'{_MOD}.configurationInterface')
+    @patch(f'{_MOD}.is_gparray_balanced', return_value=True)
+    def test_multiple_down_segments_each_logged(self, _bal, mock_cfg):
+        sm = _make_sm()
+        sm.rebalance_schema.getProgressType.return_value = (
+            RebalanceSchema.ProgressType.PROGRESS_SIMPLE)
+
+        down_segs = []
+        for i in range(3):
+            seg = MagicMock()
+            seg.isSegmentDown.return_value = True
+            seg.__str__.return_value = f"Segment(content={i})"
+            down_segs.append(seg)
+        gp_array = MagicMock()
+        gp_array.getSegDbList.return_value = down_segs
+        mock_cfg.getConfigurationProvider.return_value \
+            .loadSystemConfig.return_value = gp_array
+
+        _call(sm, _make_summary([_mirror(RebalanceStep.Status.DONE)]))
+
+        for seg in down_segs:
+            sm.logger.warning.assert_any_call(str(seg))
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -668,8 +668,8 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And ggrebalance should not print "Tables rollback rate:" to logfile with latest timestamp
          And ggrebalance should not print "Rollback total time:" to logfile with latest timestamp
          And ggrebalance should not print "Segments moved:" to logfile with latest timestamp
-         And ggrebalance should not print "Rolled back moves:" to logfile with latest timestamp
-         And ggrebalance should not print "Cancelled moves:" to logfile with latest timestamp
+         And ggrebalance should not print "Rolled back steps:" to logfile with latest timestamp
+         And ggrebalance should not print "Cancelled steps:" to logfile with latest timestamp
          And ggrebalance should not print " WARNINGS " to logfile with latest timestamp
          And all files in gpAdminLogs directory are deleted
 
@@ -849,8 +849,8 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And ggrebalance should not print "Tables rollback rate:" to logfile with latest timestamp
          And ggrebalance should print "Rollback total time:" to logfile with latest timestamp
          And ggrebalance should not print "Segments moved:" to logfile with latest timestamp
-         And ggrebalance should not print "Rolled back moves:" to logfile with latest timestamp
-         And ggrebalance should not print "Cancelled moves:" to logfile with latest timestamp
+         And ggrebalance should not print "Rolled back steps:" to logfile with latest timestamp
+         And ggrebalance should not print "Cancelled steps:" to logfile with latest timestamp
          And ggrebalance should not print " WARNINGS " to logfile with latest timestamp
          And all files in gpAdminLogs directory are deleted
 
@@ -1180,6 +1180,6 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And ggrebalance should print "Tables rollback rate:" to logfile with latest timestamp
          And ggrebalance should print "Rollback total time:" to logfile with latest timestamp
          And ggrebalance should not print "Segments moved:" to logfile with latest timestamp
-         And ggrebalance should not print "Rolled back moves:" to logfile with latest timestamp
-         And ggrebalance should not print "Cancelled moves:" to logfile with latest timestamp
+         And ggrebalance should not print "Rolled back steps:" to logfile with latest timestamp
+         And ggrebalance should not print "Cancelled steps:" to logfile with latest timestamp
          And ggrebalance should not print " WARNINGS " to logfile with latest timestamp

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -123,8 +123,8 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should not print "Tables rollback rate:" to logfile with latest timestamp
          And ggrebalance should not print "Rollback total time:" to logfile with latest timestamp
          And ggrebalance should print "Segments moved:\s*\d+" regex to logfile
-         And ggrebalance should print "Rolled back moves:\s*0" regex to logfile
-         And ggrebalance should print "Cancelled moves:\s*0" regex to logfile
+         And ggrebalance should print "Rolled back steps:\s*0" regex to logfile
+         And ggrebalance should print "Cancelled steps:\s*0" regex to logfile
          And ggrebalance should not print " WARNINGS " to logfile with latest timestamp
          And the cluster configuration has 1 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
          And the cluster configuration has 1 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
@@ -177,8 +177,8 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should not print "Tables rollback rate:" to logfile with latest timestamp
          And ggrebalance should not print "Rollback total time:" to logfile with latest timestamp
          And ggrebalance should print "Segments moved:\s*\d+" regex to logfile
-         And ggrebalance should print "Rolled back moves:\s*0" regex to logfile
-         And ggrebalance should print "Cancelled moves:\s*0" regex to logfile
+         And ggrebalance should print "Rolled back steps:\s*0" regex to logfile
+         And ggrebalance should print "Cancelled steps:\s*0" regex to logfile
          And ggrebalance should not print " WARNINGS " to logfile with latest timestamp
          And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
          And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
@@ -497,8 +497,8 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should print "Plan to rollback step" to logfile with latest timestamp
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And ggrebalance should print "Segments moved:\s*\d+" regex to logfile
-         And ggrebalance should print "Rolled back moves:\s*\d+" regex to logfile
-         And ggrebalance should print "Cancelled moves:\s*0" regex to logfile
+         And ggrebalance should print "Rolled back steps:\s*\d+" regex to logfile
+         And ggrebalance should print "Cancelled steps:\s*0" regex to logfile
          And ggrebalance should print " WARNINGS " to logfile with latest timestamp
          And ggrebalance should not print " Cancelled moves " to logfile with latest timestamp
          And ggrebalance should not print "Cluster might be not in fault tolerance mode!" to logfile with latest timestamp
@@ -556,8 +556,8 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should print "Cancel step" to logfile with latest timestamp
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And ggrebalance should print "Segments moved:\s*\d+" regex to logfile
-         And ggrebalance should print "Rolled back moves:\s*0" regex to logfile
-         And ggrebalance should print "Cancelled moves:\s*\d+" regex to logfile
+         And ggrebalance should print "Rolled back steps:\s*0" regex to logfile
+         And ggrebalance should print "Cancelled steps:\s*\d+" regex to logfile
          And ggrebalance should print " WARNINGS " to logfile with latest timestamp
          And ggrebalance should print " Cancelled moves " to logfile with latest timestamp
          And ggrebalance should print "Cluster might be not in fault tolerance mode!" to logfile with latest timestamp
@@ -663,8 +663,8 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should print "Plan to rollback step" to logfile with latest timestamp
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And ggrebalance should not print "Segments moved:" to logfile with latest timestamp
-         And ggrebalance should not print "Rolled back moves:" to logfile with latest timestamp
-         And ggrebalance should not print "Cancelled moves:" to logfile with latest timestamp
+         And ggrebalance should not print "Rolled back steps:" to logfile with latest timestamp
+         And ggrebalance should not print "Cancelled steps:" to logfile with latest timestamp
          And ggrebalance should print " WARNINGS " to logfile with latest timestamp
          And ggrebalance should not print " Cancelled moves " to logfile with latest timestamp
          And ggrebalance should print "Cluster is left in unbalanced state" to logfile with latest timestamp
@@ -769,8 +769,8 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should print "Cancel step" to logfile with latest timestamp
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And ggrebalance should not print "Segments moved:" to logfile with latest timestamp
-         And ggrebalance should not print "Rolled back moves:" to logfile with latest timestamp
-         And ggrebalance should not print "Cancelled moves:" to logfile with latest timestamp
+         And ggrebalance should not print "Rolled back steps:" to logfile with latest timestamp
+         And ggrebalance should not print "Cancelled steps:" to logfile with latest timestamp
          And ggrebalance should print " WARNINGS " to logfile with latest timestamp
          And ggrebalance should print " Cancelled moves " to logfile with latest timestamp
          And ggrebalance should not print "Cluster might be not in fault tolerance mode!" to logfile with latest timestamp
@@ -828,8 +828,8 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should print "Cancel step" to logfile with latest timestamp
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And ggrebalance should not print "Segments moved:" to logfile with latest timestamp
-         And ggrebalance should not print "Rolled back moves:" to logfile with latest timestamp
-         And ggrebalance should not print "Cancelled moves:" to logfile with latest timestamp
+         And ggrebalance should not print "Rolled back steps:" to logfile with latest timestamp
+         And ggrebalance should not print "Cancelled steps:" to logfile with latest timestamp
          And ggrebalance should print " WARNINGS " to logfile with latest timestamp
          And ggrebalance should print " Cancelled moves " to logfile with latest timestamp
          And ggrebalance should print "Cluster might be not in fault tolerance mode!" to logfile with latest timestamp
@@ -1445,8 +1445,8 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should not print "Tables rollback rate:" to logfile with latest timestamp
          And ggrebalance should not print "Rollback total time:" to logfile with latest timestamp
          And ggrebalance should print "Segments moved:\s*0" regex to logfile
-         And ggrebalance should print "Rolled back moves:\s*\d+" regex to logfile
-         And ggrebalance should print "Cancelled moves:\s*0" regex to logfile
+         And ggrebalance should print "Rolled back steps:\s*\d+" regex to logfile
+         And ggrebalance should print "Cancelled steps:\s*0" regex to logfile
          And ggrebalance should not print " WARNINGS " to logfile with latest timestamp
          And verify the gp_segment_configuration has been restored
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 6, row count = 100

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -500,10 +500,10 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should print "Rolled back steps:\s*\d+" regex to logfile
          And ggrebalance should print "Cancelled steps:\s*0" regex to logfile
          And ggrebalance should print " WARNINGS " to logfile with latest timestamp
-         And ggrebalance should not print " Cancelled moves " to logfile with latest timestamp
+         And ggrebalance should not print " Cancelled steps " to logfile with latest timestamp
          And ggrebalance should not print "Cluster might be not in fault tolerance mode!" to logfile with latest timestamp
          And ggrebalance should print "Cluster is left in unbalanced state" to logfile with latest timestamp
-         And ggrebalance should print " Rolled back moves " to logfile with latest timestamp
+         And ggrebalance should print " Rolled back steps " to logfile with latest timestamp
          And clear user's answers
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
@@ -559,7 +559,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should print "Rolled back steps:\s*0" regex to logfile
          And ggrebalance should print "Cancelled steps:\s*\d+" regex to logfile
          And ggrebalance should print " WARNINGS " to logfile with latest timestamp
-         And ggrebalance should print " Cancelled moves " to logfile with latest timestamp
+         And ggrebalance should print " Cancelled steps " to logfile with latest timestamp
          And ggrebalance should print "Cluster might be not in fault tolerance mode!" to logfile with latest timestamp
          And ggrebalance should print "These segments should be started manually in order cluster to become fault tolerant:" to logfile with latest timestamp
          And clear user's answers
@@ -666,9 +666,9 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should not print "Rolled back steps:" to logfile with latest timestamp
          And ggrebalance should not print "Cancelled steps:" to logfile with latest timestamp
          And ggrebalance should print " WARNINGS " to logfile with latest timestamp
-         And ggrebalance should not print " Cancelled moves " to logfile with latest timestamp
+         And ggrebalance should not print " Cancelled steps " to logfile with latest timestamp
          And ggrebalance should print "Cluster is left in unbalanced state" to logfile with latest timestamp
-         And ggrebalance should print " Rolled back moves " to logfile with latest timestamp
+         And ggrebalance should print " Rolled back steps " to logfile with latest timestamp
          And clear user's answers
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
          And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
@@ -772,10 +772,10 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should not print "Rolled back steps:" to logfile with latest timestamp
          And ggrebalance should not print "Cancelled steps:" to logfile with latest timestamp
          And ggrebalance should print " WARNINGS " to logfile with latest timestamp
-         And ggrebalance should print " Cancelled moves " to logfile with latest timestamp
+         And ggrebalance should print " Cancelled steps " to logfile with latest timestamp
          And ggrebalance should not print "Cluster might be not in fault tolerance mode!" to logfile with latest timestamp
          And ggrebalance should print "Cluster is left in unbalanced state" to logfile with latest timestamp
-         And ggrebalance should not print " Rolled back moves " to logfile with latest timestamp
+         And ggrebalance should not print " Rolled back steps " to logfile with latest timestamp
          And clear user's answers
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
          And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
@@ -831,11 +831,11 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should not print "Rolled back steps:" to logfile with latest timestamp
          And ggrebalance should not print "Cancelled steps:" to logfile with latest timestamp
          And ggrebalance should print " WARNINGS " to logfile with latest timestamp
-         And ggrebalance should print " Cancelled moves " to logfile with latest timestamp
+         And ggrebalance should print " Cancelled steps " to logfile with latest timestamp
          And ggrebalance should print "Cluster might be not in fault tolerance mode!" to logfile with latest timestamp
          And ggrebalance should print "These segments should be started manually in order cluster to become fault tolerant:" to logfile with latest timestamp
          And ggrebalance should print "Cluster is left in unbalanced state" to logfile with latest timestamp
-         And ggrebalance should not print " Rolled back moves " to logfile with latest timestamp
+         And ggrebalance should not print " Rolled back steps " to logfile with latest timestamp
          And clear user's answers
          # some mirrors are definitely down, so do not check them
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"


### PR DESCRIPTION
Adjust summary reporting code to make report more transparent.
GGRebalanceMainSM could duplicate rollbacked/cancelled moves
while printing the summary in print_rebalance_summary. Such behaviour
was caused by equating physical execution step (which is stored in
db schema) with logical move in function code. For e.x. if the primary
move is rollbacked, the same string is reported for SwitchoverToMirror,
MoveMirror, SwitchoverToPrimary steps.

This patch changes the summary generation logic by replacing logical
moves with physical step reporting. Corresponding unit test has been
added and current behave tests are adjusted as well.