### PR TITLE
CI-5911: SQL dump generated but not collected for 8.x

### DIFF
--- a/concourse/scripts/dumpdb.bash
+++ b/concourse/scripts/dumpdb.bash
@@ -26,5 +26,15 @@ psql \
 done
 
 mkdir -pm 777 sqldump
-pg_dumpall -f ./sqldump/dump.sql
-[ -z "${CI:-}" ] && xz -z ./sqldump/dump.sql
+echo "-----------------------------------------------------------------"
+echo "Starting 'pg_dumpall'"
+echo "-----------------------------------------------------------------"
+pg_dumpall -f ./sqldump/dump.sql -v || pg_dumpall_exit_code=$?
+pg_dumpall_exit_code=${pg_dumpall_exit_code:-0}
+echo "-----------------------------------------------------------------"
+echo "Finished 'pg_dumpall' with exit code: '$pg_dumpall_exit_code'"
+echo "-----------------------------------------------------------------"
+if [[ -z "${CI:-}" ]]; then
+    xz -z ./sqldump/dump.sql
+fi
+exit "$pg_dumpall_exit_code"

--- a/concourse/scripts/dumpdb.bash
+++ b/concourse/scripts/dumpdb.bash
@@ -26,15 +26,7 @@ psql \
 done
 
 mkdir -pm 777 sqldump
-echo "-----------------------------------------------------------------"
-echo "Starting 'pg_dumpall'"
-echo "-----------------------------------------------------------------"
-pg_dumpall -f ./sqldump/dump.sql -v || pg_dumpall_exit_code=$?
-pg_dumpall_exit_code=${pg_dumpall_exit_code:-0}
-echo "-----------------------------------------------------------------"
-echo "Finished 'pg_dumpall' with exit code: '$pg_dumpall_exit_code'"
-echo "-----------------------------------------------------------------"
+pg_dumpall -f ./sqldump/dump.sql
 if [[ -z "${CI:-}" ]]; then
     xz -z ./sqldump/dump.sql
 fi
-exit "$pg_dumpall_exit_code"


### PR DESCRIPTION
## SQL dump generated but not collected for 8.x (#513)

- replace one-liner `[ -z "${CI:-}" ] && xz` with explicit `if/else`
  to prevent `set -e` from killing the script when `xz` is skipped in CI
  (non-zero exit from `&&` chain propagates even on the false branch)

Task: [CI-5911](https://tracker.yandex.ru/CI-5911)