### PR TITLE
CI-5908: Directory `sqldump` absent for 8.x

### DIFF
--- a/concourse/scripts/dumpdb.bash
+++ b/concourse/scripts/dumpdb.bash
@@ -25,5 +25,6 @@ psql \
     echo ""
 done
 
+mkdir -pm 777 sqldump
 pg_dumpall -f ./sqldump/dump.sql
-xz -z ./sqldump/dump.sql
+[ -z "${CI:-}" ] && xz -z ./sqldump/dump.sql

--- a/concourse/scripts/ic_gpdb.bash
+++ b/concourse/scripts/ic_gpdb.bash
@@ -72,7 +72,7 @@ function _main() {
     fi
 
     if [ "${DUMP_DB}" == "true" ]; then
-        chmod 777 sqldump
+        [ -d sqldump ] && chmod 777 sqldump || true
         su gpadmin -c ./gpdb_src/concourse/scripts/dumpdb.bash
     fi
 }


### PR DESCRIPTION
## Directory `sqldump` absent for 8.x

- Create directory immediately before create dump with `777` permissions
- Set `777` permissions on `sqldump` directory if exists
- No need to pack SQL dump in CI

Task:[ CI-5908](https://tracker.yandex.ru/CI-5908)