### PR TITLE
GG-561: Add autocompletion tests

### DIFF
--- a/configure
+++ b/configure
@@ -731,6 +731,7 @@ XML2_CONFIG
 with_libxml
 UUID_EXTRA_OBJS
 with_uuid
+with_readline
 with_systemd
 with_selinux
 with_openssl

--- a/configure.in
+++ b/configure.in
@@ -1018,6 +1018,7 @@ if test "$PORTNAME" = "win32"; then
     with_readline=no
   fi
 fi
+AC_SUBST(with_readline)
 
 
 #

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -196,6 +196,7 @@ with_perl	= @with_perl@
 with_python	= @with_python@
 with_tcl	= @with_tcl@
 with_openssl	= @with_openssl@
+with_readline = @with_readline@
 with_selinux	= @with_selinux@
 with_systemd	= @with_systemd@
 with_gssapi	= @with_gssapi@

--- a/src/bin/psql/.gitignore
+++ b/src/bin/psql/.gitignore
@@ -7,3 +7,4 @@
 /lex.backup
 
 /psql
+/tmp_check/

--- a/src/bin/psql/Makefile
+++ b/src/bin/psql/Makefile
@@ -16,6 +16,8 @@ subdir = src/bin/psql
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
+export with_readline
+
 REFDOCDIR= $(top_srcdir)/doc/src/sgml/ref
 
 override CPPFLAGS := -I. -I$(srcdir) -I$(libpq_srcdir) $(CPPFLAGS)
@@ -60,6 +62,7 @@ uninstall:
 
 clean distclean:
 	rm -f psql$(X) $(OBJS) lex.backup
+	rm -rf tmp_check
 
 # files removed here are supposed to be in the distribution tarball,
 # so do not clean them in the clean/distclean rules

--- a/src/bin/psql/Makefile
+++ b/src/bin/psql/Makefile
@@ -65,3 +65,9 @@ clean distclean:
 # so do not clean them in the clean/distclean rules
 maintainer-clean: distclean
 	rm -f sql_help.h sql_help.c psqlscanslash.c
+
+check:
+	$(prove_check)
+
+installcheck:
+	$(prove_installcheck)

--- a/src/bin/psql/t/010_tab_completion.pl
+++ b/src/bin/psql/t/010_tab_completion.pl
@@ -7,10 +7,10 @@ use Test::More;
 use Data::Dumper;
 
 # Do nothing unless Makefile has told us that the build is --with-readline.
-# if (!defined($ENV{with_readline}) || $ENV{with_readline} ne 'yes')
-# {
-# 	plan skip_all => 'readline is not supported by this build';
-# }
+if (!defined($ENV{with_readline}) || $ENV{with_readline} ne 'yes')
+{
+	plan skip_all => 'readline is not supported by this build';
+}
 
 # Also, skip if user has set environment variable to command that.
 # This is mainly intended to allow working around some of the more broken

