### PR TITLE
GG-552: Fix file transfer for foreign tables in pg_upgrade

### DIFF
--- a/src/bin/pg_upgrade/info.c
+++ b/src/bin/pg_upgrade/info.c
@@ -493,6 +493,7 @@ get_rel_infos(ClusterInfo *cluster, DbInfo *dbinfo)
 			 CppAsString2(RELKIND_AOSEGMENTS) ", "
 			 CppAsString2(RELKIND_AOBLOCKDIR) ", "
 			 CppAsString2(RELKIND_MATVIEW) ", "
+			 CppAsString2(RELKIND_FOREIGN_TABLE) ", "
 			 "%s"
 			 CppAsString2(RELKIND_SEQUENCE) ") AND "
 	/* exclude possible orphaned temp tables */

--- a/src/bin/pg_upgrade/info.c
+++ b/src/bin/pg_upgrade/info.c
@@ -493,7 +493,6 @@ get_rel_infos(ClusterInfo *cluster, DbInfo *dbinfo)
 			 CppAsString2(RELKIND_AOSEGMENTS) ", "
 			 CppAsString2(RELKIND_AOBLOCKDIR) ", "
 			 CppAsString2(RELKIND_MATVIEW) ", "
-			 CppAsString2(RELKIND_FOREIGN_TABLE) ", "
 			 "%s"
 			 CppAsString2(RELKIND_SEQUENCE) ") AND "
 	/* exclude possible orphaned temp tables */

--- a/src/bin/pg_upgrade/info.c
+++ b/src/bin/pg_upgrade/info.c
@@ -139,8 +139,8 @@ gen_db_file_maps(DbInfo *old_db, DbInfo *new_db,
 		/*
 		 * For the following cases, file transfer is not necessary:
 
-		 * External tables have relfilenodes but no physical files, and aoseg
-		 * tables are handled by their AO table.
+		 * External and foreign tables have relfilenodes but no physical
+		 * files, and aoseg tables are handled by their AO table.
 		 * 
 		 * Partitioned tables have relfilenodes = 0 and no physical files in GG7.
 		 * 
@@ -148,6 +148,7 @@ gen_db_file_maps(DbInfo *old_db, DbInfo *new_db,
 		 * 
 		 */
 		if ((old_rel->relstorage == 'x' || strcmp(new_rel->nspname, "pg_aoseg") == 0) ||
+			(new_rel->relkind == RELKIND_FOREIGN_TABLE) ||
 			(new_rel->relkind == RELKIND_PARTITIONED_TABLE) ||
 			(new_rel->relkind == RELKIND_SEQUENCE) )
 		{

--- a/src/bin/pg_upgrade/info.c
+++ b/src/bin/pg_upgrade/info.c
@@ -139,8 +139,8 @@ gen_db_file_maps(DbInfo *old_db, DbInfo *new_db,
 		/*
 		 * For the following cases, file transfer is not necessary:
 
-		 * External and foreign tables have relfilenodes but no physical
-		 * files, and aoseg tables are handled by their AO table.
+		 * External tables have relfilenodes but no physical files, and aoseg
+		 * tables are handled by their AO table.
 		 * 
 		 * Partitioned tables have relfilenodes = 0 and no physical files in GG7.
 		 * 
@@ -148,7 +148,6 @@ gen_db_file_maps(DbInfo *old_db, DbInfo *new_db,
 		 * 
 		 */
 		if ((old_rel->relstorage == 'x' || strcmp(new_rel->nspname, "pg_aoseg") == 0) ||
-			(new_rel->relkind == RELKIND_FOREIGN_TABLE) ||
 			(new_rel->relkind == RELKIND_PARTITIONED_TABLE) ||
 			(new_rel->relkind == RELKIND_SEQUENCE) )
 		{


### PR DESCRIPTION
pg_upgrade failed when the source cluster contained foreign tables because file
mappings were created for them even though foreign tables do not have physical
relation files on disk.

Skip foreign tables when building the file transfer map, similar to external
tables, pg_aoseg, partitioned tables, and sequences.

Keep foreign tables in get_rel_infos() because Greengage 6 external tables are
restored in Greengage 7 as foreign tables, so they are needed for old/new
relation matching.

Don't add tests because this patch is part of fixing cross-version pg_upgrade
test failures.

Ticket: GG-552