### PR TITLE
GG-518: Improve autocomplete for some misc. commands

### DIFF
--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2407,10 +2407,19 @@ psql_completion(const char *text, int start, int end)
 
 	/* Handle COPY [BINARY] <sth> FROM|TO filename */
 	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny))
-		COMPLETE_WITH("BINARY", "DELIMITER", "NULL", "CSV",
+		COMPLETE_WITH("BINARY", "DELIMITER", "NULL", "CSV", "WITH",
 					  "ENCODING", "FREEZE", "FILL MISSING FIELDS", "NEWLINE",
 					  "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
 	else if (Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny))
+		COMPLETE_WITH("CSV", "ENCODING", "FREEZE", "FILL MISSING FIELDS",
+					  "WITH", "NEWLINE", "ON SEGMENT",
+					  "IGNORE EXTERNAL PARTITIONS");
+
+	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny, "WITH"))
+		COMPLETE_WITH("BINARY", "DELIMITER", "NULL", "CSV",
+					  "ENCODING", "FREEZE", "FILL MISSING FIELDS", "NEWLINE",
+					  "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
+	else if (Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny, "WITH"))
 		COMPLETE_WITH("CSV", "ENCODING", "FREEZE", "FILL MISSING FIELDS",
 					  "NEWLINE", "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
 

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -3328,7 +3328,7 @@ psql_completion(const char *text, int start, int end)
 		 * one word, so the above test is correct.
 		 */
 		if (ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
-			COMPLETE_WITH("ANALYZE", "VERBOSE", "DXL", "COSTS", "SETTINGS",
+			COMPLETE_WITH_UNUSED_OPTIONS("ANALYZE", "VERBOSE", "DXL", "COSTS", "SETTINGS",
 						  "BUFFERS", "TIMING", "SUMMARY", "FORMAT");
 		else if (TailMatches("ANALYZE|VERBOSE|DXL|COSTS|SETTINGS|BUFFERS|TIMING|SUMMARY"))
 			COMPLETE_WITH("ON", "OFF");
@@ -3976,7 +3976,7 @@ psql_completion(const char *text, int start, int end)
 		 * one word, so the above test is correct.
 		 */
 		if (ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
-			COMPLETE_WITH("FULL", "FREEZE", "ANALYZE", "VERBOSE", "AO_AUX_ONLY",
+			COMPLETE_WITH_UNUSED_OPTIONS("FULL", "FREEZE", "ANALYZE", "VERBOSE", "AO_AUX_ONLY",
 						  "DISABLE_PAGE_SKIPPING", "SKIP_LOCKED",
 						  "INDEX_CLEANUP", "TRUNCATE", "PARALLEL", "SKIP_DATABASE_STATS",
 						  "ONLY_DATABASE_STATS");

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1836,20 +1836,20 @@ psql_completion(const char *text, int start, int end)
 					  "RENAME TO", "REPLICATION", "RESET", "SET", "SUPERUSER",
 					  "VALID UNTIL");
 
-	else if(TailMatches("DENY") && !TailMatches("DROP", "DENY"))
+	else if (TailMatches("DENY") && !TailMatches("DROP", "DENY"))
 		COMPLETE_WITH("DAY", "BETWEEN DAY");
-	else if(TailMatches("DROP", "DENY", "FOR"))
+	else if (TailMatches("DROP", "DENY", "FOR"))
 		COMPLETE_WITH("DAY");
-	else if(TailMatches("DAY"))
+	else if (TailMatches("DAY"))
 		COMPLETE_WITH("'Monday'", "'Tuesday'", "'Wednesday'", "'Thursday'",
 					  "'Friday'", "'Saturday'", "'Sunday'");
-	else if(TailMatches("DENY", "DAY", MatchAny) ||
+	else if (TailMatches("DENY", "DAY", MatchAny) ||
 			TailMatches("AND", "DAY", MatchAny) ||
 			TailMatches("FOR", "DAY", MatchAny))
 		COMPLETE_WITH("TIME");
-	else if(TailMatches("DENY", "BETWEEN", "DAY", MatchAny))
+	else if (TailMatches("DENY", "BETWEEN", "DAY", MatchAny))
 		COMPLETE_WITH("AND DAY", "TIME");
-	else if(TailMatches("DENY", "BETWEEN", "DAY", MatchAny, "TIME", "'*'") ||
+	else if (TailMatches("DENY", "BETWEEN", "DAY", MatchAny, "TIME", "'*'") ||
 			TailMatches("DENY", "BETWEEN", "DAY", MatchAny, "TIME", "'*", "PM'|AM'"))
 		COMPLETE_WITH("AND DAY");
 
@@ -2216,7 +2216,7 @@ psql_completion(const char *text, int start, int end)
 	/* complete ALTER TYPE <foo> ADD with actions */
 	else if (Matches("ALTER", "TYPE", MatchAny, "ADD"))
 		COMPLETE_WITH("ATTRIBUTE", "VALUE");
-	else if(Matches("ALTER", "TYPE", MatchAny, "SET"))
+	else if (Matches("ALTER", "TYPE", MatchAny, "SET"))
 		COMPLETE_WITH_SUPPRESS_APPEND("SCHEMA ", "DEFAULT ENCODING (");
 	/* ALTER TYPE <foo> RENAME	*/
 	else if (Matches("ALTER", "TYPE", MatchAny, "RENAME"))
@@ -2250,9 +2250,9 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("ALTER", "TYPE", MatchAny, "RENAME", "VALUE"))
 		COMPLETE_WITH_ENUM_VALUE(prev3_wd);
 
-	else if(Matches("ALTER", "TYPE", MatchAny, "SET", "DEFAULT", "ENCODING", "("))
+	else if (Matches("ALTER", "TYPE", MatchAny, "SET", "DEFAULT", "ENCODING", "("))
 		COMPLETE_WITH("COMPRESSTYPE =", "COMPRESSLEVEL =", "BLOCKSIZE =");
-	else if(Matches("ALTER", "TYPE", MatchAny, "SET", "DEFAULT", "ENCODING", "(", "COMPRESSTYPE", "="))
+	else if (Matches("ALTER", "TYPE", MatchAny, "SET", "DEFAULT", "ENCODING", "(", "COMPRESSTYPE", "="))
 		COMPLETE_WITH("ZLIB", "ZSTD", "RLE_TYPE", "NONE");
 
 /*
@@ -2354,7 +2354,7 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH_QUERY(Query_for_list_of_access_methods);
 	else if (Matches("COMMENT", "ON", "FOREIGN"))
 		COMPLETE_WITH("DATA WRAPPER", "TABLE");
-	else if(Matches("COMMENT", "ON", "RESOURCE"))
+	else if (Matches("COMMENT", "ON", "RESOURCE"))
 		COMPLETE_WITH("GROUP", "QUEUE");
 	else if (Matches("COMMENT", "ON", "RESOURCE", "GROUP"))
 		COMPLETE_WITH_QUERY(Query_for_list_of_resgroups);
@@ -2412,7 +2412,7 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH("BINARY", "DELIMITER", "NULL", "CSV",
 					  "ENCODING", "FREEZE", "FILL MISSING FILEDS", "NEWLINE",
 					  "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
-	else if(Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny))
+	else if (Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny))
 		COMPLETE_WITH("CSV", "ENCODING", "FREEZE", "FILL MISSING FILEDS",
 					  "NEWLINE", "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
 

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2407,25 +2407,42 @@ psql_completion(const char *text, int start, int end)
 	}
 
 	/* Handle COPY [BINARY] <sth> FROM|TO filename */
-	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny))
+	else if (Matches("COPY|\\copy", MatchAny, "FROM", MatchAny))
 		COMPLETE_WITH("BINARY", "DELIMITER", "NULL", "CSV", "WITH",
 					  "ENCODING", "FREEZE", "FILL MISSING FIELDS", "NEWLINE",
-					  "LOG ERRORS", "ON SEGMENT", "ESCAPE", "HEADER",
-					  "IGNORE EXTERNAL PARTITIONS");
-	else if (Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny))
+					  "LOG ERRORS", "SEGMENT REJECT LIMIT", "ON SEGMENT",
+					  "ESCAPE", "HEADER", "IGNORE EXTERNAL PARTITIONS");
+	else if (Matches("COPY", "BINARY", MatchAny, "FROM", MatchAny))
 		COMPLETE_WITH("ENCODING", "FREEZE", "FILL MISSING FIELDS", "ESCAPE",
 					  "WITH", "NEWLINE", "ON SEGMENT", "LOG ERRORS",
+					  "SEGMENT REJECT LIMIT", "IGNORE EXTERNAL PARTITIONS");
+	else if (Matches("COPY|\\copy", MatchAny, "TO", MatchAny))
+		COMPLETE_WITH("BINARY", "DELIMITER", "NULL", "CSV", "WITH",
+					  "ENCODING", "FREEZE", "FILL MISSING FIELDS", "NEWLINE",
+					  "ON SEGMENT", "ESCAPE", "HEADER",
+					  "IGNORE EXTERNAL PARTITIONS");
+	else if (Matches("COPY", "BINARY", MatchAny, "TO", MatchAny))
+		COMPLETE_WITH("ENCODING", "FREEZE", "FILL MISSING FIELDS", "ESCAPE",
+					  "WITH", "NEWLINE", "ON SEGMENT",
 					  "IGNORE EXTERNAL PARTITIONS");
 
-	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny, "WITH"))
-		COMPLETE_WITH("BINARY", "DELIMITER", "NULL", "CSV",
-					  "ENCODING", "FREEZE", "FILL MISSING FIELDS", "NEWLINE",
-					  "LOG ERRORS","ON SEGMENT", "HEADER", "ESCAPE",
+	/* Handle COPY [BINARY] <sth> FROM|TO filename WITH */
+	else if (Matches("COPY|\\copy", MatchAny, "FROM", MatchAny, "WITH"))
+		COMPLETE_WITH("BINARY", "DELIMITER", "NULL", "CSV", "ENCODING",
+					  "FREEZE", "FILL MISSING FIELDS", "NEWLINE", "LOG ERRORS",
+					  "SEGMENT REJECT LIMIT", "ON SEGMENT", "ESCAPE", "HEADER",
 					  "IGNORE EXTERNAL PARTITIONS");
-	else if (Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny, "WITH"))
-		COMPLETE_WITH("ENCODING", "FREEZE", "FILL MISSING FIELDS",
-					  "NEWLINE", "ON SEGMENT", "LOG ERRORS", "ESCAPE",
-					  "IGNORE EXTERNAL PARTITIONS");
+	else if (Matches("COPY", "BINARY", MatchAny, "FROM", MatchAny, "WITH"))
+		COMPLETE_WITH("ENCODING", "FREEZE", "FILL MISSING FIELDS", "ESCAPE",
+					  "NEWLINE", "ON SEGMENT", "LOG ERRORS",
+					  "SEGMENT REJECT LIMIT", "IGNORE EXTERNAL PARTITIONS");
+	else if (Matches("COPY|\\copy", MatchAny, "TO", MatchAny, "WITH"))
+		COMPLETE_WITH("BINARY", "DELIMITER", "NULL", "CSV", "ENCODING",
+					  "FREEZE", "FILL MISSING FIELDS", "NEWLINE", "ON SEGMENT",
+					  "ESCAPE", "HEADER", "IGNORE EXTERNAL PARTITIONS");
+	else if (Matches("COPY", "BINARY", MatchAny, "TO", MatchAny, "WITH"))
+		COMPLETE_WITH("ENCODING", "FREEZE", "FILL MISSING FIELDS", "ESCAPE",
+					  "NEWLINE", "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
 
 	/* Handle COPY [BINARY] <sth> FROM filename CSV */
 	else if (Matches("COPY|\\copy", MatchAny, "FROM", MatchAny, "CSV"))
@@ -2438,10 +2455,13 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("COPY|\\copy", MatchAny, "TO", MatchAny, "CSV"))
 		COMPLETE_WITH("HEADER", "QUOTE", "ESCAPE", "FORCE QUOTE");
 
