### PR TITLE
GG-567: Fix handling path with trailing slashes

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -67,6 +67,7 @@ RECOVERY_REWIND_APPNAME = '__gprecoverseg_pg_rewind__'
 PGDATABASE_FOR_COMMON_USE= 'postgres'
 
 def get_postmaster_pid_locally(datadir):
+    datadir = os.path.normpath(datadir)
     cmdStr = "ps -ef | grep 'postgres -D %s' | grep -v grep" % (datadir)
     name = "get postmaster"
     cmd = Command(name, cmdStr)
@@ -78,6 +79,7 @@ def get_postmaster_pid_locally(datadir):
         return -1
 
 def getPostmasterPID(hostname, datadir):
+    datadir = os.path.normpath(datadir)
     cmdStr="echo 'START_CMD_OUTPUT';ps -ef | grep 'postgres -D %s' | grep -v grep" % (datadir)
     name="get postmaster pid"
     cmd=Command(name,cmdStr,ctxt=REMOTE,remoteHost=hostname)
@@ -1399,6 +1401,8 @@ def conflict_with_gpexpand(utility, refuse_phase1=True, refuse_phase2=False):
 def start_standbycoordinator(host, datadir, port, era=None,
                         wrapper=None, wrapper_args=None):
     logger.info("Starting standby coordinator")
+
+    datadir = os.path.normpath(datadir)
 
     logger.info("Checking if standby coordinator is running on host: %s  in directory: %s" % (host,datadir))
     cmd = Command("recovery_startup",

--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -79,6 +79,20 @@ Feature: gpactivatestandby
           And the tablespace is valid on the standby coordinator
           And clean up and revert back to original coordinator
 
+    Scenario: coordinator can be made on dir with trailing slash
+        Given the database is running
+          And the standby is not initialized
+
+         When the user runs gpinitstandby with options "-S /tmp/standby_data/"
+         Then gpinitstandby should return a return code of 0
+          And verify the standby coordinator entries in catalog
+        
+         When the coordinator goes down
+          And the user runs gpactivatestandby with options "-d /tmp/standby_data/"
+         Then gpactivatestandby should return a return code of 0
+          And verify the standby coordinator is now acting as coordinator
+          And clean up and revert back to original coordinator
+
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 

--- a/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
@@ -140,6 +140,16 @@ Feature: Tests for gpinitstandby feature
         Then gpinitstandby should return a return code of 0
         And verify that pg_hba.conf file has "standby" entries in each segment (primary and mirror) data directories
 
+    Scenario: gpinitstandby on dir with trailing slash
+        Given the database is running
+          And the standby is not initialized
+
+         When the user runs gpinitstandby with options "-S /tmp/standby_data/"
+         Then gpinitstandby should return a return code of 0
+          And verify the standby coordinator entries in catalog
+         When execute sql "select datadir from gp_segment_configuration where content = -1 and role = 'm'" in db "postgres" and store result in the context
+         Then validate that "/tmp/standby_data/" is in the stored rows
+
     @backup_restore_bashrc
     Scenario: gpinitstandby should not throw error when banner exists on the host
         Given the database is running

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -203,6 +203,23 @@ Feature: gpstart behave tests
           And gpcheckcat should not print "Number of segments which failed to start:.*" to stdout
 
     @demo_cluster
+    Scenario: gpstart on dir with trailing slash
+        Given the database is running
+          And the standby is not initialized
+
+         When the user runs gpinitstandby with options "-S /tmp/standby_data/"
+         Then gpinitstandby should return a return code of 0
+         Then verify the standby coordinator entries in catalog
+        
+         When the coordinator goes down
+          And the user runs "gpstart -a"
+         Then gpstart should return a return code of 0
+          And verify the standby coordinator entries in catalog
+        
+         When execute sql "select datadir from gp_segment_configuration where content = -1 and role = 'm'" in db "postgres" and store result in the context
+         Then validate that "/tmp/standby_data/" is in the stored rows
+
+    @demo_cluster
     Scenario: gpstart succeeds when cluster shut down during segment promotion
         Given the database is running
           And the user runs psql with "-c "CREATE EXTENSION IF NOT EXISTS gp_inject_fault;"" against database "postgres"


### PR DESCRIPTION
Previously `gpstart` utility couldn't start standby on directory specified with trailing slash, like that:
`/path/to/standby/`.

It was enough to add normalization on path for further usage, to fix the issue.