### PR TITLE
GG-521: Improve autocomplete for ALTER TABLE

### DIFF
--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2212,6 +2212,11 @@ psql_completion(const char *text, int start, int end)
 	else if(Matches("ALTER", "TABLE", MatchAny, MatchAny, "DEFAULT"))
 		COMPLETE_WITH("PARTITION");
 
+	else if (Matches("ALTER", "TABLE", MatchAny, "RENAME", "PARTITION", MatchAny))
+		COMPLETE_WITH("TO");
+	else if (Matches("ALTER", "TABLE", MatchAny, "RENAME", "DEFAULT", "PARTITION"))
+		COMPLETE_WITH("TO");
+
 	/* ALTER TABLE xxx yyy PARTITION */
 	else if(Matches("ALTER", "TABLE", MatchAny, MatchAnyExcept("ADD"), "PARTITION"))
 	{

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2110,9 +2110,12 @@ psql_completion(const char *text, int start, int end)
 	}
 	/* If we have ALTER TABLE <sth> SET, provide list of attributes and '(' */
 	else if (Matches("ALTER", "TABLE", MatchAny, "SET"))
-		COMPLETE_WITH("(", "ACCESS METHOD", "LOGGED", "SCHEMA",
-					  "TABLESPACE", "UNLOGGED", "WITH", "WITHOUT");
+		COMPLETE_WITH("(", "ACCESS METHOD", "LOGGED", "SCHEMA", "TABLESPACE",
+					  "UNLOGGED", "WITH", "WITHOUT", "DISTRIBUTED");
 
+	else if (Matches("ALTER", "TABLE", MatchAny, "SET", "DISTRIBUTED") ||
+			 Matches("ALTER", "TABLE", MatchAny, "SET", "WITH", "(*)", "DISTRIBUTED"))
+		COMPLETE_WITH("BY (", "RANDOMLY", "REPLICATED");
 	/*
 	 * If we have ALTER TABLE <smt> SET ACCESS METHOD provide a list of table
 	 * AMs.

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1993,6 +1993,10 @@ psql_completion(const char *text, int start, int end)
 					  "REPLICA IDENTITY", "ATTACH PARTITION",
 					  "DETACH PARTITION", "REPACK BY COLUMNS (",
 					  "EXCHANGE", "SPLIT", "TRUNCATE", "FORCE", "NO FORCE");
+
+	else if (Matches("ALTER", "TABLE", MatchAny, "ADD"))
+		COMPLETE_WITH("CONSTRAINT", "COLUMN", "PARTITION", "DEFAULT");
+
 	else if(Matches("ALTER", "TABLE", MatchAny, "NO"))
 		COMPLETE_WITH("INHERIT", "FORCE");
 	/* ALTER TABLE xxx ENABLE */
@@ -2049,22 +2053,31 @@ psql_completion(const char *text, int start, int end)
 	}
 
 	/* ALTER TABLE xxx FORCE/NO FORCE */