-	else if(HeadMatches("COPY|\\copy", MatchAny) && TailMatches("LOG", "ERRORS"))
-		COMPLETE_WITH("", "SEGMENT REJECT LIMIT");
-	else if(HeadMatches("COPY|\\copy", MatchAny) &&
-			TailMatches("LOG", "ERRORS", "SEGMENT", "REJECT", "LIMIT", MatchAny))
+	else if((HeadMatches("COPY|\\copy", MatchAny, "FROM") ||
+			 HeadMatches("COPY", "BINARY", MatchAny, "FROM")) &&
+			 TailMatches("LOG", "ERRORS"))
+		COMPLETE_WITH("SEGMENT REJECT LIMIT");
+	else if((HeadMatches("COPY|\\copy", MatchAny, "FROM") ||
+			 HeadMatches("COPY", "BINARY", MatchAny, "FROM")) &&
+			 TailMatches("SEGMENT", "REJECT", "LIMIT", MatchAny))
 		COMPLETE_WITH("ROWS", "PERCENT");
 
 

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2410,10 +2410,10 @@ psql_completion(const char *text, int start, int end)
 	/* Handle COPY [BINARY] <sth> FROM|TO filename */
 	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny))
 		COMPLETE_WITH("BINARY", "DELIMITER", "NULL", "CSV",
-					  "ENCODING", "FREEZE", "FILL MISSING FILEDS", "NEWLINE",
+					  "ENCODING", "FREEZE", "FILL MISSING FIELDS", "NEWLINE",
 					  "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
 	else if (Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny))
-		COMPLETE_WITH("CSV", "ENCODING", "FREEZE", "FILL MISSING FILEDS",
+		COMPLETE_WITH("CSV", "ENCODING", "FREEZE", "FILL MISSING FIELDS",
 					  "NEWLINE", "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
 
 	/* Handle COPY [BINARY] <sth> FROM filename CSV */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2217,7 +2217,7 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("ALTER", "TYPE", MatchAny, "ADD"))
 		COMPLETE_WITH("ATTRIBUTE", "VALUE");
 	else if(Matches("ALTER", "TYPE", MatchAny, "SET"))
-		COMPLETE_WITH("SCHEMA", "DEFAULT ENCODING (");
+		COMPLETE_WITH_SUPPRESS_APPEND("SCHEMA ", "DEFAULT ENCODING (");
 	/* ALTER TYPE <foo> RENAME	*/
 	else if (Matches("ALTER", "TYPE", MatchAny, "RENAME"))
 		COMPLETE_WITH("ATTRIBUTE", "TO", "VALUE");
@@ -2408,21 +2408,28 @@ psql_completion(const char *text, int start, int end)
 	}
 
 	/* Handle COPY [BINARY] <sth> FROM|TO filename */
