### PR TITLE
Fix ggrebalance not failing when a parallel one is already running

### DIFF
--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -282,8 +282,13 @@ def remove_pid_file(coordinator_data_directory: str):
     """
     Removes ggrebalance pid file
     """
+    pid_filename = f'{coordinator_data_directory}/ggrebalance.pid'
     try:
-        os.unlink(coordinator_data_directory + '/ggrebalance.pid')
+        with open(pid_filename, 'r') as fp:
+            pid = int(fp.readline().strip())
+            if os.getpid() != pid:
+                return
+        os.unlink(pid_filename)
     except IOError:
         pass
 

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -340,6 +340,10 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance is already running." to logfile with latest timestamp
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance is already running." to logfile with latest timestamp
          And the background pid is killed on "coordinator" segment
          And a sample ggrebalance.pid file is removed from the coordinator_data_directory
          And all files in gpAdminLogs directory are deleted


### PR DESCRIPTION
Fix ggrebalance not failing when a parallel one is already running

Problem description:
If one instance of ggrebalance was already running, 1st attempt to launch
2nd instance of ggrebalance failed with proper error message, while the 2nd
attempt didn't fail.

Root cause:
ggrebalance creates the 'ggrebalance.pid' file in the coordinator data
directory, and removes it before each exit. ggrebalance didn't check the actual
PID value in the file before removing. Therefore, the 1st invocation attempt
(which failed with the proper error message) removed the PID file of the
already running ggrebalance instance. And the 2nd attempt didn't find the PID
file, and, therefore, started its work.

Fix:
Check the PID value in 'ggrebalance.pid' file before file removal and remove
the file only if it was created by the same process.