-	else if (Matches("ALTER", "TABLE", MatchAny, "FORCE") || 
+	else if (Matches("ALTER", "TABLE", MatchAny, "FORCE") ||
 			 Matches("ALTER", "TABLE", MatchAny, "NO", "FORCE"))
 		COMPLETE_WITH("ROW LEVEL SECURITY");
 
 	/* ALTER TABLE xxx ALTER */
 	else if (Matches("ALTER", "TABLE", MatchAny, "ALTER"))
-		COMPLETE_WITH_ATTR(prev2_wd, " UNION SELECT 'COLUMN' UNION SELECT 'CONSTRAINT'");
+		COMPLETE_WITH_ATTR(prev2_wd,
+						   " UNION SELECT 'COLUMN'"
+						   " UNION SELECT 'CONSTRAINT'"
+						   " UNION SELECT 'DEFAULT'"
+						   " UNION SELECT 'PARTITION'");
 
 	/* ALTER TABLE xxx RENAME */
 	else if (Matches("ALTER", "TABLE", MatchAny, "RENAME"))
-		COMPLETE_WITH_ATTR(prev2_wd, " UNION SELECT 'COLUMN' UNION SELECT 'CONSTRAINT' UNION SELECT 'TO'");
+		COMPLETE_WITH_ATTR(prev2_wd,
+						   " UNION SELECT 'COLUMN'"
+						   " UNION SELECT 'CONSTRAINT'"
+						   " UNION SELECT 'TO'"
+						   " UNION SELECT 'DEFAULT'"
+						   " UNION SELECT 'PARTITION'");
 	else if (Matches("ALTER", "TABLE", MatchAny, "ALTER|RENAME", "COLUMN"))
 		COMPLETE_WITH_ATTR(prev3_wd, "");
 
 	/* ALTER TABLE xxx RENAME yyy */
-	else if (Matches("ALTER", "TABLE", MatchAny, "RENAME", MatchAnyExcept("CONSTRAINT|TO")))
+	else if (Matches("ALTER", "TABLE", MatchAny, "RENAME", MatchAnyExcept("CONSTRAINT|TO|DEFAULT|PARTITION")))
 		COMPLETE_WITH("TO");
 
 	/* ALTER TABLE xxx RENAME COLUMN/CONSTRAINT yyy */
@@ -2073,7 +2086,7 @@ psql_completion(const char *text, int start, int end)
 
 	/* If we have ALTER TABLE <sth> DROP, provide COLUMN or CONSTRAINT */
 	else if (Matches("ALTER", "TABLE", MatchAny, "DROP"))
-		COMPLETE_WITH("COLUMN", "CONSTRAINT");
+		COMPLETE_WITH("COLUMN", "CONSTRAINT", "DEFAULT", "PARTITION");
 	/* If we have ALTER TABLE <sth> DROP COLUMN, provide list of columns */
 	else if (Matches("ALTER", "TABLE", MatchAny, "DROP", "COLUMN"))
 		COMPLETE_WITH_ATTR(prev3_wd, "");
@@ -2089,7 +2102,7 @@ psql_completion(const char *text, int start, int end)
 	}
 	/* ALTER TABLE ALTER [COLUMN] <foo> */
 	else if (Matches("ALTER", "TABLE", MatchAny, "ALTER", "COLUMN", MatchAny) ||
-			 Matches("ALTER", "TABLE", MatchAny, "ALTER", MatchAny))
+			 Matches("ALTER", "TABLE", MatchAny, "ALTER", MatchAnyExcept("DEFAULT|PARTITION")))
 		COMPLETE_WITH("TYPE", "SET", "RESET", "RESTART", "ADD", "DROP");
 	/* ALTER TABLE ALTER [COLUMN] <foo> SET */
 	else if (Matches("ALTER", "TABLE", MatchAny, "ALTER", "COLUMN", MatchAny, "SET") ||
@@ -2127,7 +2140,7 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("ALTER", "TABLE", MatchAny, "SET"))
 		COMPLETE_WITH("(", "ACCESS METHOD", "LOGGED", "SCHEMA", "TABLESPACE",
 					  "UNLOGGED", "WITH", "WITHOUT", "DISTRIBUTED",
-					  "SUBPARTITION TEMPLATE");
+					  "SUBPARTITION TEMPLATE (");
 
 	else if (Matches("ALTER", "TABLE", MatchAny, "SET", "DISTRIBUTED") ||
 			 Matches("ALTER", "TABLE", MatchAny, "SET", "WITH", "(*)", "DISTRIBUTED"))
@@ -2177,6 +2190,15 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH("FOR VALUES", "DEFAULT");
 	else if (TailMatches("ATTACH", "PARTITION", MatchAny, "FOR", "VALUES"))
 		COMPLETE_WITH("FROM (", "IN (", "WITH (");
+
+	else if (Matches("ALTER", "TABLE", MatchAny, "EXCHANGE"))
+		COMPLETE_WITH("PARTITION", "DEFAULT");
+	else if (Matches("ALTER", "TABLE", MatchAny, "SPLIT"))
+		COMPLETE_WITH("PARTITION", "DEFAULT");
+	else if (Matches("ALTER", "TABLE", MatchAny, "TRUNCATE"))
+		COMPLETE_WITH("PARTITION", "DEFAULT");
+	else if(Matches("ALTER", "TABLE", MatchAny, MatchAny, "DEFAULT"))
+		COMPLETE_WITH("PARTITION");
 
 	/* ALTER TABLE xxx yyy PARTITION */
 	else if(Matches("ALTER", "TABLE", MatchAny, MatchAnyExcept("ADD"), "PARTITION"))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2143,6 +2143,15 @@ psql_completion(const char *text, int start, int end)
 					  "UNLOGGED", "WITH", "WITHOUT", "DISTRIBUTED",
 					  "SUBPARTITION TEMPLATE (");
 