-	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny) ||
-			 Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny))
+	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny))
 		COMPLETE_WITH("BINARY", "DELIMITER", "NULL", "CSV",
 					  "ENCODING", "FREEZE", "FILL MISSING FILEDS", "NEWLINE",
 					  "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
+	else if(Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny))
+		COMPLETE_WITH("CSV", "ENCODING", "FREEZE", "FILL MISSING FILEDS",
+					  "NEWLINE", "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
 
-	/* Handle COPY [BINARY] <sth> FROM|TO filename CSV */
-	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny, "CSV") ||
-			 Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny, "CSV"))
-		COMPLETE_WITH("HEADER", "QUOTE", "ESCAPE", "FORCE QUOTE", "FORCE NULL",
+	/* Handle COPY [BINARY] <sth> FROM filename CSV */
+	else if (Matches("COPY|\\copy", MatchAny, "FROM", MatchAny, "CSV") ||
+			 Matches("COPY", "BINARY", MatchAny, "FROM", MatchAny, "CSV"))
+		COMPLETE_WITH("HEADER", "QUOTE", "ESCAPE", "FORCE NULL",
 					  "FORCE NOT NULL");
+	else if (Matches("COPY|\\copy", MatchAny, "FROM", MatchAny, "CSV", "FORCE") ||
+			 Matches("COPY", "BINARY", MatchAny, "FROM", MatchAny, "CSV", "FORCE"))
+		COMPLETE_WITH("NULL", "NOT NULL");
 
-	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny, "CSV", "FORCE") ||
-			 Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny, "CSV", "FORCE"))
-		COMPLETE_WITH("QUOTE", "NULL", "NOT NULL");
+	/* Handle COPY [BINARY] <sth> TO filename CSV */
+	else if (Matches("COPY|\\copy", MatchAny, "TO", MatchAny, "CSV") ||
+			 Matches("COPY", "BINARY", MatchAny, "TO", MatchAny, "CSV"))
+		COMPLETE_WITH("HEADER", "QUOTE", "ESCAPE", "FORCE QUOTE");
+
 
 	/* CREATE ACCESS METHOD */
 	/* Complete "CREATE ACCESS METHOD <name>" */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1714,6 +1714,7 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("ALTER", "USER|ROLE", MatchAny) &&
 			 !TailMatches("USER", "MAPPING"))
 		COMPLETE_WITH("BYPASSRLS", "CONNECTION LIMIT", "CREATEDB", "CREATEROLE",
+					  "DENY", "DROP DENY FOR",
 					  "ENCRYPTED PASSWORD", "INHERIT", "LOGIN", "NOBYPASSRLS",
 					  "NOCREATEDB", "NOCREATEROLE", "NOINHERIT",
 					  "NOLOGIN", "NOREPLICATION", "NOSUPERUSER", "PASSWORD",
@@ -1724,11 +1725,19 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("ALTER", "USER|ROLE", MatchAny, "WITH"))
 		/* Similar to the above, but don't complete "WITH" again. */
 		COMPLETE_WITH("BYPASSRLS", "CONNECTION LIMIT", "CREATEDB", "CREATEROLE",
+					  "DENY", "DENY BETWEEN", "DROP DENY FOR",
 					  "ENCRYPTED PASSWORD", "INHERIT", "LOGIN", "NOBYPASSRLS",
 					  "NOCREATEDB", "NOCREATEROLE", "NOINHERIT",
 					  "NOLOGIN", "NOREPLICATION", "NOSUPERUSER", "PASSWORD",
 					  "RENAME TO", "REPLICATION", "RESET", "SET", "SUPERUSER",
 					  "VALID UNTIL");
+
+	else if(TailMatches("DENY") && !TailMatches("DROP", "DENY"))
+		COMPLETE_WITH("DAY", "BETWEEN DAY");
+	else if(TailMatches("DENY", "BETWEEN", "DAY", MatchAny) ||
+			TailMatches("DENY", "BETWEEN", "DAY", MatchAny, "TIME", "'*'") ||
+			TailMatches("DENY", "BETWEEN", "DAY", MatchAny, "TIME", "'*", "PM'|AM'"))
+		COMPLETE_WITH("AND DAY");
 
 	/* ALTER DEFAULT PRIVILEGES */
 	else if (Matches("ALTER", "DEFAULT", "PRIVILEGES"))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2276,7 +2276,18 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny) ||
 			 Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny))
 		COMPLETE_WITH("BINARY", "DELIMITER", "NULL", "CSV",
-					  "ENCODING");
+					  "ENCODING", "FREEZE", "HEADER", "QUOTE", "ESCAPE",
+					  "FORCE QUOTE", "FORCE NULL", "FILL MISSING FILEDS",
+					  "NEWLINE", "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS",
+					  "IGNORE FOREIGN PARTITIONS");
+
+	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny, "IGNORE") ||
+			 Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny, "IGNORE"))
+		COMPLETE_WITH("EXTERNAL PARTITIONS", "FOREIGN PARTITIONS");
+
+	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny, "FORCE") ||
+			 Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny, "FORCE"))
+		COMPLETE_WITH("QUOTE", "NULL");
 
 	/* Handle COPY [BINARY] <sth> FROM|TO filename CSV */
 	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny, "CSV") ||

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2400,24 +2400,18 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny) ||
 			 Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny))
 		COMPLETE_WITH("BINARY", "DELIMITER", "NULL", "CSV",
-					  "ENCODING", "FREEZE", "HEADER", "QUOTE", "ESCAPE",
-					  "FORCE QUOTE", "FORCE NULL", "FILL MISSING FILEDS",
-					  "NEWLINE", "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS",
-					  "IGNORE FOREIGN PARTITIONS");
-
-	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny, "IGNORE") ||
-			 Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny, "IGNORE"))
-		COMPLETE_WITH("EXTERNAL PARTITIONS", "FOREIGN PARTITIONS");
-
-	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny, "FORCE") ||
-			 Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny, "FORCE"))
-		COMPLETE_WITH("QUOTE", "NULL");
+					  "ENCODING", "FREEZE", "FILL MISSING FILEDS", "NEWLINE",
+					  "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
 
 	/* Handle COPY [BINARY] <sth> FROM|TO filename CSV */
 	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny, "CSV") ||
 			 Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny, "CSV"))
-		COMPLETE_WITH("HEADER", "QUOTE", "ESCAPE", "FORCE QUOTE",
+		COMPLETE_WITH("HEADER", "QUOTE", "ESCAPE", "FORCE QUOTE", "FORCE NULL",
 					  "FORCE NOT NULL");
+
+	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny, "CSV", "FORCE") ||
+			 Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny, "CSV", "FORCE"))
+		COMPLETE_WITH("QUOTE", "NULL", "NOT NULL");
 
 	/* CREATE ACCESS METHOD */
 	/* Complete "CREATE ACCESS METHOD <name>" */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2409,19 +2409,22 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny))
 		COMPLETE_WITH("BINARY", "DELIMITER", "NULL", "CSV", "WITH",
 					  "ENCODING", "FREEZE", "FILL MISSING FIELDS", "NEWLINE",
-					  "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
+					  "LOG ERRORS", "ON SEGMENT", "ESCAPE", "HEADER",
+					  "IGNORE EXTERNAL PARTITIONS");
 	else if (Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny))