--- a/src/bin/psql/t/010_tab_completion.pl
+++ b/src/bin/psql/t/010_tab_completion.pl
@@ -1,0 +1,203 @@
+use strict;
+use warnings;
+
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+use Data::Dumper;
+
+# Do nothing unless Makefile has told us that the build is --with-readline.
+# if (!defined($ENV{with_readline}) || $ENV{with_readline} ne 'yes')
+# {
+# 	plan skip_all => 'readline is not supported by this build';
+# }
+
+# Also, skip if user has set environment variable to command that.
+# This is mainly intended to allow working around some of the more broken
+# versions of libedit --- some users might find them acceptable even if
+# they won't pass these tests.
+if (defined($ENV{SKIP_READLINE_TESTS}))
+{
+	plan skip_all => 'SKIP_READLINE_TESTS is set';
+}
+
+# If we don't have IO::Pty, forget it, because IPC::Run depends on that
+# to support pty connections
+eval { require IO::Pty; };
+if ($@)
+{
+	plan skip_all => 'IO::Pty is needed to run this test';
+}
+
+# start a new server
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
+$node->start;
+
+# set up a few database objects
+$node->safe_psql('postgres',
+	    "CREATE TABLE tab1 (f1 int, f2 text);\n"
+	  . "CREATE TABLE mytab123 (f1 int, f2 text);\n"
+	  . "CREATE TABLE mytab246 (f1 int, f2 text);\n"
+	  . "CREATE TYPE enum1 AS ENUM ('foo', 'bar', 'baz');\n");
+
+# Developers would not appreciate this test adding a bunch of junk to
+# their ~/.psql_history, so be sure to redirect history into a temp file.
+# We might as well put it in the test log directory, so that buildfarm runs
+# capture the result for possible debugging purposes.
+my $historyfile = "${PostgreSQL::Test::Utils::log_path}/010_psql_history.txt";
+$ENV{PSQL_HISTORY} = $historyfile;
+
+# Another pitfall for developers is that they might have a ~/.inputrc
+# file that changes readline's behavior enough to affect this test.
+# So ignore any such file.
+$ENV{INPUTRC} = '/dev/null';
+
+# Unset $TERM so that readline/libedit won't use any terminal-dependent
+# escape sequences; that leads to way too many cross-version variations
+# in the output.
+delete $ENV{TERM};
+# Some versions of readline inspect LS_COLORS, so for luck unset that too.
+delete $ENV{LS_COLORS};
+
+# In a VPATH build, we'll be started in the source directory, but we want
+# to run in the build directory so that we can use relative paths to
+# access the tmp_check subdirectory; otherwise the output from filename
+# completion tests is too variable.
+if ($ENV{TESTDIR})
+{
+	chdir $ENV{TESTDIR} or die "could not chdir to \"$ENV{TESTDIR}\": $!";
+}
+
+# Create some junk files for filename completion testing.
+my $FH;
+open $FH, ">", "tmp_check/somefile"
+  or die("could not create file \"tmp_check/somefile\": $!");
+print $FH "some stuff\n";
+close $FH;
+open $FH, ">", "tmp_check/afile123"
+  or die("could not create file \"tmp_check/afile123\": $!");
+print $FH "more stuff\n";
+close $FH;
+open $FH, ">", "tmp_check/afile456"
+  or die("could not create file \"tmp_check/afile456\": $!");
+print $FH "other stuff\n";
+close $FH;
+
+# fire up an interactive psql session
+my $h = $node->interactive_psql('postgres');
+
+# Simple test case: type something and see if psql responds as expected
+sub check_completion
+{
+	my ($send, $pattern, $annotation) = @_;
+
+	# report test failures from caller location
+	local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+	# restart per-command timer
+	$h->{timeout}->start($PostgreSQL::Test::Utils::timeout_default);
+
+	# send the data to be sent and wait for its result
+	my $out = $h->query_until($pattern, $send);
+	my $okay = ($out =~ $pattern && !$h->{timeout}->is_expired);
+	ok($okay, $annotation);
+	# for debugging, log actual output if it didn't match
+	local $Data::Dumper::Terse = 1;
+	local $Data::Dumper::Useqq = 1;
+	diag 'Actual output was ' . Dumper($out) . "Did not match \"$pattern\"\n"
+	  if !$okay;
+	return;
+}
+
+# Clear query buffer to start over
+# (won't work if we are inside a string literal!)
+sub clear_query
+{
+	local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+	check_completion("\\r\n", qr/postgres=# /, "\\r works");
+	return;
+}
+
+# Clear current line to start over
+# (this will work in an incomplete string literal, but it's less desirable
+# than clear_query because we lose evidence in the history file)
+sub clear_line
+{
+	local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+	check_completion("\025\n", qr/postgres=# /, "control-U works");
+	return;
+}
+
+# check basic command completion: SEL<tab> produces SELECT<space>
+check_completion("SEL\t", qr/SELECT /, "complete SEL<tab> to SELECT");
+
+clear_query();
+
+# check case variation is honored
+check_completion("sel\t", qr/select /, "complete sel<tab> to select");
+
+# check basic table name completion
+check_completion("* from t\t", qr/\* from tab1 /, "complete t<tab> to tab1");
+
+clear_query();
+
+# check table name completion with multiple alternatives
+# note: readline might print a bell before the completion
+check_completion(
+	"select * from my\t",
+	qr/select \* from my\a?tab/,
+	"complete my<tab> to mytab when there are multiple choices");
+
+# some versions of readline/libedit require two tabs here, some only need one
+check_completion(
+	"\t\t",
+	qr/mytab123 +mytab246/,
+	"offer multiple table choices");
+
+check_completion("2\t", qr/246 /,
+	"finish completion of one of multiple table choices");
+
+clear_query();
+
+# check case-sensitive keyword replacement
+# note: various versions of readline/libedit handle backspacing
+# differently, so just check that the replacement comes out correctly
+check_completion("\\DRD\t", qr/drds /, "complete \\DRD<tab> to \\drds");
+
+clear_query();
+
+# check filename completion
+check_completion(
+	"\\lo_import tmp_check/some\t",
+	qr|tmp_check/somefile |,
+	"filename completion with one possibility");
+
+clear_query();
+
+# note: readline might print a bell before the completion
+check_completion(
+	"\\lo_import tmp_check/af\t",
+	qr|tmp_check/af\a?ile|,
+	"filename completion with multiple possibilities");
+
+clear_query();
+
+# check enum label completion
+# some versions of readline/libedit require two tabs here, some only need one
+# also, some versions will offer quotes, some will not
+check_completion(
+	"ALTER TYPE enum1 RENAME VALUE 'ba\t\t",
+	qr|'?bar'? +'?baz'?|,
+	"offer multiple enum choices");
+
+clear_line();
+
+# send psql an explicit \q to shut it down, else pty won't close properly
+$h->quit or die "psql returned $?";
+
+# done
+$node->stop;
+done_testing();

--- a/src/test/perl/PostgreSQL/Test/Cluster.pm
+++ b/src/test/perl/PostgreSQL/Test/Cluster.pm
@@ -1553,6 +1553,28 @@ sub _get_env
 	return (%inst_env);
 }
 
+# Private routine to get an installation path qualified command.
+#
+# IPC::Run maintains a cache, %cmd_cache, mapping commands to paths.  Tests
+# which use nodes spanning more than one postgres installation path need to
+# avoid confusing which installation's binaries get run.  Setting $ENV{PATH} is
+# insufficient, as IPC::Run does not check to see if the path has changed since
+# caching a command.
+sub installed_command
+{
+	my ($self, $cmd) = @_;
+
+	# Nodes using alternate installation locations use their installation's
+	# bin/ directory explicitly
+	return join('/', $self->{_install_path}, 'bin', $cmd)
+	  if defined $self->{_install_path};
+
+	# Nodes implicitly using the default installation location rely on IPC::Run
+	# to find the right binary, which should not cause %cmd_cache confusion,
+	# because no nodes with other installation paths do it that way.
+	return $cmd;
+}
+
 =pod
 
 =item get_free_port()


### PR DESCRIPTION
psql lacked automatic testing for autocompletion.

Add support for autcompletion tests.

Main part of changes taken from 7c015045b9141cc30272930ea88cfa5df47240b7
010_tab_completion.pl taken as in postgres/postgres@12f327b210b3b093e09778ec05fd44bbee4b0736
installed_command function taken from 95c3a1956ec9eac686c1b69b033dd79211b72343

Co-authored by: Andrew Dunstan <andrew@dunslane.net>
Co-authored by: Heikki Linnakangas <heikki.linnakangas@iki.fi>
Co-authored by: Tom Lane <tgl@sss.pgh.pa.us>
Co-authored by: Michael Paquier <michael@paquier.xyz>
Co-authored by: Noah Misch <noah@leadboat.com>