+	/* ALTER TABLE xxx SET WITH ( */
+	else if(Matches("ALTER", "TABLE", MatchAny, "SET", "WITH", "("))
+		COMPLETE_WITH("reorganize =");
+	else if(Matches("ALTER", "TABLE", MatchAny, "SET", "WITH", "(", "reorganize", "="))
+		COMPLETE_WITH("true )", "false )");
+	
+	else if(Matches("ALTER", "TABLE", MatchAny, "SET", "WITH", "(*)"))
+		COMPLETE_WITH("DISTRIBUTED");
+
 	else if (Matches("ALTER", "TABLE", MatchAny, "SET", "DISTRIBUTED") ||
 			 Matches("ALTER", "TABLE", MatchAny, "SET", "WITH", "(*)", "DISTRIBUTED"))
 		COMPLETE_WITH("BY (", "RANDOMLY", "REPLICATED");

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2204,7 +2204,7 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH("PARTITION");
 
 	else if (Matches("ALTER", "TABLE", MatchAny, "RENAME", "PARTITION", MatchAny) ||
-	Matches("ALTER", "TABLE", MatchAny, "RENAME", "DEFAULT", "PARTITION"))
+			 Matches("ALTER", "TABLE", MatchAny, "RENAME", "DEFAULT", "PARTITION"))
 		COMPLETE_WITH("TO");
 
 	/* ALTER TABLE xxx SET DISTRIBUTED BY ( */

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1991,7 +1991,8 @@ psql_completion(const char *text, int start, int end)
 					  "ENABLE", "INHERIT", "NO INHERIT", "RENAME", "RESET",
 					  "OWNER TO", "SET", "VALIDATE CONSTRAINT", "EXPAND",
 					  "REPLICA IDENTITY", "ATTACH PARTITION",
-					  "DETACH PARTITION", "REPACK BY COLUMNS (");
+					  "DETACH PARTITION", "REPACK BY COLUMNS (",
+					  "EXCHANGE", "SPLIT", "TRUNCATE");
 	/* ALTER TABLE xxx ENABLE */
 	else if (Matches("ALTER", "TABLE", MatchAny, "ENABLE"))
 		COMPLETE_WITH("ALWAYS", "REPLICA", "ROW LEVEL SECURITY", "RULE",
@@ -2114,7 +2115,8 @@ psql_completion(const char *text, int start, int end)
 	/* If we have ALTER TABLE <sth> SET, provide list of attributes and '(' */
 	else if (Matches("ALTER", "TABLE", MatchAny, "SET"))
 		COMPLETE_WITH("(", "ACCESS METHOD", "LOGGED", "SCHEMA", "TABLESPACE",
-					  "UNLOGGED", "WITH", "WITHOUT", "DISTRIBUTED");
+					  "UNLOGGED", "WITH", "WITHOUT", "DISTRIBUTED",
+					  "SUBPARTITION TEMPLATE");
 
 	else if (Matches("ALTER", "TABLE", MatchAny, "SET", "DISTRIBUTED") ||
 			 Matches("ALTER", "TABLE", MatchAny, "SET", "WITH", "(*)", "DISTRIBUTED"))
@@ -2162,14 +2164,11 @@ psql_completion(const char *text, int start, int end)
 	/* Limited completion support for partition bound specification */
 	else if (TailMatches("ATTACH", "PARTITION", MatchAny))
 		COMPLETE_WITH("FOR VALUES", "DEFAULT");
-	else if (TailMatches("FOR", "VALUES"))
+	else if (TailMatches("ATTACH", "PARTITION", MatchAny, "FOR", "VALUES"))
 		COMPLETE_WITH("FROM (", "IN (", "WITH (");
 
-	/*
-	 * If we have ALTER TABLE <foo> DETACH PARTITION, provide a list of
-	 * partitions of <foo>.
-	 */
-	else if (Matches("ALTER", "TABLE", MatchAny, "DETACH", "PARTITION"))
+	/* ALTER TABLE xxx yyy PARTITION */
+	else if(Matches("ALTER", "TABLE", MatchAny, MatchAnyExcept("ADD"), "PARTITION"))
 	{
 		completion_info_charp = prev3_wd;
 		COMPLETE_WITH_QUERY(Query_for_partition_of_table);

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2209,14 +2209,26 @@ psql_completion(const char *text, int start, int end)
 	}
 
 	/* ALTER TABLE xxx SET DISTRIBUTED BY ( */