-		COMPLETE_WITH("ENCODING", "FREEZE", "FILL MISSING FIELDS",
-					  "WITH", "NEWLINE", "ON SEGMENT",
+		COMPLETE_WITH("ENCODING", "FREEZE", "FILL MISSING FIELDS", "ESCAPE",
+					  "WITH", "NEWLINE", "ON SEGMENT", "LOG ERRORS",
 					  "IGNORE EXTERNAL PARTITIONS");
 
 	else if (Matches("COPY|\\copy", MatchAny, "FROM|TO", MatchAny, "WITH"))
 		COMPLETE_WITH("BINARY", "DELIMITER", "NULL", "CSV",
 					  "ENCODING", "FREEZE", "FILL MISSING FIELDS", "NEWLINE",
-					  "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
+					  "LOG ERRORS","ON SEGMENT", "HEADER", "ESCAPE",
+					  "IGNORE EXTERNAL PARTITIONS");
 	else if (Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny, "WITH"))
 		COMPLETE_WITH("ENCODING", "FREEZE", "FILL MISSING FIELDS",
-					  "NEWLINE", "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
+					  "NEWLINE", "ON SEGMENT", "LOG ERRORS", "ESCAPE",
+					  "IGNORE EXTERNAL PARTITIONS");
 
 	/* Handle COPY [BINARY] <sth> FROM filename CSV */
 	else if (Matches("COPY|\\copy", MatchAny, "FROM", MatchAny, "CSV"))
@@ -2433,6 +2436,12 @@ psql_completion(const char *text, int start, int end)
 	/* Handle COPY [BINARY] <sth> TO filename CSV */
 	else if (Matches("COPY|\\copy", MatchAny, "TO", MatchAny, "CSV"))
 		COMPLETE_WITH("HEADER", "QUOTE", "ESCAPE", "FORCE QUOTE");
+
+	else if(HeadMatches("COPY|\\copy", MatchAny) && TailMatches("LOG", "ERRORS"))
+		COMPLETE_WITH("", "SEGMENT REJECT LIMIT");
+	else if(HeadMatches("COPY|\\copy", MatchAny) &&
+			TailMatches("LOG", "ERRORS", "SEGMENT", "REJECT", "LIMIT", MatchAny))
+		COMPLETE_WITH("ROWS", "PERCENT");
 
 
 	/* CREATE ACCESS METHOD */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2291,8 +2291,6 @@ psql_completion(const char *text, int start, int end)
 	else if (HeadMatches("ANALYZE") && TailMatches("("))
 		/* "ANALYZE (" should be caught above, so assume we want columns */
 		COMPLETE_WITH_ATTR(prev2_wd, "");
-	else if (HeadMatches("ANALYZE") && !TailMatches("ALL"))
-		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_analyzables, NULL);
 
 /* BEGIN */
 	else if (Matches("BEGIN"))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2247,7 +2247,7 @@ psql_completion(const char *text, int start, int end)
 
 /*
  * ANALYZE [ ( option [, ...] ) ] [ table_and_columns [, ...] ]
- * ANALYZE [ VERBOSE ] [ table_and_columns [, ...] ]
+ * ANALYZE [ VERBOSE ] [ ROOTPARTITION ] [ table_and_columns [, ...] ]
  */
 	else if (Matches("ANALYZE"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_analyzables,
@@ -2265,9 +2265,6 @@ psql_completion(const char *text, int start, int end)
 			 Matches("ANALYZE", "VERBOSE", "ROOTPARTITION"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_analyzables,
 								   " UNION SELECT 'ALL'");
-	else if (Matches("ANALYZE", "FULLSCAN") ||
-			Matches("ANALYZE", "VERBOSE", "FULLSCAN"))
-		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_analyzables, NULL);
 	else if (HeadMatches("ANALYZE", "(*") &&
 			 !HeadMatches("ANALYZE", "(*)"))
 	{
@@ -2277,7 +2274,7 @@ psql_completion(const char *text, int start, int end)
 		 * one word, so the above test is correct.
 		 */
 		if (ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
-			COMPLETE_WITH("VERBOSE", "SKIP_LOCKED", "FULLSCAN", "ROOTPARTIION");
+			COMPLETE_WITH("VERBOSE", "SKIP_LOCKED", "FULLSCAN", "ROOTPARTITION");
 		else if (TailMatches("VERBOSE|SKIP_LOCKED|FULLSCAN|ROOTPARTITION"))
 			COMPLETE_WITH("ON", "OFF");
 	}

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2918,7 +2918,7 @@ psql_completion(const char *text, int start, int end)
  */
 	else if (Matches("EXPLAIN"))
 		COMPLETE_WITH("SELECT", "INSERT", "DELETE", "UPDATE", "DECLARE",
-					  "ANALYZE", "VERBOSE");
+					  "ANALYZE", "VERBOSE", "DXL", " (");
 	else if (HeadMatches("EXPLAIN", "(*") &&
 			 !HeadMatches("EXPLAIN", "(*)"))
 	{
@@ -2928,19 +2928,24 @@ psql_completion(const char *text, int start, int end)
 		 * one word, so the above test is correct.
 		 */
 		if (ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
-			COMPLETE_WITH("ANALYZE", "VERBOSE", "COSTS", "SETTINGS",
+			COMPLETE_WITH("ANALYZE", "VERBOSE", "DXL", "COSTS", "SETTINGS",
 						  "BUFFERS", "TIMING", "SUMMARY", "FORMAT");
-		else if (TailMatches("ANALYZE|VERBOSE|COSTS|SETTINGS|BUFFERS|TIMING|SUMMARY"))
+		else if (TailMatches("ANALYZE|VERBOSE|DXL|COSTS|SETTINGS|BUFFERS|TIMING|SUMMARY"))
 			COMPLETE_WITH("ON", "OFF");
 		else if (TailMatches("FORMAT"))
 			COMPLETE_WITH("TEXT", "XML", "JSON", "YAML");
 	}
 	else if (Matches("EXPLAIN", "ANALYZE"))
 		COMPLETE_WITH("SELECT", "INSERT", "DELETE", "UPDATE", "DECLARE",
-					  "VERBOSE");
+					  "VERBOSE", "DXL");
 	else if (Matches("EXPLAIN", "(*)") ||
 			 Matches("EXPLAIN", "VERBOSE") ||
 			 Matches("EXPLAIN", "ANALYZE", "VERBOSE"))
+		COMPLETE_WITH("DXL", "SELECT", "INSERT", "DELETE", "UPDATE", "DECLARE");
+	else if (Matches("EXPLAIN", "(*)") ||
+			 Matches("EXPLAIN", "DXL") ||
+			 Matches("EXPLAIN", "ANALYZE|VERBOSE", "DXL") ||
+			 Matches("EXPLAIN", "ANALYZE", "VERBOSE", "DXL"))
 		COMPLETE_WITH("SELECT", "INSERT", "DELETE", "UPDATE", "DECLARE");
 
 /* FETCH && MOVE */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2917,7 +2917,7 @@ psql_completion(const char *text, int start, int end)
 
 /*
  * EXPLAIN [ ( option [, ...] ) ] statement
- * EXPLAIN [ ANALYZE ] [ VERBOSE ] statement
+ * EXPLAIN [ ANALYZE ] [ VERBOSE ] [ DXL ] statement
  */
 	else if (Matches("EXPLAIN"))
 		COMPLETE_WITH("SELECT", "INSERT", "DELETE", "UPDATE", "DECLARE",

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1844,7 +1844,8 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH("'Monday'", "'Tuesday'", "'Wednesday'", "'Thursday'",
 					  "'Friday'", "'Saturday'", "'Sunday'");
 	else if(TailMatches("DENY", "DAY", MatchAny) ||
-			TailMatches("AND", "DAY", MatchAny))
+			TailMatches("AND", "DAY", MatchAny) ||
+			TailMatches("FOR", "DAY", MatchAny))
 		COMPLETE_WITH("TIME");
 	else if(TailMatches("DENY", "BETWEEN", "DAY", MatchAny))
 		COMPLETE_WITH("AND DAY", "TIME");

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -3623,8 +3623,7 @@ psql_completion(const char *text, int start, int end)
 					  "ROW SHARE MODE", "ROW EXCLUSIVE MODE",
 					  "SHARE UPDATE EXCLUSIVE MODE", "SHARE MODE",
 					  "SHARE ROW EXCLUSIVE MODE",
-					  "EXCLUSIVE MODE", "ACCESS EXCLUSIVE MODE",
-					  "NOWAIT");
+					  "EXCLUSIVE MODE", "ACCESS EXCLUSIVE MODE");
 
 	/* Complete LOCK [TABLE] <table> IN ACCESS|ROW with rest of lock mode */
 	else if (Matches("LOCK", MatchAny, "IN", "ACCESS|ROW") ||
@@ -3646,12 +3645,9 @@ psql_completion(const char *text, int start, int end)
 			 Matches("LOCK", "TABLE", MatchAny, "IN", "ACCESS", "SHARE", "MODE", "NOWAIT"))
 		COMPLETE_WITH("COORDINATOR ONLY");
 
