### PR TITLE
GG-545: Fix handling path with trailing slashes

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1380,6 +1380,8 @@ def start_standbymaster(host, datadir, port, era=None,
                         wrapper=None, wrapper_args=None):
     logger.info("Starting standby master")
 
+    datadir = os.path.normpath(datadir)
+
     logger.info("Checking if standby master is running on host: %s  in directory: %s" % (host,datadir))
     cmd = Command("recovery_startup",
                   ("python -c "

--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -76,6 +76,21 @@ Feature: gpactivatestandby
           And the tablespace is valid on the standby master
           And clean up and revert back to original master
 
+    Scenario: master can be made on dir with trailing slash
+        Given the database is running
+          And the catalog has a standby master entry
+          And the standby is not initialized
+
+         When the user runs gpinitstandby with options "-S /tmp/standby_data/"
+         Then gpinitstandby should return a return code of 0
+          And verify the standby master entries in catalog
+        
+         When the master goes down
+          And the user runs gpactivatestandby with options "-d /tmp/standby_data/"
+         Then gpactivatestandby should return a return code of 0
+          And verify the standby master is now acting as master
+          And clean up and revert back to original master
+
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 

--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -78,7 +78,6 @@ Feature: gpactivatestandby
 
     Scenario: master can be made on dir with trailing slash
         Given the database is running
-          And the catalog has a standby master entry
           And the standby is not initialized
 
          When the user runs gpinitstandby with options "-S /tmp/standby_data/"

--- a/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
@@ -106,7 +106,8 @@ Feature: Tests for gpinitstandby feature
           And the standby is not initialized
 
          When the user runs gpinitstandby with options "-S /tmp/standby_data/"
-         Then verify the standby master entries in catalog
+         Then gpinitstandby should return a return code of 0
+          And verify the standby master entries in catalog
          When execute sql "select datadir from gp_segment_configuration where content = -1 and role = 'm'" in db "postgres" and store result in the context
          Then validate that "/tmp/standby_data/" is in the stored rows
 

--- a/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
@@ -101,6 +101,15 @@ Feature: Tests for gpinitstandby feature
         Then gpinitstandby should return a return code of 0
         And verify that the file "pg_hba.conf" in the master data directory has "no" line starting with "host.*replication.*(127.0.0.1|::1).*trust"
 
+    Scenario: gpinitstandby on dir with trailing slash
+        Given the database is running
+          And the standby is not initialized
+
+         When the user runs gpinitstandby with options "-S /tmp/standby_data/"
+         Then verify the standby master entries in catalog
+         When execute sql "select datadir from gp_segment_configuration where content = -1 and role = 'm'" in db "postgres" and store result in the context
+         Then validate that "/tmp/standby_data/" is in the stored rows
+
     @backup_restore_bashrc
     Scenario: gpinitstandby should not throw error when banner exists on the hsot
         Given the database is running

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -179,7 +179,8 @@ Feature: gpstart behave tests
           And the standby is not initialized
 
          When the user runs gpinitstandby with options "-S /tmp/standby_data/"
-         Then verify the standby master entries in catalog
+         Then gpinitstandby should return a return code of 0
+          And verify the standby master entries in catalog
         
          When the master goes down
           And the user runs "gpstart -a"

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -172,3 +172,19 @@ Feature: gpstart behave tests
 
           When the user runs psql with "-c 'drop user foouser;'" against database "postgres"
           Then psql should return a return code of 0
+
+    Scenario: gpstart on dir with trailing slash
+        Given the database is running
+          And the catalog has a standby master entry
+          And the standby is not initialized
+
+         When the user runs gpinitstandby with options "-S /tmp/standby_data/"
+         Then verify the standby master entries in catalog
+        
+         When the master goes down
+          And the user runs "gpstart -a"
+         Then gpstart should return a return code of 0
+          And verify the standby master entries in catalog
+        
+         When execute sql "select datadir from gp_segment_configuration where content = -1 and role = 'm'" in db "postgres" and store result in the context
+         Then validate that "/tmp/standby_data/" is in the stored rows


### PR DESCRIPTION
Previously `gpstart` utility couldn't start standby on directory specified with trailing slash, like that:
`/path/to/standby/`. 

It was enough to add normalization on path for further usage, to fix the issue.