-	else if (Matches("ALTER", "TABLE", MatchAny, "SET", "DISTRIBUTED", "BY", "("))
-		COMPLETE_WITH_ATTR(prev5_wd, "");
-	else if(Matches("ALTER", "TABLE", MatchAny, "SET", "WITH", "(*)", "DISTRIBUTED", "BY", "("))
-		COMPLETE_WITH_ATTR(prev7_wd, "");
+	else if (HeadMatches("ALTER", "TABLE", MatchAny, "SET", "DISTRIBUTED", "BY", "(*") ||
+			!HeadMatches("ALTER", "TABLE", MatchAny, "SET", "DISTRIBUTED", "BY", "(*)"))
+	{
+		if(ends_with(prev_wd, ',') || ends_with(prev_wd, '('))
+			COMPLETE_WITH_ATTR(previous_words[previous_words_count - 3], "");
+	}
+	else if(HeadMatches("ALTER", "TABLE", MatchAny, "SET", "WITH", "(*)", "DISTRIBUTED", "BY", "(*") ||
+		   !HeadMatches("ALTER", "TABLE", MatchAny, "SET", "WITH", "(*)", "DISTRIBUTED", "BY", "(*)"))
+	{
+		if(ends_with(prev_wd, ',') || ends_with(prev_wd, '('))
+			COMPLETE_WITH_ATTR(previous_words[previous_words_count - 3], "");
+	}
 
 	/* ALTER TABLE xxx REPACK BY COLUMN ( */
-	else if (Matches("ALTER", "TABLE", MatchAny, "REPACK", "BY", "COLUMNS", "("))
-		COMPLETE_WITH_ATTR(prev5_wd, "");
+	else if (HeadMatches("ALTER", "TABLE", MatchAny, "REPACK", "BY", "COLUMNS", "(*") ||
+			!HeadMatches("ALTER", "TABLE", MatchAny, "REPACK", "BY", "COLUMNS", "(*)"))
+	{
+		if(ends_with(prev_wd, ',') || ends_with(prev_wd, '('))
+			COMPLETE_WITH_ATTR(previous_words[previous_words_count - 3], "");
+	}
 
 	/* ALTER TABLESPACE <foo> with RENAME TO, OWNER TO, SET, RESET */
 	else if (Matches("ALTER", "TABLESPACE", MatchAny))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2030,7 +2030,9 @@ psql_completion(const char *text, int start, int end)
 	}
 	/* ALTER TABLE xxx EXPAND */
 	else if (Matches("ALTER", "TABLE", MatchAny, "EXPAND"))
-		COMPLETE_WITH("TABLE", "PARTITION PREPARE");
+		COMPLETE_WITH("TABLE", "PARTITION");
+	else if (Matches("ALTER", "TABLE", MatchAny, "EXPAND", "PARTITION"))
+		COMPLETE_WITH("PREPARE");
 	/* ALTER TABLE xxx INHERIT */
 	else if (Matches("ALTER", "TABLE", MatchAny, "INHERIT"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_tables, "");

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1992,7 +1992,9 @@ psql_completion(const char *text, int start, int end)
 					  "OWNER TO", "SET", "VALIDATE CONSTRAINT", "EXPAND",
 					  "REPLICA IDENTITY", "ATTACH PARTITION",
 					  "DETACH PARTITION", "REPACK BY COLUMNS (",
-					  "EXCHANGE", "SPLIT", "TRUNCATE");
+					  "EXCHANGE", "SPLIT", "TRUNCATE", "FORCE", "NO FORCE");
+	else if(Matches("ALTER", "TABLE", MatchAny, "NO"))
+		COMPLETE_WITH("INHERIT", "FORCE");
 	/* ALTER TABLE xxx ENABLE */
 	else if (Matches("ALTER", "TABLE", MatchAny, "ENABLE"))
 		COMPLETE_WITH("ALWAYS", "REPLICA", "ROW LEVEL SECURITY", "RULE",
@@ -2012,7 +2014,9 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("ALTER", "TABLE", MatchAny, "ENABLE", "TRIGGER"))
 	{
 		completion_info_charp = prev3_wd;
-		COMPLETE_WITH_QUERY(Query_for_trigger_of_table);
+		COMPLETE_WITH_QUERY(Query_for_trigger_of_table
+							" UNION SELECT 'ALL'"
+							" UNION SELECT 'USER'");
 	}
 	else if (Matches("ALTER", "TABLE", MatchAny, "ENABLE", MatchAny, "TRIGGER"))
 	{
@@ -2039,8 +2043,15 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("ALTER", "TABLE", MatchAny, "DISABLE", "TRIGGER"))
 	{
 		completion_info_charp = prev3_wd;
-		COMPLETE_WITH_QUERY(Query_for_trigger_of_table);
+		COMPLETE_WITH_QUERY(Query_for_trigger_of_table
+							" UNION SELECT 'ALL'"
+							" UNION SELECT 'USER'");
 	}