-	else if (Matches("LOCK", MatchAny, "IN", "SHARE|EXCLUSIVE", "MODE") ||
-			 Matches("LOCK", MatchAny, "IN", "ACCESS|ROW", "SHARE|EXCLUSIVE", "MODE") ||
-			 Matches("LOCK", MatchAny, "IN", "SHARE", "ROW|UPDATE", "EXCLUSIVE", "MODE") ||
-			 Matches("LOCK", "TABLE", MatchAny, "IN", "SHARE|EXCLUSIVE", "MODE") ||
-			 Matches("LOCK", "TABLE", MatchAny, "IN", "ACCESS|ROW", "SHARE|EXCLUSIVE", "MODE") ||
-			 Matches("LOCK", "TABLE", MatchAny, "IN", "SHARE", "ROW|UPDATE", "EXCLUSIVE", "MODE"))
+	else if ((HeadMatches("LOCK", "TABLE", MatchAny, "IN") ||
+			  HeadMatches("LOCK", MatchAnyExcept("TABLE"), "IN")) &&
+			  TailMatches("MODE"))
 		COMPLETE_WITH("NOWAIT");
 
 /* NOTIFY --- can be inside EXPLAIN, RULE, etc */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -3520,29 +3520,40 @@ psql_completion(const char *text, int start, int end)
 
 /*
  * VACUUM [ ( option [, ...] ) ] [ table_and_columns [, ...] ]
- * VACUUM [ FULL ] [ FREEZE ] [ VERBOSE ] [ ANALYZE ] [ table_and_columns [, ...] ]
+ * VACUUM [ FULL ] [ FREEZE ] [ VERBOSE ] [ ANALYZE ] [ AO_AUX_ONLY ] [ table_and_columns [, ...] ]
  */
 	else if (Matches("VACUUM"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_vacuumables,
 								   " UNION SELECT 'FULL'"
 								   " UNION SELECT 'FREEZE'"
 								   " UNION SELECT 'ANALYZE'"
-								   " UNION SELECT 'VERBOSE'");
+								   " UNION SELECT 'VERBOSE'"
+								   " UNION SELECT 'AO_AUX_ONLY'"
+								   " UNION SELECT '('");
 	else if (Matches("VACUUM", "FULL"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_vacuumables,
 								   " UNION SELECT 'FREEZE'"
 								   " UNION SELECT 'ANALYZE'"
-								   " UNION SELECT 'VERBOSE'");
+								   " UNION SELECT 'VERBOSE'"
+								   " UNION SELECT 'AO_AUX_ONLY'");
 	else if (Matches("VACUUM", "FREEZE") ||
 			 Matches("VACUUM", "FULL", "FREEZE"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_vacuumables,
 								   " UNION SELECT 'VERBOSE'"
-								   " UNION SELECT 'ANALYZE'");
+								   " UNION SELECT 'ANALYZE'"
+								   " UNION SELECT 'AO_AUX_ONLY'");
 	else if (Matches("VACUUM", "VERBOSE") ||
 			 Matches("VACUUM", "FULL|FREEZE", "VERBOSE") ||
 			 Matches("VACUUM", "FULL", "FREEZE", "VERBOSE"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_vacuumables,
-								   " UNION SELECT 'ANALYZE'");
+								   " UNION SELECT 'ANALYZE'"
+								   " UNION SELECT 'AO_AUX_ONLY'");
+	else if (Matches("VACUUM", "ANALYZE") ||
+			 Matches("VACUUM", "FULL|FREEZE|VERBOSE", "ANALYZE") ||
+			 Matches("VACUUM", "FULL|FREEZE", "FREEZE|VERBOSE", "ANALYZE") ||
+			 Matches("VACUUM", "FULL", "FREEZE", "VERBOSE", "ANALYZE"))
+		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_vacuumables,
+								   " UNION SELECT 'AO_AUX_ONLY'");
 	else if (HeadMatches("VACUUM", "(*") &&
 			 !HeadMatches("VACUUM", "(*)"))
 	{
@@ -3552,11 +3563,11 @@ psql_completion(const char *text, int start, int end)
 		 * one word, so the above test is correct.
 		 */
 		if (ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
-			COMPLETE_WITH("FULL", "FREEZE", "ANALYZE", "VERBOSE",
+			COMPLETE_WITH("FULL", "FREEZE", "ANALYZE", "VERBOSE", "AO_AUX_ONLY",
 						  "DISABLE_PAGE_SKIPPING", "SKIP_LOCKED",
 						  "INDEX_CLEANUP", "TRUNCATE", "PARALLEL", "SKIP_DATABASE_STATS",
 						  "ONLY_DATABASE_STATS");
-		else if (TailMatches("FULL|FREEZE|ANALYZE|VERBOSE|DISABLE_PAGE_SKIPPING|SKIP_LOCKED|TRUNCATE|SKIP_DATABASE_STATS|ONLY_DATABASE_STATS"))
+		else if (TailMatches("FULL|FREEZE|ANALYZE|VERBOSE|AO_AUX_ONLY|DISABLE_PAGE_SKIPPING|SKIP_LOCKED|TRUNCATE|SKIP_DATABASE_STATS|ONLY_DATABASE_STATS"))
 			COMPLETE_WITH("ON", "OFF");
 	}
 	else if (HeadMatches("VACUUM") && TailMatches("("))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2196,6 +2196,7 @@ psql_completion(const char *text, int start, int end)
 					  "DATABASE", "EVENT TRIGGER", "EXTENSION",
 					  "FOREIGN DATA WRAPPER", "FOREIGN TABLE", "SERVER",
 					  "INDEX", "LANGUAGE", "POLICY", "PUBLICATION", "RULE",
+					  "RESOURCE GROUP", "RESOURCE QUEUE",
 					  "SCHEMA", "SEQUENCE", "STATISTICS", "SUBSCRIPTION",
 					  "TABLE", "TYPE", "VIEW", "MATERIALIZED VIEW",
 					  "COLUMN", "AGGREGATE", "FUNCTION",
@@ -2206,6 +2207,8 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH_QUERY(Query_for_list_of_access_methods);
 	else if (Matches("COMMENT", "ON", "FOREIGN"))
 		COMPLETE_WITH("DATA WRAPPER", "TABLE");
+	else if(Matches("COMMENT", "ON", "RESOURCE"))
+			COMPLETE_WITH("GROUP", "QUEUE");
 	else if (Matches("COMMENT", "ON", "TEXT", "SEARCH"))
 		COMPLETE_WITH("CONFIGURATION", "DICTIONARY", "PARSER", "TEMPLATE");
 	else if (Matches("COMMENT", "ON", "CONSTRAINT"))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2345,7 +2345,11 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("COMMENT", "ON", "FOREIGN"))
 		COMPLETE_WITH("DATA WRAPPER", "TABLE");
 	else if(Matches("COMMENT", "ON", "RESOURCE"))
-			COMPLETE_WITH("GROUP", "QUEUE");
+		COMPLETE_WITH("GROUP", "QUEUE");
+	else if (Matches("COMMENT", "ON", "RESOURCE", "GROUP"))
+		COMPLETE_WITH_QUERY(Query_for_list_of_resgroups);
+	else if (Matches("COMMENT", "ON", "RESOURCE", "QUEUE"))
+		COMPLETE_WITH_QUERY(Query_for_list_of_resqueues);
 	else if (Matches("COMMENT", "ON", "TEXT", "SEARCH"))
 		COMPLETE_WITH("CONFIGURATION", "DICTIONARY", "PARSER", "TEMPLATE");
 	else if (Matches("COMMENT", "ON", "CONSTRAINT"))
@@ -3945,7 +3949,7 @@ psql_completion(const char *text, int start, int end)
 			 Matches("VACUUM", "FULL|FREEZE|VERBOSE", "ANALYZE") ||
 			 Matches("VACUUM", "FULL|FREEZE", "FREEZE|VERBOSE", "ANALYZE") ||
 			 Matches("VACUUM", "FULL", "FREEZE", "VERBOSE", "ANALYZE"))
