### PR TITLE
GG-584: Disable gpssh and cross_subnet behave tests

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/cross_subnet.feature
+++ b/gpMgmt/test/behave/mgmt_utils/cross_subnet.feature
@@ -1,4 +1,4 @@
-@cross_subnet
+@cross_subnet @skip
 Feature: Tests for a cross_subnet cluster
 
     Scenario: gpinitsystem works across subnets

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -243,6 +243,7 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand to redistribute
         Then the numsegments of table "ext_test" is 4
 
+    @skip
     @gpexpand_icw_db_concourse
     Scenario: Use a dump of the ICW database for expansion
         Given the database is not running

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -243,7 +243,6 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand to redistribute
         Then the numsegments of table "ext_test" is 4
 
-    @skip
     @gpexpand_icw_db_concourse
     Scenario: Use a dump of the ICW database for expansion
         Given the database is not running

--- a/gpMgmt/test/behave/mgmt_utils/gpssh.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpssh.feature
@@ -1,4 +1,4 @@
-@gpssh
+@gpssh @skip
 Feature: gpssh behave tests
 
     Scenario: gpssh -d and -t options


### PR DESCRIPTION
Our infrastructure is not ready for these tests yet.