+
+	/* ALTER TABLE xxx FORCE/NO FORCE */
+	else if (Matches("ALTER", "TABLE", MatchAny, "FORCE") || 
+			 Matches("ALTER", "TABLE", MatchAny, "NO", "FORCE"))
+		COMPLETE_WITH("ROW LEVEL SECURITY");
 
 	/* ALTER TABLE xxx ALTER */
 	else if (Matches("ALTER", "TABLE", MatchAny, "ALTER"))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2227,13 +2227,13 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH("TO");
 
 	/* ALTER TABLE xxx SET DISTRIBUTED BY ( */
-	else if (HeadMatches("ALTER", "TABLE", MatchAny, "SET", "DISTRIBUTED", "BY", "(*") ||
+	else if (HeadMatches("ALTER", "TABLE", MatchAny, "SET", "DISTRIBUTED", "BY", "(*") &&
 			!HeadMatches("ALTER", "TABLE", MatchAny, "SET", "DISTRIBUTED", "BY", "(*)"))
 	{
 		if(ends_with(prev_wd, ',') || ends_with(prev_wd, '('))
 			COMPLETE_WITH_ATTR(previous_words[previous_words_count - 3], "");
 	}
-	else if(HeadMatches("ALTER", "TABLE", MatchAny, "SET", "WITH", "(*)", "DISTRIBUTED", "BY", "(*") ||
+	else if(HeadMatches("ALTER", "TABLE", MatchAny, "SET", "WITH", "(*)", "DISTRIBUTED", "BY", "(*") &&
 		   !HeadMatches("ALTER", "TABLE", MatchAny, "SET", "WITH", "(*)", "DISTRIBUTED", "BY", "(*)"))
 	{
 		if(ends_with(prev_wd, ',') || ends_with(prev_wd, '('))
@@ -2241,7 +2241,7 @@ psql_completion(const char *text, int start, int end)
 	}
 
 	/* ALTER TABLE xxx REPACK BY COLUMN ( */
-	else if (HeadMatches("ALTER", "TABLE", MatchAny, "REPACK", "BY", "COLUMNS", "(*") ||
+	else if (HeadMatches("ALTER", "TABLE", MatchAny, "REPACK", "BY", "COLUMNS", "(*") &&
 			!HeadMatches("ALTER", "TABLE", MatchAny, "REPACK", "BY", "COLUMNS", "(*)"))
 	{
 		if(ends_with(prev_wd, ',') || ends_with(prev_wd, '('))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2139,9 +2139,16 @@ psql_completion(const char *text, int start, int end)
 	{
 		/* Enforce no completion here, as an integer has to be specified */
 	}
-	else if (Matches("ALTER", "TABLE", MatchAny, "ALTER", "COLUMN", MatchAny, "SET", "ENCODING", "(") ||
-			 Matches("ALTER", "TABLE", MatchAny, "ALTER", MatchAny, "SET", "ENCODING", "("))
-			COMPLETE_WITH("compresslevel =", "compresstype =", "blocksize =");
+	else if((HeadMatches("ALTER", "TABLE", MatchAny, "ALTER", MatchAny, "SET", "ENCODING", "(*") &&
+		    !HeadMatches("ALTER", "TABLE", MatchAny, "ALTER", MatchAny, "SET", "ENCODING", "(*)")) ||
+			(HeadMatches("ALTER", "TABLE", MatchAny, "ALTER", "COLUMN", MatchAny, "SET", "ENCODING", "(*") &&
+			!HeadMatches("ALTER", "TABLE", MatchAny, "ALTER", "COLUMN", MatchAny, "SET", "ENCODING", "(*)")))
+	{
+		if(ends_with(prev_wd, ',') || ends_with(prev_wd, '('))
+			COMPLETE_WITH_UNUSED_OPTIONS("compresslevel", "compresstype", "blocksize");
+		else if(TailMatches("compresslevel|compresstype|blocksize"))
+			COMPLETE_WITH("=");
+	}
 	/* ALTER TABLE ALTER [COLUMN] <foo> DROP */
 	else if (Matches("ALTER", "TABLE", MatchAny, "ALTER", "COLUMN", MatchAny, "DROP") ||
 			 Matches("ALTER", "TABLE", MatchAny, "ALTER", MatchAny, "DROP"))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1996,7 +1996,7 @@ psql_completion(const char *text, int start, int end)
 					  "EXCHANGE", "SPLIT", "TRUNCATE", "FORCE", "NO FORCE");
 
 	else if (Matches("ALTER", "TABLE", MatchAny, "ADD"))
-		COMPLETE_WITH("CONSTRAINT", "COLUMN", "PARTITION", "DEFAULT");
+		COMPLETE_WITH("CONSTRAINT", "COLUMN", "PARTITION", "DEFAULT PARTITION");
 
 	else if(Matches("ALTER", "TABLE", MatchAny, "NO"))
 		COMPLETE_WITH("INHERIT", "FORCE");
@@ -2060,7 +2060,7 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH_ATTR(prev2_wd,
 						   " UNION SELECT 'COLUMN'"
 						   " UNION SELECT 'CONSTRAINT'"
-						   " UNION SELECT 'DEFAULT'"
+						   " UNION SELECT 'DEFAULT PARTITION'"
 						   " UNION SELECT 'PARTITION'");
 
 	/* ALTER TABLE xxx RENAME */
@@ -2069,7 +2069,7 @@ psql_completion(const char *text, int start, int end)
 						   " UNION SELECT 'COLUMN'"
 						   " UNION SELECT 'CONSTRAINT'"
 						   " UNION SELECT 'TO'"
-						   " UNION SELECT 'DEFAULT'"
+						   " UNION SELECT 'DEFAULT PARTITION'"
 						   " UNION SELECT 'PARTITION'");
 	else if (Matches("ALTER", "TABLE", MatchAny, "ALTER|RENAME", "COLUMN"))
 		COMPLETE_WITH_ATTR(prev3_wd, "");
@@ -2084,7 +2084,7 @@ psql_completion(const char *text, int start, int end)
 
 	/* If we have ALTER TABLE <sth> DROP, provide COLUMN or CONSTRAINT */
 	else if (Matches("ALTER", "TABLE", MatchAny, "DROP"))
-		COMPLETE_WITH("COLUMN", "CONSTRAINT", "DEFAULT", "PARTITION");
+		COMPLETE_WITH("COLUMN", "CONSTRAINT", "PARTITION", "DEFAULT PARTITION");
 	/* If we have ALTER TABLE <sth> DROP COLUMN, provide list of columns */
 	else if (Matches("ALTER", "TABLE", MatchAny, "DROP", "COLUMN"))
 		COMPLETE_WITH_ATTR(prev3_wd, "");
@@ -2198,12 +2198,8 @@ psql_completion(const char *text, int start, int end)
 	else if (TailMatches("ATTACH", "PARTITION", MatchAny, "FOR", "VALUES"))
 		COMPLETE_WITH("FROM (", "IN (", "WITH (");
 
-	else if (Matches("ALTER", "TABLE", MatchAny, "EXCHANGE"))
-		COMPLETE_WITH("PARTITION", "DEFAULT");
-	else if (Matches("ALTER", "TABLE", MatchAny, "SPLIT"))
-		COMPLETE_WITH("PARTITION", "DEFAULT");
-	else if (Matches("ALTER", "TABLE", MatchAny, "TRUNCATE"))
-		COMPLETE_WITH("PARTITION", "DEFAULT");
+	else if (Matches("ALTER", "TABLE", MatchAny, "EXCHANGE|SPLIT|TRUNCATE"))
+		COMPLETE_WITH("PARTITION", "DEFAULT PARTITION");
 	else if(Matches("ALTER", "TABLE", MatchAny, MatchAny, "DEFAULT"))
 		COMPLETE_WITH("PARTITION");
 

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2175,6 +2175,12 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH_QUERY(Query_for_partition_of_table);
 	}
 
+	/* ALTER TABLE xxx SET DISTRIBUTED BY ( */
+	else if (Matches("ALTER", "TABLE", MatchAny, "SET", "DISTRIBUTED", "BY", "("))
+		COMPLETE_WITH_ATTR(prev5_wd, "");
+	else if(Matches("ALTER", "TABLE", MatchAny, "SET", "WITH", "(*)", "DISTRIBUTED", "BY", "("))
+		COMPLETE_WITH_ATTR(prev7_wd, "");
+
 	/* ALTER TABLE xxx REPACK BY COLUMN ( */
 	else if (Matches("ALTER", "TABLE", MatchAny, "REPACK", "BY", "COLUMNS", "("))
 		COMPLETE_WITH_ATTR(prev5_wd, "");

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1991,7 +1991,7 @@ psql_completion(const char *text, int start, int end)
 					  "ENABLE", "INHERIT", "NO INHERIT", "RENAME", "RESET",
 					  "OWNER TO", "SET", "VALIDATE CONSTRAINT", "EXPAND",
 					  "REPLICA IDENTITY", "ATTACH PARTITION",
-					  "DETACH PARTITION");
+					  "DETACH PARTITION", "REPACK BY COLUMNS (");
 	/* ALTER TABLE xxx ENABLE */
 	else if (Matches("ALTER", "TABLE", MatchAny, "ENABLE"))
 		COMPLETE_WITH("ALWAYS", "REPLICA", "ROW LEVEL SECURITY", "RULE",
@@ -2174,6 +2174,10 @@ psql_completion(const char *text, int start, int end)
 		completion_info_charp = prev3_wd;
 		COMPLETE_WITH_QUERY(Query_for_partition_of_table);
 	}