-		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_vacuumables, "");
+		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_vacuumables, NULL);
 	else if (HeadMatches("VACUUM", "(*") &&
 			 !HeadMatches("VACUUM", "(*)"))
 	{

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -3920,7 +3920,7 @@ psql_completion(const char *text, int start, int end)
 
 /*
  * VACUUM [ ( option [, ...] ) ] [ table_and_columns [, ...] ]
- * VACUUM [ FULL ] [ FREEZE ] [ VERBOSE ] [ ANALYZE ] [ AO_AUX_ONLY ] [ table_and_columns [, ...] ]
+ * VACUUM [ FULL ] [ FREEZE ] [ VERBOSE ] [ ANALYZE ] [ table_and_columns [, ...] ]
  */
 	else if (Matches("VACUUM"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_vacuumables,
@@ -3928,32 +3928,27 @@ psql_completion(const char *text, int start, int end)
 								   " UNION SELECT 'FREEZE'"
 								   " UNION SELECT 'ANALYZE'"
 								   " UNION SELECT 'VERBOSE'"
-								   " UNION SELECT 'AO_AUX_ONLY'"
 								   " UNION SELECT '('");
 	else if (Matches("VACUUM", "FULL"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_vacuumables,
 								   " UNION SELECT 'FREEZE'"
 								   " UNION SELECT 'ANALYZE'"
-								   " UNION SELECT 'VERBOSE'"
-								   " UNION SELECT 'AO_AUX_ONLY'");
+								   " UNION SELECT 'VERBOSE'");
 	else if (Matches("VACUUM", "FREEZE") ||
 			 Matches("VACUUM", "FULL", "FREEZE"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_vacuumables,
 								   " UNION SELECT 'VERBOSE'"
-								   " UNION SELECT 'ANALYZE'"
-								   " UNION SELECT 'AO_AUX_ONLY'");
+								   " UNION SELECT 'ANALYZE'");
 	else if (Matches("VACUUM", "VERBOSE") ||
 			 Matches("VACUUM", "FULL|FREEZE", "VERBOSE") ||
 			 Matches("VACUUM", "FULL", "FREEZE", "VERBOSE"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_vacuumables,
-								   " UNION SELECT 'ANALYZE'"
-								   " UNION SELECT 'AO_AUX_ONLY'");
+								   " UNION SELECT 'ANALYZE'");
 	else if (Matches("VACUUM", "ANALYZE") ||
 			 Matches("VACUUM", "FULL|FREEZE|VERBOSE", "ANALYZE") ||
 			 Matches("VACUUM", "FULL|FREEZE", "FREEZE|VERBOSE", "ANALYZE") ||
 			 Matches("VACUUM", "FULL", "FREEZE", "VERBOSE", "ANALYZE"))
-		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_vacuumables,
-								   " UNION SELECT 'AO_AUX_ONLY'");
+		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_vacuumables, "");
 	else if (HeadMatches("VACUUM", "(*") &&
 			 !HeadMatches("VACUUM", "(*)"))
 	{

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2284,7 +2284,7 @@ psql_completion(const char *text, int start, int end)
 		 * one word, so the above test is correct.
 		 */
 		if (ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
-			COMPLETE_WITH("VERBOSE", "SKIP_LOCKED", "FULLSCAN", "ROOTPARTITION");
+			COMPLETE_WITH_UNUSED_OPTIONS("VERBOSE", "SKIP_LOCKED", "FULLSCAN", "ROOTPARTITION");
 		else if (TailMatches("VERBOSE|SKIP_LOCKED|FULLSCAN|ROOTPARTITION"))
 			COMPLETE_WITH("ON", "OFF");
 	}

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1838,8 +1838,17 @@ psql_completion(const char *text, int start, int end)
 
 	else if(TailMatches("DENY") && !TailMatches("DROP", "DENY"))
 		COMPLETE_WITH("DAY", "BETWEEN DAY");
-	else if(TailMatches("DENY", "BETWEEN", "DAY", MatchAny) ||
-			TailMatches("DENY", "BETWEEN", "DAY", MatchAny, "TIME", "'*'") ||
+	else if(TailMatches("DROP", "DENY", "FOR"))
+		COMPLETE_WITH("DAY");
+	else if(TailMatches("DAY"))
+		COMPLETE_WITH("'Monday'", "'Tuesday'", "'Wednesday'", "'Thursday'",
+					  "'Friday'", "'Saturday'", "'Sunday'");
+	else if(TailMatches("DENY", "DAY", MatchAny) ||
+			TailMatches("AND", "DAY", MatchAny))
+		COMPLETE_WITH("TIME");
+	else if(TailMatches("DENY", "BETWEEN", "DAY", MatchAny))
+		COMPLETE_WITH("AND DAY", "TIME");
+	else if(TailMatches("DENY", "BETWEEN", "DAY", MatchAny, "TIME", "'*'") ||
 			TailMatches("DENY", "BETWEEN", "DAY", MatchAny, "TIME", "'*", "PM'|AM'"))
 		COMPLETE_WITH("AND DAY");
 

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -3314,11 +3314,11 @@ psql_completion(const char *text, int start, int end)
 
 /*
  * EXPLAIN [ ( option [, ...] ) ] statement
- * EXPLAIN [ ANALYZE ] [ VERBOSE ] [ DXL ] statement
+ * EXPLAIN [ ANALYZE ] [ VERBOSE ] statement
  */
 	else if (Matches("EXPLAIN"))
 		COMPLETE_WITH("SELECT", "INSERT", "DELETE", "UPDATE", "DECLARE",
-					  "ANALYZE", "VERBOSE", "DXL", " (");
+					  "ANALYZE", "VERBOSE");
 	else if (HeadMatches("EXPLAIN", "(*") &&
 			 !HeadMatches("EXPLAIN", "(*)"))
 	{
@@ -3328,24 +3328,19 @@ psql_completion(const char *text, int start, int end)
 		 * one word, so the above test is correct.
 		 */
 		if (ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
-			COMPLETE_WITH_UNUSED_OPTIONS("ANALYZE", "VERBOSE", "DXL", "COSTS", "SETTINGS",
+			COMPLETE_WITH_UNUSED_OPTIONS("ANALYZE", "VERBOSE", "COSTS", "SETTINGS",
 						  "BUFFERS", "TIMING", "SUMMARY", "FORMAT");
-		else if (TailMatches("ANALYZE|VERBOSE|DXL|COSTS|SETTINGS|BUFFERS|TIMING|SUMMARY"))
+		else if (TailMatches("ANALYZE|VERBOSE|COSTS|SETTINGS|BUFFERS|TIMING|SUMMARY"))
 			COMPLETE_WITH("ON", "OFF");
 		else if (TailMatches("FORMAT"))
 			COMPLETE_WITH("TEXT", "XML", "JSON", "YAML");
 	}
 	else if (Matches("EXPLAIN", "ANALYZE"))
 		COMPLETE_WITH("SELECT", "INSERT", "DELETE", "UPDATE", "DECLARE",
-					  "VERBOSE", "DXL");
+					  "VERBOSE");
 	else if (Matches("EXPLAIN", "(*)") ||
 			 Matches("EXPLAIN", "VERBOSE") ||
 			 Matches("EXPLAIN", "ANALYZE", "VERBOSE"))
-		COMPLETE_WITH("DXL", "SELECT", "INSERT", "DELETE", "UPDATE", "DECLARE");
-	else if (Matches("EXPLAIN", "(*)") ||
-			 Matches("EXPLAIN", "DXL") ||
-			 Matches("EXPLAIN", "ANALYZE|VERBOSE", "DXL") ||
-			 Matches("EXPLAIN", "ANALYZE", "VERBOSE", "DXL"))
 		COMPLETE_WITH("SELECT", "INSERT", "DELETE", "UPDATE", "DECLARE");
 
 /* FETCH && MOVE */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -3218,10 +3218,10 @@ psql_completion(const char *text, int start, int end)
 
 	/* For the following, handle the case of a single table only for now */
 
-	/* Complete LOCK [TABLE] <table> with "IN" */
+	/* Complete LOCK [TABLE] <table> with "IN", "NOWAIT" */
 	else if (Matches("LOCK", MatchAnyExcept("TABLE")) ||
 			 Matches("LOCK", "TABLE", MatchAny))
-		COMPLETE_WITH("IN");
+		COMPLETE_WITH("IN", "NOWAIT");
 
 	/* Complete LOCK [TABLE] <table> IN with a lock mode */
 	else if (Matches("LOCK", MatchAny, "IN") ||
@@ -3242,6 +3242,11 @@ psql_completion(const char *text, int start, int end)
 			 Matches("LOCK", "TABLE", MatchAny, "IN", "SHARE"))
 		COMPLETE_WITH("MODE", "ROW EXCLUSIVE MODE",
 					  "UPDATE EXCLUSIVE MODE");
+	
+	/* Complete LOCK [TABLE] <table> IN ACESS SHARE MODE with "NOWAIT", "MASTER ONLY", "COORDINATOR ONLY" */
+	else if (Matches("LOCK", MatchAny, "IN", "ACCESS", "SHARE", "MODE") ||
+			 Matches("LOCK", "TABLE", MatchAny, "IN", "ACCESS", "SHARE", "MODE"))
+		COMPLETE_WITH("NOWAIT", "MASTER ONLY", "COORDINATOR ONLY");
 
 /* NOTIFY --- can be inside EXPLAIN, RULE, etc */
 	else if (TailMatches("NOTIFY"))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2084,11 +2084,13 @@ psql_completion(const char *text, int start, int end)
 	/* complete ALTER TYPE <foo> with actions */
 	else if (Matches("ALTER", "TYPE", MatchAny))
 		COMPLETE_WITH("ADD ATTRIBUTE", "ADD VALUE", "ALTER ATTRIBUTE",
-					  "DROP ATTRIBUTE",
-					  "OWNER TO", "RENAME", "SET SCHEMA");
+					  "DROP ATTRIBUTE", "OWNER TO", "RENAME", "SET SCHEMA",
+					  "SET DEFAULT ENCODING (");
 	/* complete ALTER TYPE <foo> ADD with actions */
 	else if (Matches("ALTER", "TYPE", MatchAny, "ADD"))
 		COMPLETE_WITH("ATTRIBUTE", "VALUE");
+	else if(Matches("ALTER", "TYPE", MatchAny, "SET"))
+		COMPLETE_WITH("SCHEMA", "DEFAULT ENCODING (");
 	/* ALTER TYPE <foo> RENAME	*/
 	else if (Matches("ALTER", "TYPE", MatchAny, "RENAME"))
 		COMPLETE_WITH("ATTRIBUTE", "TO", "VALUE");
@@ -2120,6 +2122,11 @@ psql_completion(const char *text, int start, int end)
 	 */
 	else if (Matches("ALTER", "TYPE", MatchAny, "RENAME", "VALUE"))
 		COMPLETE_WITH_ENUM_VALUE(prev3_wd);
+
+	else if(Matches("ALTER", "TYPE", MatchAny, "SET", "DEFAULT", "ENCODING", "("))
+		COMPLETE_WITH("COMPRESSTYPE =", "COMPRESSLEVEL =", "BLOCKSIZE =");
+	else if(Matches("ALTER", "TYPE", MatchAny, "SET", "DEFAULT", "ENCODING", "(", "COMPRESSTYPE", "="))
+		COMPLETE_WITH("ZLIB", "ZSTD", "RLE_TYPE", "NONE");
 
 /*
  * ANALYZE [ ( option [, ...] ) ] [ table_and_columns [, ...] ]

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2127,7 +2127,23 @@ psql_completion(const char *text, int start, int end)
  */
 	else if (Matches("ANALYZE"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_analyzables,
-								   " UNION SELECT 'VERBOSE'");
+								   " UNION SELECT 'VERBOSE'"
+								   " UNION SELECT 'ROOTPARTITION'"
+								   " UNION SELECT 'ROOTPARTITION ALL'"
+								   " UNION SELECT 'FULLSCAN'"
+								   " UNION SELECT '('");
+	else if (Matches("ANALYZE", "VERBOSE"))
+		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_analyzables,
+								   " UNION SELECT 'ROOTPARTITION'"
+								   " UNION SELECT 'ROOTPARTITION ALL'"
+								   " UNION SELECT 'FULLSCAN'");
+	else if (Matches("ANALYZE", "ROOTPARTITION") ||
+			 Matches("ANALYZE", "VERBOSE", "ROOTPARTITION"))
+		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_analyzables,
+								   " UNION SELECT 'ALL'");
+	else if (Matches("ANALYZE", "FULLSCAN") ||
+			Matches("ANALYZE", "VERBOSE", "FULLSCAN"))
+		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_analyzables, NULL);
 	else if (HeadMatches("ANALYZE", "(*") &&
 			 !HeadMatches("ANALYZE", "(*)"))
 	{
@@ -2137,14 +2153,14 @@ psql_completion(const char *text, int start, int end)
 		 * one word, so the above test is correct.
 		 */
 		if (ends_with(prev_wd, '(') || ends_with(prev_wd, ','))
-			COMPLETE_WITH("VERBOSE", "SKIP_LOCKED");
-		else if (TailMatches("VERBOSE|SKIP_LOCKED"))
+			COMPLETE_WITH("VERBOSE", "SKIP_LOCKED", "FULLSCAN", "ROOTPARTIION");
+		else if (TailMatches("VERBOSE|SKIP_LOCKED|FULLSCAN|ROOTPARTITION"))
 			COMPLETE_WITH("ON", "OFF");
 	}
 	else if (HeadMatches("ANALYZE") && TailMatches("("))
 		/* "ANALYZE (" should be caught above, so assume we want columns */
 		COMPLETE_WITH_ATTR(prev2_wd, "");
