### PR TITLE
Fix wrong message on consequent calls of ggrebalance after rebalance is done

### DIFF
--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
@@ -32,8 +32,8 @@ class GGRebalanceMainSM:
         'STATE_PLANNING_STARTED',
         'STATE_PLANNING_DONE',
         'STATE_CHECK_PREVIOUS_RUN',
-        'STATE_END',
-        'STATE_ERROR'
+        'STATE_ERROR',
+        'STATE_END_DUMMY'
     ]
 
     states_logged = [
@@ -46,6 +46,7 @@ class GGRebalanceMainSM:
         'STATE_SHRINK_DONE',
         'STATE_REBALANCE_STARTED',
         'STATE_REBALANCE_DONE',
+        'STATE_END'
     ]
 
     transitions = [
@@ -121,8 +122,13 @@ class GGRebalanceMainSM:
         },
         {
             'trigger': 'move_to_STATE_END',
-            'source': ['STATE_EXECUTOR_DONE', 'STATE_CHECK_PREVIOUS_RUN', 'STATE_CLEANUP', 'STATE_ROLLBACK', 'STATE_PLANNING_STARTED'],
+            'source': ['STATE_EXECUTOR_DONE', 'STATE_CHECK_PREVIOUS_RUN', 'STATE_CLEANUP', 'STATE_ROLLBACK', 'STATE_PLANNING_STARTED', 'STATE_CHECK_PREVIOUS_RUN'],
             'dest': 'STATE_END'
+        },
+        {
+            'trigger': 'move_to_STATE_END_DUMMY',
+            'source': 'STATE_END',
+            'dest': 'STATE_END_DUMMY'
         },
         {
             'trigger': 'move_to_STATE_ERROR',
@@ -365,8 +371,9 @@ class GGRebalanceMainSM:
             # In this case we already have a plan saved in the schema,
             # and we'll continue (or rollback) according to it.
             # Or, if everything is complete, just exit.
-            if self.main_state_from_prev_run == 'STATE_EXECUTOR_DONE':
+            if self.main_state_from_prev_run == 'STATE_END':
                 self.logger.info('Previous run was completed successfully. Please execute cleanup before a new run.')
+                self.trigger('move_to_STATE_END')
                 return
 
             if self.plan != None:
@@ -436,6 +443,7 @@ class GGRebalanceMainSM:
     @wrap_func_with_faults
     def on_enter_STATE_END(self) -> None:
         self.print_full_summary()
+        self.trigger('move_to_STATE_END_DUMMY')
 
     @wrap_func_with_faults
     def on_enter_STATE_ERROR(self) -> None:

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
@@ -164,6 +164,11 @@ class GGRebalanceMainSM:
             self.rebalance_schema.storeMainState(self.state)
 
     def run(self) -> None:
+        # Do some early checks here before we store any state in the rebalance schema,
+        # in order not to spoil the last state if it was the final one.
+        if not (self.options.clean_required or self.options.rollback_required) and self.main_state_from_prev_run == 'STATE_EXECUTOR_DONE':
+            self.logger.info('Previous run was completed successfully. Please execute cleanup before a new run.')
+            return
         self.trigger('start')
 
     def set_hard_shutdown(self, hard_shutdown: bool) -> None:
@@ -364,11 +369,6 @@ class GGRebalanceMainSM:
             # Schema already exists from the previous run.
             # In this case we already have a plan saved in the schema,
             # and we'll continue (or rollback) according to it.
-            # Or, if everything is complete, just exit.
-            if self.main_state_from_prev_run == 'STATE_EXECUTOR_DONE':
-                self.logger.info('Previous run was completed successfully. Please execute cleanup before a new run.')
-                return
-
             if self.plan != None:
                 self.logger.error("Can't start a new operation, because the previous one was interrupted. "
                                   "Please try to launch again without a plan to continue from the interrupted state, "

--- a/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/ggrebalance_modules/ggrebalance_main_sm.py
@@ -32,8 +32,8 @@ class GGRebalanceMainSM:
         'STATE_PLANNING_STARTED',
         'STATE_PLANNING_DONE',
         'STATE_CHECK_PREVIOUS_RUN',
-        'STATE_ERROR',
-        'STATE_END_DUMMY'
+        'STATE_END',
+        'STATE_ERROR'
     ]
 
     states_logged = [
@@ -46,7 +46,6 @@ class GGRebalanceMainSM:
         'STATE_SHRINK_DONE',
         'STATE_REBALANCE_STARTED',
         'STATE_REBALANCE_DONE',
-        'STATE_END'
     ]
 
     transitions = [
@@ -122,13 +121,8 @@ class GGRebalanceMainSM:
         },
         {
             'trigger': 'move_to_STATE_END',
-            'source': ['STATE_EXECUTOR_DONE', 'STATE_CHECK_PREVIOUS_RUN', 'STATE_CLEANUP', 'STATE_ROLLBACK', 'STATE_PLANNING_STARTED', 'STATE_CHECK_PREVIOUS_RUN'],
+            'source': ['STATE_EXECUTOR_DONE', 'STATE_CHECK_PREVIOUS_RUN', 'STATE_CLEANUP', 'STATE_ROLLBACK', 'STATE_PLANNING_STARTED'],
             'dest': 'STATE_END'
-        },
-        {
-            'trigger': 'move_to_STATE_END_DUMMY',
-            'source': 'STATE_END',
-            'dest': 'STATE_END_DUMMY'
         },
         {
             'trigger': 'move_to_STATE_ERROR',
@@ -371,9 +365,8 @@ class GGRebalanceMainSM:
             # In this case we already have a plan saved in the schema,
             # and we'll continue (or rollback) according to it.
             # Or, if everything is complete, just exit.
-            if self.main_state_from_prev_run == 'STATE_END':
+            if self.main_state_from_prev_run == 'STATE_EXECUTOR_DONE':
                 self.logger.info('Previous run was completed successfully. Please execute cleanup before a new run.')
-                self.trigger('move_to_STATE_END')
                 return
 
             if self.plan != None:
@@ -443,7 +436,6 @@ class GGRebalanceMainSM:
     @wrap_func_with_faults
     def on_enter_STATE_END(self) -> None:
         self.print_full_summary()
-        self.trigger('move_to_STATE_END_DUMMY')
 
     @wrap_func_with_faults
     def on_enter_STATE_ERROR(self) -> None:

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
@@ -101,6 +101,14 @@ Feature: ggrebalance behave tests
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Previous run was completed successfully. Please execute cleanup before a new run." to logfile with latest timestamp
          And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Previous run was completed successfully. Please execute cleanup before a new run." to logfile with latest timestamp
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Previous run was completed successfully. Please execute cleanup before a new run." to logfile with latest timestamp
+         And all files in gpAdminLogs directory are deleted
         When the user runs "ggrebalance -r"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "No steps to rollback found for rebalance" to logfile with latest timestamp

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
@@ -96,6 +96,11 @@ Feature: ggrebalance behave tests
         When the user runs "ggrebalance -x 1 --skip-rebalance"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Previous run was completed successfully. Please execute cleanup before a new run." to logfile with latest timestamp
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -x 1 --skip-rebalance"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Previous run was completed successfully. Please execute cleanup before a new run." to logfile with latest timestamp
+         And all files in gpAdminLogs directory are deleted
         When the user runs "ggrebalance -r"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "No steps to rollback found for rebalance" to logfile with latest timestamp


### PR DESCRIPTION
Fix wrong message on consequent calls of ggrebalance after rebalance is done

Problem description:
After ggrebalance has finished cluster shrink, the 2nd call to ggrebalance
provides the proper message 'Previous run was completed successfully. Please
execute cleanup before a new run.'. But 3rd call did not do so, it launched
the last state of shrink and printed the result summary. And the next
consequent call to to rebalance provided a proper message, while the next
one after again tried to launch shrink, and so on...

Root cause:
In order to show proper message, ggrebalance checks the last finished state
taken from the ggrebalance schema. If it is 'STATE_EXECUTOR_DONE', message is
shown, and execution is stopped. The last finished state is extracted from the 
ggrebalance schema at the init stage of ggrebalance main state machine creation.
But we did the check when the main state machine had already stored it's 1st
state ('STATE_START') in the ggrebalance schema. Therefore, on the next call,
the last finished state was 'STATE_START', and ggrebalance tried to continue
interrupted operation, printed final summary, and stored again
'STATE_EXECUTOR_DONE' in the schema. Therefore, we got such loop with switching
behavior.

Fix:
Move the check of the last finished state to an earlier stage, before triggering
the first state of the main state machine. Therefore, if the state is final, we
do not store any new state in the ggrebalance schema. Also, when doing check
in the new place, we also need to consider 'clean_required' and
'rollback_required' options.