### PR TITLE
GG-576: Fix "Host key verification failed" error in tests

### DIFF
--- a/concourse/scripts/setup_gpadmin_user.bash
+++ b/concourse/scripts/setup_gpadmin_user.bash
@@ -92,6 +92,7 @@ setup_sshd() {
   # Disable password authentication so builds never hang given bad keys
   sed -ri 's/PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config
 
+  echo "MaxStartups 100:30:200" >> /etc/ssh/sshd_config
 
   case "$TEST_OS" in
     centos6 | sles*)


### PR DESCRIPTION
Some behave tests had problem with host key verification. They threw 
`Host key verification failed` on attempt to ssh to some host.

It was happening because of lack of host keys in file `known_hosts`, which
population was happening in `init_containers.sh`.

`ssh-keyscan` was responsible for this task. It was successfully opening
sockets on hosts for each of 5 default algorithms for key authentication (see
`ssh-keyscan` code to understand details, `get_keytypes` holds these default
algorithms), but still was failing to gather required information out of these
sockets: because out of 5 opened sockets only 3 could provide keys by the
chosen algorithm (KT_RSA, KT_ECDSA, KT_ED25519). And these 3 sockets could be
closed after beginning of ssh-protocol, because server was always having
default `sshd` utility configuration, which included default settings of
MaxStartups (10:30:100, it means that if number of unauthorized connections
were bigger then 10, it could close the connection with 30% chance).

To fix this issue, patch suggests to change MaxStartups default setting.

Considering that this is infrastructural issue only and doesn't affect
anything in core, tests are not provided.