### PR TITLE
GG-551: Report tables and columns removed from Greengage 7 (7.x)

### DIFF
--- a/src/bin/pg_upgrade/greengage/check_gp.c
+++ b/src/bin/pg_upgrade/greengage/check_gp.c
@@ -37,6 +37,8 @@ static void check_views_with_changed_function_signatures(void);
 static void check_execute_on_master_functions(void);
 static void check_for_missing_support_function_for_partitions(void);
 static void check_for_incompatible_guc_settings(void);
+static void check_views_with_removed_columns(void);
+static void check_views_with_removed_relations(void);
 
 /*
  *	check_greengage
@@ -60,6 +62,8 @@ check_greengage(void)
 	check_views_with_removed_operators();
 	check_views_with_removed_functions();
 	check_views_with_removed_types();
+	check_views_with_removed_columns();
+	check_views_with_removed_relations();
 	check_for_disallowed_pg_operator();
 	check_views_with_changed_function_signatures();
 	check_execute_on_master_functions();
@@ -882,7 +886,7 @@ check_views_with_removed_operators()
 		res = executeQueryOrDie(conn,
 								"SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS badviewname "
 								"FROM pg_class c JOIN pg_namespace n on c.relnamespace=n.oid "
-								"WHERE c.relkind = 'v' AND "
+								"WHERE c.relkind IN ('v', 'm') AND "
 								"view_has_removed_operators(c.oid) = TRUE;");
 
 		PQclear(executeQueryOrDie(conn, "DROP FUNCTION view_has_removed_operators(OID);"));
@@ -969,7 +973,7 @@ check_views_with_removed_functions()
 		res = executeQueryOrDie(conn,
 								"SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS badviewname "
 								"FROM pg_class c JOIN pg_namespace n on c.relnamespace=n.oid "
-								"WHERE c.relkind = 'v' "
+								"WHERE c.relkind IN ('v', 'm') "
 								"AND c.oid >= 16384 "
 								"AND view_has_removed_functions(c.oid) = TRUE;");
 
@@ -1057,7 +1061,7 @@ check_views_with_removed_types()
 		res = executeQueryOrDie(conn,
 								"SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS badviewname "
 								"FROM pg_class c JOIN pg_namespace n on c.relnamespace=n.oid "
-								"WHERE c.relkind = 'v' "
+								"WHERE c.relkind IN ('v', 'm') "
 								"AND c.oid >= 16384 "
 								"AND view_has_removed_types(c.oid) = TRUE;");
 
@@ -1210,7 +1214,7 @@ check_views_with_changed_function_signatures()
 								"SELECT pg_catalog.quote_ident(n.nspname) "
 								"|| '.' || pg_catalog.quote_ident(c.relname) AS badviewname "
 								"FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n on c.relnamespace=n.oid "
-								"WHERE c.relkind = 'v' "
+								"WHERE c.relkind IN ('v', 'm') "
 								"AND c.oid >= %d "
 								"AND public.view_has_changed_function_signatures(c.oid) = TRUE;", FirstNormalObjectId);
 
@@ -1537,6 +1541,214 @@ check_for_incompatible_guc_settings(void)
 			"| Remove unsupported storage options from gp_default_storage_options before\n"
 			"| upgrade can continue. A list of the problem settings is in the file:\n"
 			"|     %s\n\n", output_path);
+	}
+	else
+		check_ok();
+}
+
+static void
+check_views_with_removed_columns()
+{
+	if (GET_MAJOR_VERSION(old_cluster.major_version) > 904)
+		return;
+
+	char  output_path[MAXPGPATH];
+	FILE *script = NULL;
+	bool  found = false;
+	prep_status("Checking for views with removed columns");
+
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir, "view_referencing_removed_columns.txt");
+
+	for (int dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
+	{
+		PGresult *res;
+		int		  ntups;
+		int		  rowno;
+		DbInfo	 *active_db = &old_cluster.dbarr.dbs[dbnum];
+		PGconn	 *conn;
+		int       i_viewname;
+		int       i_removed_columns;
+
+		conn = connectToServer(&old_cluster, active_db->db_name);
+
+		/* track_counts is disables for the same reason as above */
+		PQclear(executeQueryOrDie(conn, "SET track_counts TO off;"));
+
+		/* Install check support function */
+		PQclear(executeQueryOrDie(conn,
+								  "CREATE OR REPLACE FUNCTION "
+								  "public.get_removed_columns(OID) "
+								  "RETURNS TEXT "
+								  "AS '$libdir/pg_upgrade_support' "
+								  "LANGUAGE C STRICT;"));
+		res = executeQueryOrDie(conn,
+								"SELECT badviewname, removed_columns FROM ("
+								"	SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS badviewname, "
+								"          public.get_removed_columns(c.oid) AS removed_columns "
+								"	FROM pg_class c JOIN pg_namespace n on c.relnamespace=n.oid "
+								"	WHERE c.oid >= %d AND "
+								"	c.relkind IN ('v', 'm') "
+								") views "
+								"WHERE removed_columns != ''",
+								FirstNormalObjectId);
+
+		PQclear(executeQueryOrDie(conn, "DROP FUNCTION public.get_removed_columns(OID);"));
+		PQclear(executeQueryOrDie(conn, "RESET track_counts;"));
+
+		ntups = PQntuples(res);
+		if (ntups == 0)
+		{
+			PQclear(res);
+			PQfinish(conn);
+			continue;
+		}
+		found = true;
+
+		if (!script)
+		{
+			/*
+			 * This is the first database that has affected view,
+			 * try to open the output file
+			 */
+			script = fopen(output_path, "w");
+			if (!script)
+				pg_fatal("could not open file \"%s\": %s\n",
+					output_path, strerror(errno));
+		}
+
+		fprintf(script, "Database: %s\n", active_db->db_name);
+
+		i_viewname = PQfnumber(res, "badviewname");
+		i_removed_columns = PQfnumber(res, "removed_columns");
+
+		for (rowno = 0; rowno < ntups; rowno++)
+		{
+			fprintf(script, "  %s\n%s\n",
+					PQgetvalue(res, rowno, i_viewname),
+					PQgetvalue(res, rowno, i_removed_columns));
+		}
+
+		PQclear(res);
+		PQfinish(conn);
+	}
+
+	if (script)
+		fclose(script);
+
+	if (found)
+	{
+		pg_log(PG_REPORT, "fatal\n");
+		gp_fatal_log(
+		   "| Your installation contains views using removed columns.\n"
+		   "| These columns are no longer present on the target version.\n"
+		   "| These views must be updated to use columns supported in the\n"
+		   "| target version or removed before upgrade can continue. A list\n"
+		   "| of the problem views is in the file:\n\t%s\n\n", output_path);
+	}
+	else
+		check_ok();
+}
+
+
+static void
+check_views_with_removed_relations()
+{
+	if (GET_MAJOR_VERSION(old_cluster.major_version) > 904)
+		return;
+
+	char  output_path[MAXPGPATH];
+	FILE *script = NULL;
+	bool  found = false;
+	prep_status("Checking for views with removed relations");
+
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir, "view_referencing_removed_relations.txt");
+
+	for (int dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
+	{
+		PGresult *res;
+		int		  ntups;
+		int		  rowno;
+		DbInfo	 *active_db = &old_cluster.dbarr.dbs[dbnum];
+		PGconn	 *conn;
+		int       i_viewname;
+		int       i_removed_tables;
+
+		conn = connectToServer(&old_cluster, active_db->db_name);
+
+		/* track_counts is disables for the same reason as above */
+		PQclear(executeQueryOrDie(conn, "SET track_counts TO off;"));
+
+		/* Install check support function */
+		PQclear(executeQueryOrDie(conn,
+								  "CREATE OR REPLACE FUNCTION "
+								  "public.get_removed_tables(OID) "
+								  "RETURNS TEXT "
+								  "AS '$libdir/pg_upgrade_support' "
+								  "LANGUAGE C STRICT;"));
+		res = executeQueryOrDie(conn,
+								"SELECT badviewname, removed_tables FROM ("
+								"	SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS badviewname, "
+								"          public.get_removed_tables(c.oid) AS removed_tables "
+								"	FROM pg_class c JOIN pg_namespace n on c.relnamespace=n.oid "
+								"	WHERE c.oid >= %d AND "
+								"	c.relkind IN ('v', 'm') "
+								") views "
+								"WHERE removed_tables != ''",
+								FirstNormalObjectId);
+		PQclear(executeQueryOrDie(conn, "DROP FUNCTION public.get_removed_tables(OID);"));
+		PQclear(executeQueryOrDie(conn, "RESET track_counts;"));
+
+		ntups = PQntuples(res);
+		if (ntups == 0)
+		{
+			PQclear(res);
+			PQfinish(conn);
+			continue;
+		}
+		found = true;
+
+		if (!script)
+		{
+			/*
+			 * This is the first database that has affected views,
+			 * try to open the output file
+			 */
+			script = fopen(output_path, "w");
+			if (!script)
+				pg_fatal("could not open file \"%s\": %s\n",
+					output_path, strerror(errno));
+		}
+
+		fprintf(script, "Database: %s\n", active_db->db_name);
+
+		i_viewname = PQfnumber(res, "badviewname");
+		i_removed_tables = PQfnumber(res, "removed_tables");
+
+		for (rowno = 0; rowno < ntups; rowno++)
+		{
+			fprintf(script, "  %s\n%s\n",
+					PQgetvalue(res, rowno, i_viewname),
+					PQgetvalue(res, rowno, i_removed_tables));
+		}
+
+		PQclear(res);
+		PQfinish(conn);
+	}
+
+	if (script)
+		fclose(script);
+
+	if (found)
+	{
+		pg_log(PG_REPORT, "fatal\n");
+		gp_fatal_log(
+		   "| Your installation contains views using removed relations.\n"
+		   "| These relations are no longer present on the target version.\n"
+		   "| These views must be updated to use relations supported in the\n"
+		   "| target version or removed before upgrade can continue. A list\n"
+		   "| of the problem views is in the file:\n\t%s\n\n", output_path);
 	}
 	else
 		check_ok();


### PR DESCRIPTION
Check for views with removed relations and columns before 
performing upgrade. They will cause pg_restore to fail in the 
middle of the upgrade, and it might get a lot of time to get 
to this point. So report them to the user in advance.

The same problems can appear in materialized views,
therefore it is necessary to checks them in addition 
to regular ones.

Don't add tests because they belong to the ggupgrade repo
and will be added there after this patch.

Ticket: GG-551