+
+	/* ALTER TABLE xxx REPACK BY COLUMN ( */
+	else if (Matches("ALTER", "TABLE", MatchAny, "REPACK", "BY", "COLUMNS", "("))
+		COMPLETE_WITH_ATTR(prev5_wd, "");
 
 	/* ALTER TABLESPACE <foo> with RENAME TO, OWNER TO, SET, RESET */
 	else if (Matches("ALTER", "TABLESPACE", MatchAny))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2079,7 +2079,7 @@ psql_completion(const char *text, int start, int end)
 	/* ALTER TABLE ALTER [COLUMN] <foo> SET */
 	else if (Matches("ALTER", "TABLE", MatchAny, "ALTER", "COLUMN", MatchAny, "SET") ||
 			 Matches("ALTER", "TABLE", MatchAny, "ALTER", MatchAny, "SET"))
-		COMPLETE_WITH("(", "DEFAULT", "NOT NULL", "STATISTICS", "STORAGE");
+		COMPLETE_WITH("(", "DEFAULT", "NOT NULL", "STATISTICS", "STORAGE", "ENCODING (");
 	/* ALTER TABLE ALTER [COLUMN] <foo> SET ( */
 	else if (Matches("ALTER", "TABLE", MatchAny, "ALTER", "COLUMN", MatchAny, "SET", "(") ||
 			 Matches("ALTER", "TABLE", MatchAny, "ALTER", MatchAny, "SET", "("))