-	else if (HeadMatches("ANALYZE"))
+	else if (HeadMatches("ANALYZE") && !TailMatches("ALL"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_analyzables, NULL);
 
 /* BEGIN */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2411,7 +2411,7 @@ psql_completion(const char *text, int start, int end)
 					  "ENCODING", "FREEZE", "FILL MISSING FIELDS", "NEWLINE",
 					  "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
 	else if (Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny))
-		COMPLETE_WITH("CSV", "ENCODING", "FREEZE", "FILL MISSING FIELDS",
+		COMPLETE_WITH("ENCODING", "FREEZE", "FILL MISSING FIELDS",
 					  "WITH", "NEWLINE", "ON SEGMENT",
 					  "IGNORE EXTERNAL PARTITIONS");
 
@@ -2420,21 +2420,18 @@ psql_completion(const char *text, int start, int end)
 					  "ENCODING", "FREEZE", "FILL MISSING FIELDS", "NEWLINE",
 					  "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
 	else if (Matches("COPY", "BINARY", MatchAny, "FROM|TO", MatchAny, "WITH"))
-		COMPLETE_WITH("CSV", "ENCODING", "FREEZE", "FILL MISSING FIELDS",
+		COMPLETE_WITH("ENCODING", "FREEZE", "FILL MISSING FIELDS",
 					  "NEWLINE", "ON SEGMENT", "IGNORE EXTERNAL PARTITIONS");
 
 	/* Handle COPY [BINARY] <sth> FROM filename CSV */
-	else if (Matches("COPY|\\copy", MatchAny, "FROM", MatchAny, "CSV") ||
-			 Matches("COPY", "BINARY", MatchAny, "FROM", MatchAny, "CSV"))
+	else if (Matches("COPY|\\copy", MatchAny, "FROM", MatchAny, "CSV"))
 		COMPLETE_WITH("HEADER", "QUOTE", "ESCAPE", "FORCE NULL",
 					  "FORCE NOT NULL");
-	else if (Matches("COPY|\\copy", MatchAny, "FROM", MatchAny, "CSV", "FORCE") ||
-			 Matches("COPY", "BINARY", MatchAny, "FROM", MatchAny, "CSV", "FORCE"))
+	else if (Matches("COPY|\\copy", MatchAny, "FROM", MatchAny, "CSV", "FORCE"))
 		COMPLETE_WITH("NULL", "NOT NULL");
 
 	/* Handle COPY [BINARY] <sth> TO filename CSV */
-	else if (Matches("COPY|\\copy", MatchAny, "TO", MatchAny, "CSV") ||
-			 Matches("COPY", "BINARY", MatchAny, "TO", MatchAny, "CSV"))
+	else if (Matches("COPY|\\copy", MatchAny, "TO", MatchAny, "CSV"))
 		COMPLETE_WITH("HEADER", "QUOTE", "ESCAPE", "FORCE QUOTE");
 
 

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -3618,7 +3618,8 @@ psql_completion(const char *text, int start, int end)
 					  "ROW SHARE MODE", "ROW EXCLUSIVE MODE",
 					  "SHARE UPDATE EXCLUSIVE MODE", "SHARE MODE",
 					  "SHARE ROW EXCLUSIVE MODE",
-					  "EXCLUSIVE MODE", "ACCESS EXCLUSIVE MODE");
+					  "EXCLUSIVE MODE", "ACCESS EXCLUSIVE MODE",
+					  "NOWAIT");
 
 	/* Complete LOCK [TABLE] <table> IN ACCESS|ROW with rest of lock mode */
 	else if (Matches("LOCK", MatchAny, "IN", "ACCESS|ROW") ||
@@ -3634,7 +3635,19 @@ psql_completion(const char *text, int start, int end)
 	/* Complete LOCK [TABLE] <table> IN ACESS SHARE MODE with "NOWAIT", "MASTER ONLY", "COORDINATOR ONLY" */
 	else if (Matches("LOCK", MatchAny, "IN", "ACCESS", "SHARE", "MODE") ||
 			 Matches("LOCK", "TABLE", MatchAny, "IN", "ACCESS", "SHARE", "MODE"))
-		COMPLETE_WITH("NOWAIT", "MASTER ONLY", "COORDINATOR ONLY");
+		COMPLETE_WITH("NOWAIT", "COORDINATOR ONLY");
+
+	else if (Matches("LOCK", MatchAny, "IN", "ACCESS", "SHARE", "MODE", "NOWAIT") ||
+			 Matches("LOCK", "TABLE", MatchAny, "IN", "ACCESS", "SHARE", "MODE", "NOWAIT"))
+		COMPLETE_WITH("COORDINATOR ONLY");
+
+	else if (Matches("LOCK", MatchAny, "IN", "SHARE|EXCLUSIVE", "MODE") ||
+			 Matches("LOCK", MatchAny, "IN", "ACCESS|ROW", "SHARE|EXCLUSIVE", "MODE") ||
+			 Matches("LOCK", MatchAny, "IN", "SHARE", "ROW|UPDATE", "EXCLUSIVE", "MODE") ||
+			 Matches("LOCK", "TABLE", MatchAny, "IN", "SHARE|EXCLUSIVE", "MODE") ||
+			 Matches("LOCK", "TABLE", MatchAny, "IN", "ACCESS|ROW", "SHARE|EXCLUSIVE", "MODE") ||
+			 Matches("LOCK", "TABLE", MatchAny, "IN", "SHARE", "ROW|UPDATE", "EXCLUSIVE", "MODE"))
+		COMPLETE_WITH("NOWAIT");
 
 /* NOTIFY --- can be inside EXPLAIN, RULE, etc */
 	else if (TailMatches("NOTIFY"))


### PR DESCRIPTION
Some commands in psql lacked autocompletion support.

Add options to COPY.
Add NOWAIT, COORDINATOR ONLY options to LOCK TABLE.
Add AO_AUX_ONLY option to VACUUM.
Add ROOTPARTITION, FULLSCAN options to ANALYZE.
Add RESOURCE GROUP/QUEUE list suggestion to COMMENT ON.
Add DENY options to CREATE/ALTER USER/ROLE.
Add days suggestion to CREATE/ALTER USER/ROLE ... DENY.
Add SET DEFAULT ENCODING option to ALTER TYPE.

Add unused options filtering to EXPLAIN, VACUUM, ANALYZE.

Ticket: GG-518