### PR TITLE
GG-574: Fix scan for AO table without columns

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -688,8 +688,11 @@ AppendOnlyExecutorReadBlock_GetBlockInfo(AppendOnlyStorageRead *storageRead,
 	executorReadBlock->headerOffsetInFile =
 		AppendOnlyStorageRead_CurrentHeaderOffsetInFile(storageRead);
 
-	/* Start curLargestAttnum from 1, this will be updated in AppendOnlyExecutorReadBlock_BindingInit() */
-	executorReadBlock->curLargestAttnum = 1;
+	/*
+	 * Start curLargestAttnum from 0, memtuple can have no physical attributes.
+	 * This will be updated in AppendOnlyExecutorReadBlock_BindingInit().
+	 */
+	executorReadBlock->curLargestAttnum = 0;
 
 	/* mt_bind should be recreated for the new block */
 	if (executorReadBlock->mt_bind)
@@ -826,8 +829,6 @@ AppendOnlyExecutorReadBlock_BindingInit(AppendOnlyExecutorReadBlock *executorRea
 	int largestAttnum = executorReadBlock->curLargestAttnum;
 	MemoryContext oldContext;
 
-	/* for any row to be read, there's at least one column data in the row */
-	Assert(largestAttnum > 0);
 	Assert(executorReadBlock->attnum_to_rownum != NULL);
 
 	/* Find the number of attributes that are not missing in the row. */

--- a/src/test/regress/expected/alter_table_ao.out
+++ b/src/test/regress/expected/alter_table_ao.out
@@ -1205,6 +1205,89 @@ execute checkattributeencoding('t_addcol_p2');
       3 |       1 | {0,100}     | 
 (1 row)
 
+--
+-- zero-column table
+--
+create table t_addcol_zero_col_default () using ao_row distributed randomly;
+WARNING:  creating a table with no columns.
+-- rows exist, but there are no user columns
+insert into t_addcol_zero_col_default
+select from generate_series(1, 3);
+select count(*) from t_addcol_zero_col_default;
+ count 
+-------
+     3
+(1 row)
+
+execute capturerelfilenodebefore('zero column default 42', 't_addcol_zero_col_default');
+alter table t_addcol_zero_col_default add column a int default 42;
+execute checkrelfilenodediff('zero column default 42', 't_addcol_zero_col_default');
+ segid |        casename        |          relname          | rewritten 
+-------+------------------------+---------------------------+-----------
+     0 | zero column default 42 | t_addcol_zero_col_default | f
+(1 row)
+
+-- existing zero-column rows get the missing/default value
+select * from t_addcol_zero_col_default;
+ a  
+----
+ 42
+ 42
+ 42
+(3 rows)
+
+-- new rows after add column
+insert into t_addcol_zero_col_default default values;
+insert into t_addcol_zero_col_default values (7);
+select * from t_addcol_zero_col_default;
+ a  
+----
+ 42
+ 42
+ 42
+ 42
+  7
+(5 rows)
+
+create table t_addcol_zero_col_null () using ao_row distributed randomly;
+WARNING:  creating a table with no columns.
+insert into t_addcol_zero_col_null
+select from generate_series(1, 3);
+select count(*) from t_addcol_zero_col_null;
+ count 
+-------
+     3
+(1 row)
+
+execute capturerelfilenodebefore('zero column null default', 't_addcol_zero_col_null');
+alter table t_addcol_zero_col_null add column a int;
+execute checkrelfilenodediff('zero column null default', 't_addcol_zero_col_null');
+ segid |         casename         |        relname         | rewritten 
+-------+--------------------------+------------------------+-----------
+     0 | zero column null default | t_addcol_zero_col_null | f
+(1 row)
+
+-- existing zero-column rows get NULL for the new column
+select * from t_addcol_zero_col_null;
+ a 
+---
+  
+  
+  
+(3 rows)
+
+insert into t_addcol_zero_col_null default values;
+insert into t_addcol_zero_col_null values (7);
+select * from t_addcol_zero_col_null;
+ a 
+---
+ 7
+  
+  
+  
+  
+(5 rows)
+
 --- test SET ACCESS METHOD ao_column for tables with many columns
 create table t_access_method (
   c1 int,

--- a/src/test/regress/sql/alter_table_ao.sql
+++ b/src/test/regress/sql/alter_table_ao.sql
@@ -679,6 +679,50 @@ execute checkattributeencoding('t_addcol');
 execute checkattributeencoding('t_addcol_p1');
 execute checkattributeencoding('t_addcol_p2');
 
+--
+-- zero-column table
+--
+
+create table t_addcol_zero_col_default () using ao_row distributed randomly;
+
+-- rows exist, but there are no user columns
+insert into t_addcol_zero_col_default
+select from generate_series(1, 3);
+
+select count(*) from t_addcol_zero_col_default;
+
+execute capturerelfilenodebefore('zero column default 42', 't_addcol_zero_col_default');
+alter table t_addcol_zero_col_default add column a int default 42;
+execute checkrelfilenodediff('zero column default 42', 't_addcol_zero_col_default');
+
+-- existing zero-column rows get the missing/default value
+select * from t_addcol_zero_col_default;
+
+-- new rows after add column
+insert into t_addcol_zero_col_default default values;
+insert into t_addcol_zero_col_default values (7);
+
+select * from t_addcol_zero_col_default;
+
+create table t_addcol_zero_col_null () using ao_row distributed randomly;
+
+insert into t_addcol_zero_col_null
+select from generate_series(1, 3);
+
+select count(*) from t_addcol_zero_col_null;
+
+execute capturerelfilenodebefore('zero column null default', 't_addcol_zero_col_null');
+alter table t_addcol_zero_col_null add column a int;
+execute checkrelfilenodediff('zero column null default', 't_addcol_zero_col_null');
+
+-- existing zero-column rows get NULL for the new column
+select * from t_addcol_zero_col_null;
+
+insert into t_addcol_zero_col_null default values;
+insert into t_addcol_zero_col_null values (7);
+
+select * from t_addcol_zero_col_null;
+
 
 --- test SET ACCESS METHOD ao_column for tables with many columns
 create table t_access_method (


### PR DESCRIPTION
Commit d3dcb9b taught AO row scans to determine the number of physical
attributes from metadata for fast ALTER TABLE ADD COLUMN. That code assumed
that each scanned tuple had at least one physical attribute and incorrectly
started from 1. For a zero-column AO row table, the scan tuple descriptor had
natts = 0, but the read block kept curLargestAttnum at 1 and passed
expected_natts = 1 to create_memtuple_binding(). Assertion builds failed
because create_memtuple_binding() required expected_natts to be between 0 and
tupdesc->natts. Release builds could create an invalid binding and crash later
while deforming the memtuple.

Initialize curLargestAttnum to 0 when starting a new AO read block, and allow
AppendOnlyExecutorReadBlock_BindingInit() to create a binding with zero
expected attributes.

Ticket: GG-574