@@ -2094,6 +2094,9 @@ psql_completion(const char *text, int start, int end)
 	{
 		/* Enforce no completion here, as an integer has to be specified */
 	}
+	else if (Matches("ALTER", "TABLE", MatchAny, "ALTER", "COLUMN", MatchAny, "SET", "ENCODING", "(") ||
+			 Matches("ALTER", "TABLE", MatchAny, "ALTER", MatchAny, "SET", "ENCODING", "("))
+			COMPLETE_WITH("compresslevel =", "compresstype =", "blocksize =");
 	/* ALTER TABLE ALTER [COLUMN] <foo> DROP */
 	else if (Matches("ALTER", "TABLE", MatchAny, "ALTER", "COLUMN", MatchAny, "DROP") ||
 			 Matches("ALTER", "TABLE", MatchAny, "ALTER", MatchAny, "DROP"))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2208,13 +2208,6 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("ALTER", "TABLE", MatchAny, "RENAME", "DEFAULT", "PARTITION"))
 		COMPLETE_WITH("TO");
 
-	/* ALTER TABLE xxx yyy PARTITION */
-	else if(Matches("ALTER", "TABLE", MatchAny, MatchAnyExcept("ADD"), "PARTITION"))
-	{
-		completion_info_charp = prev3_wd;
-		COMPLETE_WITH_QUERY(Query_for_partition_of_table);
-	}
-
 	/* ALTER TABLE xxx SET DISTRIBUTED BY ( */
 	else if (HeadMatches("ALTER", "TABLE", MatchAny, "SET", "DISTRIBUTED", "BY", "(*") ||
 			!HeadMatches("ALTER", "TABLE", MatchAny, "SET", "DISTRIBUTED", "BY", "(*)"))

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1989,7 +1989,7 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("ALTER", "TABLE", MatchAny))
 		COMPLETE_WITH("ADD", "ALTER", "CLUSTER ON", "DISABLE", "DROP",
 					  "ENABLE", "INHERIT", "NO INHERIT", "RENAME", "RESET",
-					  "OWNER TO", "SET", "VALIDATE CONSTRAINT",
+					  "OWNER TO", "SET", "VALIDATE CONSTRAINT", "EXPAND",
 					  "REPLICA IDENTITY", "ATTACH PARTITION",
 					  "DETACH PARTITION");
 	/* ALTER TABLE xxx ENABLE */
@@ -2018,6 +2018,9 @@ psql_completion(const char *text, int start, int end)
 		completion_info_charp = prev4_wd;
 		COMPLETE_WITH_QUERY(Query_for_trigger_of_table);
 	}
+	/* ALTER TABLE xxx EXPAND */
+	else if (Matches("ALTER", "TABLE", MatchAny, "EXPAND"))
+		COMPLETE_WITH("TABLE", "PARTITION PREPARE");
 	/* ALTER TABLE xxx INHERIT */
 	else if (Matches("ALTER", "TABLE", MatchAny, "INHERIT"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_tables, "");

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1990,7 +1990,7 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("ALTER", "TABLE", MatchAny))
 		COMPLETE_WITH("ADD", "ALTER", "CLUSTER ON", "DISABLE", "DROP",
 					  "ENABLE", "INHERIT", "NO INHERIT", "RENAME", "RESET",
-					  "OWNER TO", "SET", "VALIDATE CONSTRAINT", "EXPAND",
+					  "OWNER TO", "SET", "VALIDATE CONSTRAINT",
 					  "REPLICA IDENTITY", "ATTACH PARTITION",
 					  "DETACH PARTITION", "REPACK BY COLUMNS (",
 					  "EXCHANGE", "SPLIT", "TRUNCATE", "FORCE", "NO FORCE");
@@ -2028,11 +2028,6 @@ psql_completion(const char *text, int start, int end)
 		completion_info_charp = prev4_wd;
 		COMPLETE_WITH_QUERY(Query_for_trigger_of_table);
 	}
-	/* ALTER TABLE xxx EXPAND */
-	else if (Matches("ALTER", "TABLE", MatchAny, "EXPAND"))
-		COMPLETE_WITH("TABLE", "PARTITION");
-	else if (Matches("ALTER", "TABLE", MatchAny, "EXPAND", "PARTITION"))
-		COMPLETE_WITH("PREPARE");
 	/* ALTER TABLE xxx INHERIT */
 	else if (Matches("ALTER", "TABLE", MatchAny, "INHERIT"))
 		COMPLETE_WITH_SCHEMA_QUERY(Query_for_list_of_tables, "");

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2203,9 +2203,8 @@ psql_completion(const char *text, int start, int end)
 	else if(Matches("ALTER", "TABLE", MatchAny, MatchAny, "DEFAULT"))
 		COMPLETE_WITH("PARTITION");
 
-	else if (Matches("ALTER", "TABLE", MatchAny, "RENAME", "PARTITION", MatchAny))
-		COMPLETE_WITH("TO");
-	else if (Matches("ALTER", "TABLE", MatchAny, "RENAME", "DEFAULT", "PARTITION"))
+	else if (Matches("ALTER", "TABLE", MatchAny, "RENAME", "PARTITION", MatchAny) ||
+	Matches("ALTER", "TABLE", MatchAny, "RENAME", "DEFAULT", "PARTITION"))
 		COMPLETE_WITH("TO");
 
 	/* ALTER TABLE xxx SET DISTRIBUTED BY ( */


### PR DESCRIPTION
ALTER TABLE command in psql lacked autocompletion support.

Add ENCODING option suggestion.
Add DISTRIBUTED option suggestion.
Add DISTRIBUTED BY column suggestion.
Add REPACK BY COLUMNS option suggestion.
Add USER/ALL suggestion to TRIGGER option.
Add EXCHANGE/SPLIT/TRUNCATE suggestion.
Add PARTITION/DEFAULT PARTITION suggestions to partition altering commands.