### PR TITLE
Adds a per-attribute column-fetch path for AOCS table scans

### DIFF
--- a/.abi-check/7.4.1/postgres.symbols.ignore
+++ b/.abi-check/7.4.1/postgres.symbols.ignore
@@ -1,1 +1,5 @@
 ConfigureNamesBool_gp
+TTSOpsBufferHeapTuple
+TTSOpsHeapTuple
+TTSOpsMinimalTuple
+TTSOpsVirtual

--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -350,6 +350,8 @@ AOCSSegmentFileFullCompaction(Relation aorel,
 										 curr_heap_blks_scanned);
 			prev_heap_blks_scanned = curr_heap_blks_scanned;
 		}
+
+		ExecClearTuple(slot);
 	}
 	/* Accumulate total number dead tuples */
 	vacrelstats->num_dead_tuples += scanDesc->segrowsprocessed - moved_tupleCount;

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1389,8 +1389,6 @@ aocs_getnext(AOCSScanDesc scan, ScanDirection direction, TupleTableSlot *slot)
 		initscan_with_colinfo(scan);
 	}
 
-	//elog(LOG, "[RELOG][%s] slot %p", __FUNCTION__, slot);
-
 	AttrNumber anchor_attr = scan->columnScanInfo.proj_atts[ANCHOR_COL_IN_PROJ];
 
 	if (gp_aocs_scan_shortpass &&
@@ -1515,9 +1513,6 @@ aocs_getnext(AOCSScanDesc scan, ScanDirection direction, TupleTableSlot *slot)
 	}
 	else
 	{
-
-	while (1)
-	{
 		AOCSFileSegInfo *curseginfo;
 
 		// TODO: check if we need to simply call tts_virtual_aocs_clear
@@ -1559,92 +1554,44 @@ ReadNext:
 		Assert(scan->cur_seg >= 0);
 		curseginfo = scan->seginfo[scan->cur_seg];
 
-		int tts_nvalid = anchor_attr+1;
-
-		// TODO: read only anchor column
-
 		/* Read from cur_seg */
-		for (AttrNumber i = 0; i < scan->columnScanInfo.num_proj_atts; i++)
+		AttrNumber	attno = anchor_attr;
+
+		err = datumstreamread_advance(scan->columnScanInfo.ds[attno]);
+		Assert(err >= 0);
+		if (err == 0)
 		{
-			AttrNumber	attno = scan->columnScanInfo.proj_atts[i];
-
-			if (attno > anchor_attr)
-				break;
-
-			/*
-			 * Check missing value before reading from data files.
-			 * 
-			 * We don't need to check the missing value for the anchor column.
-			 * In fact, we cannot do that either because we don't have the
-			 * row number until we've scanned the anchor column.
-			 */
-			if (attno != anchor_attr)
+			err = datumstreamread_block(scan->columnScanInfo.ds[attno], scan->blockDirectory, attno);
+			if (err < 0)
 			{
-				Assert(rowNum > 0);
-				if (AO_ATTR_VAL_IS_MISSING(rowNum,
-															attno,
-															curseginfo->segno,
-															scan->columnScanInfo.attnum_to_rownum))
-				{
-					/*
-					 * XXX: should we temporarily store the missing value to avoid repeatedly calling
-					 * getmissingattr? The performance gain seems not much though. 
-					 */
-					d[attno] = getmissingattr(slot->tts_tupleDescriptor, attno + 1, &null[attno]);
-					slotAocs->tts_is_valid[attno] = true;
-					continue;
-				}
+				/*
+				 * Ha, cannot read next block, we need to go to next seg
+				 */
+				close_cur_scan_seg(scan);
+				goto ReadNext;
 			}
 
-			/* otherwise, read from data file */
+			AOCSScanDesc_UpdateTotalBytesRead(scan, attno);
+			pgstat_count_buffer_read_ao(scan->rs_base.rs_rd,
+										RelationGuessNumberOfBlocksFromSize(scan->totalBytesRead));
+
 			err = datumstreamread_advance(scan->columnScanInfo.ds[attno]);
-			Assert(err >= 0);
-			if (err == 0)
-			{
-				err = datumstreamread_block(scan->columnScanInfo.ds[attno], scan->blockDirectory, attno);
-				if (err < 0)
-				{
-					/*
-					 * Ha, cannot read next block, we need to go to next seg
-					 */
-					close_cur_scan_seg(scan);
-					goto ReadNext;
-				}
+			Assert(err > 0);
+		}
 
-				AOCSScanDesc_UpdateTotalBytesRead(scan, attno);
-				pgstat_count_buffer_read_ao(scan->rs_base.rs_rd,
-											RelationGuessNumberOfBlocksFromSize(scan->totalBytesRead));
+		/*
+		 * Get the column's datum right here since the data structures
+		 * should still be hot in CPU data cache memory.
+		 */
+		datumstreamread_get(scan->columnScanInfo.ds[attno], &d[attno], &null[attno]);
+		slotAocs->tts_is_valid[attno] = true;
 
-				err = datumstreamread_advance(scan->columnScanInfo.ds[attno]);
-				Assert(err > 0);
-			}
-
-			/*
-			 * Get the column's datum right here since the data structures
-			 * should still be hot in CPU data cache memory.
-			 */
-			datumstreamread_get(scan->columnScanInfo.ds[attno], &d[attno], &null[attno]);
-			slotAocs->tts_is_valid[attno] = true;
-
-			nthInBlock = datumstreamread_nth(scan->columnScanInfo.ds[attno]);
-			if (rowNum == InvalidAORowNum &&
-				scan->columnScanInfo.ds[attno]->blockFirstRowNum != InvalidAORowNum)
-			{
-				Assert(scan->columnScanInfo.ds[attno]->blockFirstRowNum > 0 && nthInBlock >= 0);
-				rowNum = scan->columnScanInfo.ds[attno]->blockFirstRowNum + nthInBlock;
-			}
-#ifdef USE_ASSERT_CHECKING
-			/*
-			 * the row number from every column should match
-			 * XXX: the first assert is repeated code, we should move it outside of
-			 * the if/else block if we can be sure blockFirstRowNum cannot be -1 here.
-			 */
-			else if (scan->columnScanInfo.ds[attno]->blockFirstRowNum != InvalidAORowNum)
-			{
-				Assert(scan->columnScanInfo.ds[attno]->blockFirstRowNum > 0 && nthInBlock >= 0);
-				Assert(rowNum == scan->columnScanInfo.ds[attno]->blockFirstRowNum + nthInBlock);
-			}
-#endif
+		nthInBlock = datumstreamread_nth(scan->columnScanInfo.ds[attno]);
+		if (rowNum == InvalidAORowNum &&
+			scan->columnScanInfo.ds[attno]->blockFirstRowNum != InvalidAORowNum)
+		{
+			Assert(scan->columnScanInfo.ds[attno]->blockFirstRowNum > 0 && nthInBlock >= 0);
+			rowNum = scan->columnScanInfo.ds[attno]->blockFirstRowNum + nthInBlock;
 		}
 
 		scan->segrowsprocessed++;
@@ -1665,13 +1612,13 @@ ReadNext:
 		}
 		scan->cdb_fake_ctid = *((ItemPointer) &aoTupleId);
 
-		slot->tts_nvalid = tts_nvalid;
+		// TODO: add comments here as it might confuse
+		slot->tts_nvalid = 0;
 
 		slot->tts_tid = scan->cdb_fake_ctid;
 
 		slotAocs->current_scan = (void*)scan;
 		return true;
-	}
 	}
 
 	Assert(!"Never here");

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1515,11 +1515,6 @@ aocs_getnext(AOCSScanDesc scan, ScanDirection direction, TupleTableSlot *slot)
 	else
 	{
 		AOCSFileSegInfo *curseginfo;
-
-		// TODO: check if we need to simply call tts_virtual_aocs_clear
-		bms_free(slotAocs->tts_is_valid);
-		slotAocs->tts_is_valid = NULL;
-
 ReadNext:
 		/* If necessary, open next seg */
 		if (scan->cur_seg < 0 || err < 0)
@@ -3684,6 +3679,8 @@ aocs_writecol_rewritesegfiles(
 		ResetExprContext(econtext);
 		CHECK_FOR_INTERRUPTS();
 		expectedFRN++;
+
+		ExecClearTuple(oldslot);
 	}
 }
 

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1374,6 +1374,7 @@ aocs_getnext(AOCSScanDesc scan, ScanDirection direction, TupleTableSlot *slot)
 	int			err = 0;
 	bool		isSnapshotAny = (scan->rs_base.rs_snapshot == SnapshotAny);
 	VirtualTupleTableSlotAOCS * slotAocs = (VirtualTupleTableSlotAOCS*)slot;
+	MemoryContext oldContext;
 
 	Assert(ScanDirectionIsForward(direction));
 
@@ -1516,11 +1517,8 @@ aocs_getnext(AOCSScanDesc scan, ScanDirection direction, TupleTableSlot *slot)
 		AOCSFileSegInfo *curseginfo;
 
 		// TODO: check if we need to simply call tts_virtual_aocs_clear
-		for (AttrNumber i = 0; i < scan->columnScanInfo.num_proj_atts; i++)
-		{
-			AttrNumber	attno = scan->columnScanInfo.proj_atts[i];
-			slotAocs->tts_is_valid[attno] = false;
-		}
+		bms_free(slotAocs->tts_is_valid);
+		slotAocs->tts_is_valid = NULL;
 
 ReadNext:
 		/* If necessary, open next seg */
@@ -1584,7 +1582,10 @@ ReadNext:
 		 * should still be hot in CPU data cache memory.
 		 */
 		datumstreamread_get(scan->columnScanInfo.ds[attno], &d[attno], &null[attno]);
-		slotAocs->tts_is_valid[attno] = true;
+
+		oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
+		slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
+		MemoryContextSwitchTo(oldContext);
 
 		nthInBlock = datumstreamread_nth(scan->columnScanInfo.ds[attno]);
 		if (rowNum == InvalidAORowNum &&

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1591,6 +1591,7 @@ ReadNext:
 					 * getmissingattr? The performance gain seems not much though. 
 					 */
 					d[attno] = getmissingattr(slot->tts_tupleDescriptor, attno + 1, &null[attno]);
+					slotAocs->tts_is_valid[attno] = true;
 					continue;
 				}
 			}
@@ -1623,6 +1624,7 @@ ReadNext:
 			 * should still be hot in CPU data cache memory.
 			 */
 			datumstreamread_get(scan->columnScanInfo.ds[attno], &d[attno], &null[attno]);
+			slotAocs->tts_is_valid[attno] = true;
 
 			nthInBlock = datumstreamread_nth(scan->columnScanInfo.ds[attno]);
 			if (rowNum == InvalidAORowNum &&

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -346,6 +346,17 @@ int aoco_proj_move_anchor_first(AttrNumber *proj_atts,
 	return num_proj_atts;
 }
 
+static void
+aocs_sole_rowid_scan_finish(AOCSScanDesc scan)
+{
+	if (scan->soleRowIdScan.scan_blkdir != NULL)
+	{
+		systable_endscan(scan->soleRowIdScan.scan_blkdir);
+		pfree(scan->soleRowIdScan.curr_minipage.minipage);
+		scan->soleRowIdScan.scan_blkdir = NULL;
+	}
+}
+
 void
 initscan_with_colinfo(AOCSScanDesc scan)
 {
@@ -414,6 +425,31 @@ initscan_with_colinfo(AOCSScanDesc scan)
 				 scan->columnScanInfo.relationTupleDesc,
 				 scan->columnScanInfo.proj_atts, scan->columnScanInfo.num_proj_atts,
 				 scan->checksum);
+
+	if (gp_aocs_scan_shortpass &&
+	   !gp_select_invisible &&
+	   scan->columnScanInfo.projKind == AOCS_PROJ_ANY &&
+	   !scan->blockDirectory && scan->aocsfetch)
+	{
+		aocs_sole_rowid_scan_finish(scan);
+
+		ScanKeyData scanKey;
+		ScanKeyInit(&scanKey,
+					Anum_pg_aoblkdir_columngroupno,
+					BTEqualStrategyNumber,
+					F_INT4EQ,
+					Int32GetDatum(anchor_colno));
+
+		scan->soleRowIdScan.scan_blkdir = systable_beginscan(scan->aocsfetch->blockDirectory.blkdirRel,
+										   InvalidOid,
+										   true,
+										   scan->rs_base.rs_snapshot,
+										   1,
+										   &scanKey);
+		scan->soleRowIdScan.curr_minipage.minipage = palloc0(minipage_size(NUM_MINIPAGE_ENTRIES));
+		scan->soleRowIdScan.curr_minipage_valid = false;
+		scan->soleRowIdScan.minipage_entry = NULL;
+	}
 
 	MemoryContextSwitchTo(oldCtx);
 
@@ -733,6 +769,12 @@ aocs_beginscan_internal(Relation relation,
 
 	scan->blkdirscan = NULL;
 
+	scan->soleRowIdScan.scan_blkdir = NULL;
+	scan->soleRowIdScan.minipage_entry = NULL;
+	scan->soleRowIdScan.curr_minipage_valid = false;
+	scan->soleRowIdScan.curr_minipage_entry_idx = 0;
+	scan->soleRowIdScan.segno = -1;
+
 	if (scan->total_seg != 0)
 	{
 		AppendOnlyVisimap_Init(&scan->visibilityMap,
@@ -886,6 +928,8 @@ aocs_endscan(AOCSScanDesc scan)
 		aocs_blkdirscan_finish(scan);
 
 	RelationDecrementReferenceCount(scan->rs_base.rs_rd);
+
+	aocs_sole_rowid_scan_finish(scan);
 
 	pfree(scan);
 }
@@ -1392,44 +1436,21 @@ aocs_getnext(AOCSScanDesc scan, ScanDirection direction, TupleTableSlot *slot)
 
 	AttrNumber anchor_attr = scan->columnScanInfo.proj_atts[ANCHOR_COL_IN_PROJ];
 
-	if (gp_aocs_scan_shortpass &&
-		!gp_select_invisible &&
-		scan->columnScanInfo.projKind == AOCS_PROJ_ANY &&
-		!scan->blockDirectory && scan->aocsfetch)
+	if (unlikely(scan->soleRowIdScan.scan_blkdir))
 	{
 		/*
 		 * Short pass via visibility map and block directory for cases when
 		 * there is no actual need to access tables data, for ex. for queries
 		 * like "SELECT COUNT(*) FROM some_table;".
 		 */
-
-		typedef struct Context
-		{
-			SysScanDesc					scan_blkdir;
-			MinipagePerColumnGroup		curr_minipage;
-			MinipageEntry				*minipage_entry;
-			bool						curr_minipage_valid;
-			int							curr_minipage_entry_idx;
-			int							segno;
-		} Context;
-
-		static Context context =
-		{
-			.scan_blkdir = NULL,
-			.minipage_entry = NULL,
-			.curr_minipage_valid = false,
-			.curr_minipage_entry_idx = 0,
-			.segno = -1
-		};
-
 		while(1)
 		{
-			if (likely(context.minipage_entry &&
-					  scan->segrowsprocessed < context.minipage_entry->rowCount))
+			if (likely(scan->soleRowIdScan.minipage_entry &&
+					  scan->segrowsprocessed < scan->soleRowIdScan.minipage_entry->rowCount))
 			{
-				Assert(context.segno >= 0);
+				Assert(scan->soleRowIdScan.segno >= 0);
 				scan->segrowsprocessed++;
-				AOTupleIdInit(&aoTupleId, context.segno, context.minipage_entry->firstRowNum + scan->segrowsprocessed-1);
+				AOTupleIdInit(&aoTupleId, scan->soleRowIdScan.segno, scan->soleRowIdScan.minipage_entry->firstRowNum + scan->segrowsprocessed-1);
 				if (!isSnapshotAny && !AppendOnlyVisimap_IsVisible(&scan->visibilityMap, &aoTupleId))
 				{
 					/* The tuple is invisible */
@@ -1440,74 +1461,46 @@ aocs_getnext(AOCSScanDesc scan, ScanDirection direction, TupleTableSlot *slot)
 				return true;
 			}
 
-			if (likely(context.curr_minipage_valid))
+			if (likely(scan->soleRowIdScan.curr_minipage_valid))
 			{
-				Assert(context.curr_minipage_entry_idx < context.curr_minipage.numMinipageEntries);
+				Assert(scan->soleRowIdScan.curr_minipage_entry_idx < scan->soleRowIdScan.curr_minipage.numMinipageEntries);
 
-				context.minipage_entry = &context.curr_minipage.minipage->entry[context.curr_minipage_entry_idx];
+				scan->soleRowIdScan.minipage_entry = &scan->soleRowIdScan.curr_minipage.minipage->entry[scan->soleRowIdScan.curr_minipage_entry_idx];
 				scan->segrowsprocessed = 0;
 
-				context.curr_minipage_entry_idx++;
-				context.curr_minipage_valid =
-					(context.curr_minipage_entry_idx != context.curr_minipage.numMinipageEntries);
+				scan->soleRowIdScan.curr_minipage_entry_idx++;
+				scan->soleRowIdScan.curr_minipage_valid =
+					(scan->soleRowIdScan.curr_minipage_entry_idx != scan->soleRowIdScan.curr_minipage.numMinipageEntries);
 				continue;
 			}
 
-			if (unlikely(context.scan_blkdir == NULL))
-			{
-				static ScanKeyData scanKey;
-				ScanKeyInit(&scanKey,
-							Anum_pg_aoblkdir_columngroupno,
-							BTEqualStrategyNumber,
-							F_INT4EQ,
-							Int32GetDatum(anchor_attr));
-
-				context.scan_blkdir = systable_beginscan(scan->aocsfetch->blockDirectory.blkdirRel,
-												   InvalidOid,
-												   true,// false,
-												   scan->rs_base.rs_snapshot,
-												   1,
-												   &scanKey);
-				context.curr_minipage.minipage = palloc0(minipage_size(NUM_MINIPAGE_ENTRIES));
-				context.curr_minipage_valid = false;
-				context.minipage_entry = NULL;
-			}
-
-			if (!context.curr_minipage_valid)
+			if (!scan->soleRowIdScan.curr_minipage_valid)
 			{
 				Datum	minipage_datum;
 				bool	minipageNull;
 				bool	segnoNull;
 
-				if (!HeapTupleIsValid(systable_getnext(context.scan_blkdir)))
+				if (!HeapTupleIsValid(systable_getnext(scan->soleRowIdScan.scan_blkdir)))
 				{
 					/* No more seg, we are at the end */
-					systable_endscan(context.scan_blkdir);
-					context.scan_blkdir = NULL;
-					pfree(context.curr_minipage.minipage);
-					context.curr_minipage.minipage = NULL;
-					context.curr_minipage_valid = false;
-					context.minipage_entry = NULL;
-					context.curr_minipage_entry_idx = 0;
-
 					ExecClearTuple(slot);
 					scan->cur_seg = -1;
 					slotAocs->current_scan = NULL;
 					return false;
 				}
 
-				TupleTableSlot *blkdir_slot = context.scan_blkdir->slot;
+				TupleTableSlot *blkdir_slot = scan->soleRowIdScan.scan_blkdir->slot;
 
 				slot_getallattrs(blkdir_slot);
 
-				context.segno = DatumGetInt32(slot_getattr(blkdir_slot, Anum_pg_aoblkdir_segno, &segnoNull));
+				scan->soleRowIdScan.segno = DatumGetInt32(slot_getattr(blkdir_slot, Anum_pg_aoblkdir_segno, &segnoNull));
 
 				minipage_datum = slot_getattr(blkdir_slot, Anum_pg_aoblkdir_minipage, &minipageNull);
-				context.curr_minipage_valid = !minipageNull;
-				if (context.curr_minipage_valid)
+				scan->soleRowIdScan.curr_minipage_valid = !minipageNull;
+				if (scan->soleRowIdScan.curr_minipage_valid)
 				{
-					copy_out_minipage(&context.curr_minipage, minipage_datum, false);
-					context.curr_minipage_entry_idx = 0;
+					copy_out_minipage(&scan->soleRowIdScan.curr_minipage, minipage_datum, false);
+					scan->soleRowIdScan.curr_minipage_entry_idx = 0;
 				}
 			}
 		}

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1601,7 +1601,17 @@ ReadNext:
 		}
 		scan->cdb_fake_ctid = *((ItemPointer) &aoTupleId);
 
-		// TODO: add comments here as it might confuse
+		/*
+		 * Only the anchor column (attno above, not necessarily attribute 0)
+		 * was just fetched into tts_values[attno]/tts_isnull[attno], and its
+		 * validity is tracked via tts_is_valid, not via tts_nvalid: the
+		 * generic "attributes 0..tts_nvalid-1 are valid" convention doesn't
+		 * hold here since the anchor column can be any attribute. Keep
+		 * tts_nvalid at 0 so slot_getattr()/slot_is_attr_valid() never trust
+		 * a stale count from a previous tuple and instead always go through
+		 * the AOCS-specific is_attr_valid()/gettargetattr() lazy-fetch path,
+		 * which consults tts_is_valid per attribute.
+		 */
 		slot->tts_nvalid = 0;
 
 		slot->tts_tid = scan->cdb_fake_ctid;

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1389,6 +1389,10 @@ aocs_getnext(AOCSScanDesc scan, ScanDirection direction, TupleTableSlot *slot)
 		initscan_with_colinfo(scan);
 	}
 
+	//elog(LOG, "[RELOG][%s] slot %p", __FUNCTION__, slot);
+
+	AttrNumber anchor_attr = scan->columnScanInfo.proj_atts[ANCHOR_COL_IN_PROJ];
+
 	if (gp_aocs_scan_shortpass &&
 		!gp_select_invisible &&
 		scan->columnScanInfo.projKind == AOCS_PROJ_ANY &&
@@ -1457,7 +1461,7 @@ aocs_getnext(AOCSScanDesc scan, ScanDirection direction, TupleTableSlot *slot)
 							Anum_pg_aoblkdir_columngroupno,
 							BTEqualStrategyNumber,
 							F_INT4EQ,
-							Int32GetDatum(scan->columnScanInfo.proj_atts[ANCHOR_COL_IN_PROJ]));
+							Int32GetDatum(anchor_attr));
 
 				context.scan_blkdir = systable_beginscan(scan->aocsfetch->blockDirectory.blkdirRel,
 												   InvalidOid,
@@ -1516,6 +1520,13 @@ aocs_getnext(AOCSScanDesc scan, ScanDirection direction, TupleTableSlot *slot)
 	{
 		AOCSFileSegInfo *curseginfo;
 
+		// TODO: check if we need to simply call tts_virtual_aocs_clear
+		for (AttrNumber i = 0; i < scan->columnScanInfo.num_proj_atts; i++)
+		{
+			AttrNumber	attno = scan->columnScanInfo.proj_atts[i];
+			slotAocs->tts_is_valid[attno] = false;
+		}
+
 ReadNext:
 		/* If necessary, open next seg */
 		if (scan->cur_seg < 0 || err < 0)
@@ -1548,8 +1559,10 @@ ReadNext:
 		Assert(scan->cur_seg >= 0);
 		curseginfo = scan->seginfo[scan->cur_seg];
 
-		AttrNumber anchor_attr = scan->columnScanInfo.proj_atts[ANCHOR_COL_IN_PROJ];
 		int tts_nvalid = anchor_attr+1;
+
+		// TODO: read only anchor column
+
 		/* Read from cur_seg */
 		for (AttrNumber i = 0; i < scan->columnScanInfo.num_proj_atts; i++)
 		{
@@ -1565,7 +1578,7 @@ ReadNext:
 			 * In fact, we cannot do that either because we don't have the
 			 * row number until we've scanned the anchor column.
 			 */
-			if (attno != scan->columnScanInfo.proj_atts[ANCHOR_COL_IN_PROJ])
+			if (attno != anchor_attr)
 			{
 				Assert(rowNum > 0);
 				if (AO_ATTR_VAL_IS_MISSING(rowNum,

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -720,6 +720,11 @@ aoco_getnextslot(TableScanDesc scan, ScanDirection direction, TupleTableSlot *sl
 	if (aocs_getnext(aoscan, direction, slot))
 	{
 		ExecStoreVirtualTuple(slot);
+
+		// TODO: add comments here
+		if (aoscan->columnScanInfo.projKind != AOCS_PROJ_ANY)
+			slot->tts_nvalid = 0;
+
 		pgstat_count_heap_getnext(aoscan->rs_base.rs_rd);
 
 		return true;

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1569,6 +1569,8 @@ aoco_relation_cluster_internals(Relation OldHeap, Relation NewHeap, TupleDesc ol
 		SIMPLE_FAULT_INJECTOR("cluster_ao_scanning_tuples");
 		tuplesort_putheaptuple(tuplesort, tuple);
 		heap_freetuple(tuple);
+
+		ExecClearTuple(slot);
 	}
 
 	ExecDropSingleTupleTableSlot(slot);

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -721,7 +721,23 @@ aoco_getnextslot(TableScanDesc scan, ScanDirection direction, TupleTableSlot *sl
 	{
 		ExecStoreVirtualTuple(slot);
 
-		// TODO: add comments here
+		/*
+		 * In aocs_getnext() we set tts_nvalid to 0, and
+		 * ExecStoreVirtualTuple() in this case sets tts_nvalid to the
+		 * full attribute count, which is the generic TupleTableSlot
+		 * convention for "attributes 0..tts_nvalid-1 are all valid". That
+		 * does not hold for our lazy AOCS slot (TTSOpsVirtualAOCS): only the
+		 * anchor/projected column(s) fetched by aocs_getnext() are actually
+		 * populated in tts_values/tts_isnull, tracked per-attribute via
+		 * tts_is_valid. If tts_nvalid were left at natts, slot_getattr()/
+		 * slot_is_attr_valid() would trust it and return stale data from a
+		 * previous tuple instead of going through is_attr_valid()/
+		 * gettargetattr() to lazily fetch the column on demand. So reset it
+		 * to 0 here to force every later attribute access through the
+		 * AOCS-specific lazy-fetch path. This is skipped for AOCS_PROJ_ANY
+		 * (e.g. count(*)) since that projection never reads column values,
+		 * only row identity.
+		 */
 		if (aoscan->columnScanInfo.projKind != AOCS_PROJ_ANY)
 			slot->tts_nvalid = 0;
 

--- a/src/backend/executor/execExpr.c
+++ b/src/backend/executor/execExpr.c
@@ -60,7 +60,7 @@ typedef struct ExprSetupInfo
 	AttrNumber	last_inner;
 	AttrNumber	last_outer;
 	AttrNumber	last_scan;
-	List	   *all_scan_attrs;
+	Bitmapset  *all_scan_attrs;
 	/* MULTIEXPR SubPlan nodes appearing in the expression: */
 	List	   *multiexpr_subplans;
 } ExprSetupInfo;
@@ -2367,7 +2367,7 @@ ExecInitFunc(ExprEvalStep *scratch, Expr *node, List *args, Oid funcid,
 static void
 ExecCreateExprSetupSteps(ExprState *state, Node *node)
 {
-	ExprSetupInfo info = {0, 0, 0, NIL, NIL};
+	ExprSetupInfo info = {0, 0, 0, NULL, NIL};
 
 	/* Prescan to find out what we need. */
 	expr_setup_walker(node, &info);
@@ -2397,7 +2397,7 @@ ExecPushExprSetupSteps(ExprState *state, ExprSetupInfo *info)
 	{
 		scratch.opcode = EEOP_INNER_FETCHSOME;
 		scratch.d.fetch.last_var = info->last_inner;
-		scratch.d.fetch.all_vars = NIL;
+		scratch.d.fetch.all_vars = NULL;
 		scratch.d.fetch.fixed = false;
 		scratch.d.fetch.kind = NULL;
 		scratch.d.fetch.known_desc = NULL;
@@ -2408,7 +2408,7 @@ ExecPushExprSetupSteps(ExprState *state, ExprSetupInfo *info)
 	{
 		scratch.opcode = EEOP_OUTER_FETCHSOME;
 		scratch.d.fetch.last_var = info->last_outer;
-		scratch.d.fetch.all_vars = NIL;
+		scratch.d.fetch.all_vars = NULL;
 		scratch.d.fetch.fixed = false;
 		scratch.d.fetch.kind = NULL;
 		scratch.d.fetch.known_desc = NULL;
@@ -2490,10 +2490,9 @@ expr_setup_walker(Node *node, ExprSetupInfo *info)
 
 			default:
 				info->last_scan = Max(info->last_scan, attnum);
-				if (attnum >= 0)
+				if (attnum > 0)
 				{
-					info->all_scan_attrs = lappend_int(info->all_scan_attrs, attnum);
-					//elog(LOG, "[RELOG][%s] req attnum = %d", __FUNCTION__, attnum);
+					info->all_scan_attrs = bms_add_member(info->all_scan_attrs, attnum - 1);
 				}
 				break;
 		}
@@ -3306,7 +3305,7 @@ ExecBuildAggTrans(AggState *aggstate, AggStatePerPhase phase,
 	ExprEvalStep scratch = {0};
 	int			transno = 0;
 	int			setoff = 0;
-	ExprSetupInfo deform = {0, 0, 0, NIL, NIL};
+	ExprSetupInfo deform = {0, 0, 0, NULL, NIL};
 
 	state->expr = (Expr *) aggstate;
 	state->parent = parent;

--- a/src/backend/executor/execExpr.c
+++ b/src/backend/executor/execExpr.c
@@ -60,6 +60,7 @@ typedef struct ExprSetupInfo
 	AttrNumber	last_inner;
 	AttrNumber	last_outer;
 	AttrNumber	last_scan;
+	List	   *all_scan_attrs;
 	/* MULTIEXPR SubPlan nodes appearing in the expression: */
 	List	   *multiexpr_subplans;
 } ExprSetupInfo;
@@ -2366,7 +2367,7 @@ ExecInitFunc(ExprEvalStep *scratch, Expr *node, List *args, Oid funcid,
 static void
 ExecCreateExprSetupSteps(ExprState *state, Node *node)
 {
-	ExprSetupInfo info = {0, 0, 0, NIL};
+	ExprSetupInfo info = {0, 0, 0, NIL, NIL};
 
 	/* Prescan to find out what we need. */
 	expr_setup_walker(node, &info);
@@ -2396,6 +2397,7 @@ ExecPushExprSetupSteps(ExprState *state, ExprSetupInfo *info)
 	{
 		scratch.opcode = EEOP_INNER_FETCHSOME;
 		scratch.d.fetch.last_var = info->last_inner;
+		scratch.d.fetch.all_vars = NIL;
 		scratch.d.fetch.fixed = false;
 		scratch.d.fetch.kind = NULL;
 		scratch.d.fetch.known_desc = NULL;
@@ -2406,6 +2408,7 @@ ExecPushExprSetupSteps(ExprState *state, ExprSetupInfo *info)
 	{
 		scratch.opcode = EEOP_OUTER_FETCHSOME;
 		scratch.d.fetch.last_var = info->last_outer;
+		scratch.d.fetch.all_vars = NIL;
 		scratch.d.fetch.fixed = false;
 		scratch.d.fetch.kind = NULL;
 		scratch.d.fetch.known_desc = NULL;
@@ -2416,6 +2419,7 @@ ExecPushExprSetupSteps(ExprState *state, ExprSetupInfo *info)
 	{
 		scratch.opcode = EEOP_SCAN_FETCHSOME;
 		scratch.d.fetch.last_var = info->last_scan;
+		scratch.d.fetch.all_vars = info->all_scan_attrs;
 		scratch.d.fetch.fixed = false;
 		scratch.d.fetch.kind = NULL;
 		scratch.d.fetch.known_desc = NULL;
@@ -2486,6 +2490,11 @@ expr_setup_walker(Node *node, ExprSetupInfo *info)
 
 			default:
 				info->last_scan = Max(info->last_scan, attnum);
+				if (attnum >= 0)
+				{
+					info->all_scan_attrs = lappend_int(info->all_scan_attrs, attnum);
+					//elog(LOG, "[RELOG][%s] req attnum = %d", __FUNCTION__, attnum);
+				}
 				break;
 		}
 		return false;
@@ -3297,7 +3306,7 @@ ExecBuildAggTrans(AggState *aggstate, AggStatePerPhase phase,
 	ExprEvalStep scratch = {0};
 	int			transno = 0;
 	int			setoff = 0;
-	ExprSetupInfo deform = {0, 0, 0, NIL};
+	ExprSetupInfo deform = {0, 0, 0, NIL, NIL};
 
 	state->expr = (Expr *) aggstate;
 	state->parent = parent;

--- a/src/backend/executor/execExprInterp.c
+++ b/src/backend/executor/execExprInterp.c
@@ -456,7 +456,20 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 		{
 			CheckOpSlotCompatibility(op, scanslot);
 
-			slot_getsomeattrs(scanslot, op->d.fetch.last_var);
+			bool got_target_attrs = false;
+			ListCell *lc;
+			foreach(lc, op->d.fetch.all_vars)
+			{
+				int attnum = lfirst_int(lc);
+				got_target_attrs = slot_gettargetattr(scanslot, attnum);
+				if (!got_target_attrs)
+					break;
+			}
+			list_free(op->d.fetch.all_vars);
+			op->d.fetch.all_vars = NIL;
+
+			if (!got_target_attrs)
+				slot_getsomeattrs(scanslot, op->d.fetch.last_var);
 
 			EEO_NEXT();
 		}
@@ -497,7 +510,7 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 
 			/* See EEOP_INNER_VAR comments */
 
-			Assert(attnum >= 0 && attnum < scanslot->tts_nvalid);
+			//Assert(attnum >= 0 && attnum < scanslot->tts_nvalid);
 			*op->resvalue = scanslot->tts_values[attnum];
 			*op->resnull = scanslot->tts_isnull[attnum];
 
@@ -573,7 +586,7 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 			 * We do not need CheckVarSlotCompatibility here; that was taken
 			 * care of at compilation time.  But see EEOP_INNER_VAR comments.
 			 */
-			Assert(attnum >= 0 && attnum < scanslot->tts_nvalid);
+			//Assert(attnum >= 0 && attnum < scanslot->tts_nvalid);
 			Assert(resultnum >= 0 && resultnum < resultslot->tts_tupleDescriptor->natts);
 			resultslot->tts_values[resultnum] = scanslot->tts_values[attnum];
 			resultslot->tts_isnull[resultnum] = scanslot->tts_isnull[attnum];

--- a/src/backend/executor/execExprInterp.c
+++ b/src/backend/executor/execExprInterp.c
@@ -498,7 +498,7 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 
 			/* See EEOP_INNER_VAR comments */
 
-			//Assert(attnum >= 0 && attnum < scanslot->tts_nvalid);
+			Assert(attnum >= 0 && slot_is_attr_valid(scanslot, attnum));
 			*op->resvalue = scanslot->tts_values[attnum];
 			*op->resnull = scanslot->tts_isnull[attnum];
 
@@ -574,7 +574,7 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 			 * We do not need CheckVarSlotCompatibility here; that was taken
 			 * care of at compilation time.  But see EEOP_INNER_VAR comments.
 			 */
-			//Assert(attnum >= 0 && attnum < scanslot->tts_nvalid);
+			Assert(attnum >= 0 && slot_is_attr_valid(scanslot, attnum));
 			Assert(resultnum >= 0 && resultnum < resultslot->tts_tupleDescriptor->natts);
 			resultslot->tts_values[resultnum] = scanslot->tts_values[attnum];
 			resultslot->tts_isnull[resultnum] = scanslot->tts_isnull[attnum];

--- a/src/backend/executor/execExprInterp.c
+++ b/src/backend/executor/execExprInterp.c
@@ -456,20 +456,7 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 		{
 			CheckOpSlotCompatibility(op, scanslot);
 
-			bool got_target_attrs = false;
-			ListCell *lc;
-			foreach(lc, op->d.fetch.all_vars)
-			{
-				int attnum = lfirst_int(lc);
-				got_target_attrs = slot_gettargetattr(scanslot, attnum);
-				if (!got_target_attrs)
-					break;
-			}
-			// TODO: where to free 'all_vars'?...
-			//list_free(op->d.fetch.all_vars);
-			//op->d.fetch.all_vars = NIL;
-
-			if (!got_target_attrs)
+			if (!slot_gettargetattr(scanslot, op->d.fetch.all_vars))
 				slot_getsomeattrs(scanslot, op->d.fetch.last_var);
 
 			EEO_NEXT();

--- a/src/backend/executor/execExprInterp.c
+++ b/src/backend/executor/execExprInterp.c
@@ -465,8 +465,9 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 				if (!got_target_attrs)
 					break;
 			}
-			list_free(op->d.fetch.all_vars);
-			op->d.fetch.all_vars = NIL;
+			// TODO: where to free 'all_vars'?...
+			//list_free(op->d.fetch.all_vars);
+			//op->d.fetch.all_vars = NIL;
 
 			if (!got_target_attrs)
 				slot_getsomeattrs(scanslot, op->d.fetch.last_var);

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -131,10 +131,8 @@ tts_virtual_aocs_init(TupleTableSlot *slot)
 {
 	VirtualTupleTableSlotAOCS *vslot_aocs = (VirtualTupleTableSlotAOCS *) slot;
 
-	//elog(LOG, "[RELOG][%s] slot %p", __FUNCTION__, slot);
 	if (slot->tts_tupleDescriptor)
 	{
-		//elog(LOG, "[RELOG][%s] slot %p, palloc0 for natts %d", __FUNCTION__, slot, slot->tts_tupleDescriptor->natts);
 		vslot_aocs->tts_is_valid = palloc0(
 			slot->tts_tupleDescriptor->natts * sizeof(bool));
 	}
@@ -144,7 +142,6 @@ static void
 tts_virtual_aocs_release(TupleTableSlot *slot)
 {
 	VirtualTupleTableSlotAOCS *vslot_aocs = (VirtualTupleTableSlotAOCS *) slot;
-	//elog(LOG, "[RELOG][%s] slot %p, vslot_aocs->tts_is_valid %p", __FUNCTION__, slot, vslot_aocs->tts_is_valid);
 	if (vslot_aocs->tts_is_valid)
 	{
 		pfree(vslot_aocs->tts_is_valid);
@@ -160,8 +157,6 @@ tts_virtual_aocs_clear(TupleTableSlot *slot)
 	tts_virtual_clear(slot);
 
 	vslot_aocs->current_scan = NULL;
-
-	//elog(LOG, "[RELOG][%s] slot %p, vslot_aocs->tts_is_valid %p, slot->tts_tupleDescriptor %p", __FUNCTION__, slot, vslot_aocs->tts_is_valid, slot->tts_tupleDescriptor);
 
 	if (vslot_aocs->tts_is_valid && slot->tts_tupleDescriptor)
 		for (int i = 0; i < slot->tts_tupleDescriptor->natts; i++)
@@ -194,8 +189,6 @@ tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 	AOTupleId	*tid = (AOTupleId *)&slot->tts_tid;
 	int64		rowNum = AOTupleIdGet_rowNum(tid);
 	Assert(rowNum != InvalidAORowNum);
-
-	//elog(LOG, "[RELOG][%s] slot %p, natts = %d, slot->tts_nvalid %d", __FUNCTION__, slot, natts, slot->tts_nvalid);
 
 	for (AttrNumber i = 1; i < scan->columnScanInfo.num_proj_atts; i++)
 	{
@@ -304,8 +297,6 @@ tts_virtual_aocs_gettargetattr(TupleTableSlot *slot, int attnum)
 	Datum	   *d = slot->tts_values;
 	bool	   *null = slot->tts_isnull;
 	int			err PG_USED_FOR_ASSERTS_ONLY;
-
-	//elog(LOG, "[RELOG][%s] attnum = %d", __FUNCTION__, attnum);
 
 	// TODO: fix the ugly naming fusion
 	AttrNumber	attno = attnum - 1;
@@ -582,14 +573,10 @@ tts_virtual_aocs_copyslot(TupleTableSlot *dstslot, TupleTableSlot *srcslot)
 		dstslot->tts_isnull[natt] = srcslot->tts_isnull[natt];
 	}
 
-	//elog(LOG, "[RELOG][%s] dstslot %p, srcslot %p [is_aocs %u]", __FUNCTION__, dstslot, srcslot, TTS_IS_VIRTUAL_AOCS(srcslot));
-
 	if (TTS_IS_VIRTUAL_AOCS(srcslot))
 	{
 		VirtualTupleTableSlotAOCS *dstslot_aocs = (VirtualTupleTableSlotAOCS *) dstslot;
 		VirtualTupleTableSlotAOCS *srcslot_aocs = (VirtualTupleTableSlotAOCS *) srcslot;
-
-		//elog(LOG, "[RELOG][%s] srcslot_aocs->tts_is_valid %p, srcdesc->natts %d", __FUNCTION__, srcslot_aocs->tts_is_valid, srcdesc->natts);
 
 		if (srcslot_aocs->tts_is_valid)
 		{
@@ -611,7 +598,6 @@ static HeapTuple
 tts_virtual_copy_heap_tuple(TupleTableSlot *slot)
 {
 	Assert(!TTS_EMPTY(slot));
-
 	return heap_form_tuple(slot->tts_tupleDescriptor,
 						   slot->tts_values,
 						   slot->tts_isnull);
@@ -621,7 +607,6 @@ static MinimalTuple
 tts_virtual_copy_minimal_tuple(TupleTableSlot *slot)
 {
 	Assert(!TTS_EMPTY(slot));
-
 	return heap_form_minimal_tuple(slot->tts_tupleDescriptor,
 								   slot->tts_values,
 								   slot->tts_isnull);

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -149,6 +149,132 @@ tts_virtual_getsomeattrs(TupleTableSlot *slot, int natts)
 	elog(ERROR, "getsomeattrs is not required to be called on a virtual tuple table slot");
 }
 
+static bool
+tts_virtual_aocs_gettargetattr(TupleTableSlot *slot, Bitmapset *attrs)
+{
+	Datum	   *d = slot->tts_values;
+	bool	   *null = slot->tts_isnull;
+	int			err PG_USED_FOR_ASSERTS_ONLY;
+	MemoryContext oldContext;
+
+	VirtualTupleTableSlotAOCS * slotAocs = (VirtualTupleTableSlotAOCS*)slot;
+	AOCSScanDesc scan = (AOCSScanDesc)slotAocs->current_scan;
+	if (unlikely(scan == NULL))
+		return false;
+
+	AOCSFileSegInfo * curseginfo = scan->seginfo[scan->cur_seg];
+	AOTupleId	*tid = (AOTupleId *)&slot->tts_tid;
+	int64		rowNum = AOTupleIdGet_rowNum(tid);
+	Assert(rowNum != InvalidAORowNum);
+
+ 	AttrNumber	attno = -1;
+	while ((attno = bms_next_member(attrs, attno)) >= 0)
+	{
+		if (unlikely(bms_is_member(attno, slotAocs->tts_is_valid)))
+			continue;
+
+		if (unlikely(AO_ATTR_VAL_IS_MISSING(rowNum,
+								attno,
+								curseginfo->segno,
+								scan->columnScanInfo.attnum_to_rownum)))
+		{
+			d[attno] = getmissingattr(slot->tts_tupleDescriptor, attno + 1, &null[attno]);
+
+			oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
+			slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
+			MemoryContextSwitchTo(oldContext);
+
+			continue;
+		}
+
+		DatumStreamRead *ds = scan->columnScanInfo.ds[attno];
+		Assert(ds);
+
+		if (unlikely(ds->noBlocksRead || rowNum > ds->blockFirstRowNum + ds->blockRowCount - 1))
+		{
+			if (!scan->blockDirectory && scan->aocsfetch)
+			{
+				AppendOnlyBlockDirectoryEntry dirEntry;
+				bool res PG_USED_FOR_ASSERTS_ONLY;
+				res = AppendOnlyBlockDirectory_GetEntry(
+									  &scan->aocsfetch->blockDirectory,
+									  tid,
+									  attno,
+									  &dirEntry,
+									  scan->columnScanInfo.attnum_to_rownum);
+				Assert(res);
+
+				Assert(dirEntry.range.fileOffset <= ds->ao_read.logicalEof);
+				AppendOnlyStorageRead_SetTemporaryStart(&ds->ao_read,
+														dirEntry.range.fileOffset,
+														dirEntry.range.afterFileOffset);
+			}
+
+			while (true)
+			{
+				bool read_ok PG_USED_FOR_ASSERTS_ONLY;
+				read_ok = datumstreamread_block_info(ds);
+				Assert(read_ok);
+
+				if (rowNum <= ds->blockFirstRowNum + ds->blockRowCount - 1)
+				{
+					int64 blocksRead;
+					/* read a new buffer to consume */
+					datumstreamread_block_content(ds);
+
+					if (scan->blockDirectory)
+					{
+						AppendOnlyBlockDirectory_InsertEntry(scan->blockDirectory,
+															 attno,
+															 ds->blockFirstRowNum,
+															 ds->blockFileOffset,
+															 ds->blockRowCount);
+					}
+
+					AOCSScanDesc_UpdateTotalBytesRead(scan, attno);
+					blocksRead =
+						RelationGuessNumberOfBlocksFromSize(scan->totalBytesRead);
+					pgstat_count_buffer_read_ao(scan->rs_base.rs_rd,
+												blocksRead);
+
+					break;
+				}
+				else
+				{
+					bool save_gp_appendonly_verify_block_checksums = gp_appendonly_verify_block_checksums;
+					gp_appendonly_verify_block_checksums = false;
+					AppendOnlyStorageRead_SkipCurrentBlock(&ds->ao_read);
+					gp_appendonly_verify_block_checksums = save_gp_appendonly_verify_block_checksums;
+				}
+			}
+		}
+
+		err = datumstreamread_advance(ds);
+		Assert(err >= 0);
+
+		int32 rowNumInBlock = rowNum - ds->blockFirstRowNum;
+		while (rowNumInBlock > datumstreamread_nth(ds))
+		{
+			err = datumstreamread_advance(ds);
+			Assert(err > 0);
+		}
+
+		datumstreamread_get(ds, &d[attno], &null[attno]);
+
+		oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
+		slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
+		MemoryContextSwitchTo(oldContext);
+	}
+	return true;
+}
+
+static bool
+tts_virtual_aocs_is_attr_valid(TupleTableSlot *slot, int attnum)
+{
+	VirtualTupleTableSlotAOCS * slotAocs = (VirtualTupleTableSlotAOCS*)slot;
+	return bms_is_member(attnum, slotAocs->tts_is_valid);
+}
+
 static void
 tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 {
@@ -270,136 +396,9 @@ tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 		oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
 		slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
 		MemoryContextSwitchTo(oldContext);
-
 	}
 
 	slot->tts_nvalid = natts;
-}
-
-static bool
-tts_virtual_aocs_is_attr_valid(TupleTableSlot *slot, int attnum)
-{
-	VirtualTupleTableSlotAOCS * slotAocs = (VirtualTupleTableSlotAOCS*)slot;
-	return bms_is_member(attnum, slotAocs->tts_is_valid);
-}
-
-static bool
-tts_virtual_aocs_gettargetattr(TupleTableSlot *slot, Bitmapset *attrs)
-{
-	VirtualTupleTableSlotAOCS * slotAocs = (VirtualTupleTableSlotAOCS*)slot;
-	AOCSScanDesc scan = (AOCSScanDesc)slotAocs->current_scan;
-	if (unlikely(scan == NULL))
-		return false;
-
- 	AttrNumber	attno = -1;
-	while ((attno = bms_next_member(attrs, attno)) >= 0)
-	{
-		Datum	   *d = slot->tts_values;
-		bool	   *null = slot->tts_isnull;
-		int			err PG_USED_FOR_ASSERTS_ONLY;
-		MemoryContext oldContext;
-
-		if (bms_is_member(attno, slotAocs->tts_is_valid))
-			continue;
-
-		AOCSFileSegInfo * curseginfo = scan->seginfo[scan->cur_seg];
-		AOTupleId	*tid = (AOTupleId *)&slot->tts_tid;
-		int64		rowNum = AOTupleIdGet_rowNum(tid);
-		Assert(rowNum != InvalidAORowNum);
-
-		if (unlikely(AO_ATTR_VAL_IS_MISSING(rowNum,
-								attno,
-								curseginfo->segno,
-								scan->columnScanInfo.attnum_to_rownum)))
-		{
-			d[attno] = getmissingattr(slot->tts_tupleDescriptor, attno + 1, &null[attno]);
-
-			oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
-			slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
-			MemoryContextSwitchTo(oldContext);
-
-			continue;
-		}
-
-		DatumStreamRead *ds = scan->columnScanInfo.ds[attno];
-		Assert(ds);
-
-		if (unlikely(ds->noBlocksRead || rowNum > ds->blockFirstRowNum + ds->blockRowCount - 1))
-		{
-			if (!scan->blockDirectory && scan->aocsfetch)
-			{
-				AppendOnlyBlockDirectoryEntry dirEntry;
-				bool res PG_USED_FOR_ASSERTS_ONLY;
-				res = AppendOnlyBlockDirectory_GetEntry(
-									  &scan->aocsfetch->blockDirectory,
-									  tid,
-									  attno,
-									  &dirEntry,
-									  scan->columnScanInfo.attnum_to_rownum);
-				Assert(res);
-
-				Assert(dirEntry.range.fileOffset <= ds->ao_read.logicalEof);
-				AppendOnlyStorageRead_SetTemporaryStart(&ds->ao_read,
-														dirEntry.range.fileOffset,
-														dirEntry.range.afterFileOffset);
-			}
-
-			while (true)
-			{
-				bool read_ok PG_USED_FOR_ASSERTS_ONLY;
-				read_ok = datumstreamread_block_info(ds);
-				Assert(read_ok);
-
-				if (rowNum <= ds->blockFirstRowNum + ds->blockRowCount - 1)
-				{
-					int64 blocksRead;
-					/* read a new buffer to consume */
-					datumstreamread_block_content(ds);
-
-					if (scan->blockDirectory)
-					{
-						AppendOnlyBlockDirectory_InsertEntry(scan->blockDirectory,
-															 attno,
-															 ds->blockFirstRowNum,
-															 ds->blockFileOffset,
-															 ds->blockRowCount);
-					}
-
-					AOCSScanDesc_UpdateTotalBytesRead(scan, attno);
-					blocksRead =
-						RelationGuessNumberOfBlocksFromSize(scan->totalBytesRead);
-					pgstat_count_buffer_read_ao(scan->rs_base.rs_rd,
-												blocksRead);
-
-					break;
-				}
-				else
-				{
-					bool save_gp_appendonly_verify_block_checksums = gp_appendonly_verify_block_checksums;
-					gp_appendonly_verify_block_checksums = false;
-					AppendOnlyStorageRead_SkipCurrentBlock(&ds->ao_read);
-					gp_appendonly_verify_block_checksums = save_gp_appendonly_verify_block_checksums;
-				}
-			}
-		}
-
-		err = datumstreamread_advance(ds);
-		Assert(err >= 0);
-
-		int32 rowNumInBlock = rowNum - ds->blockFirstRowNum;
-		while (rowNumInBlock > datumstreamread_nth(ds))
-		{
-			err = datumstreamread_advance(ds);
-			Assert(err > 0);
-		}
-
-		datumstreamread_get(ds, &d[attno], &null[attno]);
-
-		oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
-		slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
-		MemoryContextSwitchTo(oldContext);
-	}
-	return true;
 }
 
 /*

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -149,13 +149,124 @@ tts_virtual_getsomeattrs(TupleTableSlot *slot, int natts)
 	elog(ERROR, "getsomeattrs is not required to be called on a virtual tuple table slot");
 }
 
+/*
+ * Fetch a single AOCS column's value for the tuple identified by 'tid'/
+ * 'rowNum' into d[attno]/null[attno], advancing (and if needed
+ * repositioning) that column's DatumStreamRead as necessary, and marking
+ * the attribute valid in slotAocs->tts_is_valid.
+ */
+static pg_attribute_always_inline void
+tts_virtual_aocs_fetch_attr(VirtualTupleTableSlotAOCS *slotAocs,
+							 AOCSScanDesc scan,
+							 AOCSFileSegInfo *curseginfo,
+							 AOTupleId *tid,
+							 int64 rowNum,
+							 AttrNumber attno,
+							 Datum *d,
+							 bool *null)
+{
+	TupleTableSlot *slot = (TupleTableSlot *) slotAocs;
+	int			err PG_USED_FOR_ASSERTS_ONLY;
+	MemoryContext oldContext;
+
+	if (unlikely(AO_ATTR_VAL_IS_MISSING(rowNum,
+							attno,
+							curseginfo->segno,
+							scan->columnScanInfo.attnum_to_rownum)))
+	{
+		d[attno] = getmissingattr(slot->tts_tupleDescriptor, attno + 1, &null[attno]);
+
+		oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
+		slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
+		MemoryContextSwitchTo(oldContext);
+
+		return;
+	}
+
+	DatumStreamRead *ds = scan->columnScanInfo.ds[attno];
+	Assert(ds);
+
+	if (unlikely(ds->noBlocksRead || rowNum > ds->blockFirstRowNum + ds->blockRowCount - 1))
+	{
+		if (!scan->blockDirectory && scan->aocsfetch)
+		{
+			AppendOnlyBlockDirectoryEntry dirEntry;
+			bool res PG_USED_FOR_ASSERTS_ONLY;
+			res = AppendOnlyBlockDirectory_GetEntry(
+								  &scan->aocsfetch->blockDirectory,
+								  tid,
+								  attno,
+								  &dirEntry,
+								  scan->columnScanInfo.attnum_to_rownum);
+			Assert(res);
+
+			Assert(dirEntry.range.fileOffset <= ds->ao_read.logicalEof);
+			AppendOnlyStorageRead_SetTemporaryStart(&ds->ao_read,
+													dirEntry.range.fileOffset,
+													dirEntry.range.afterFileOffset);
+		}
+
+		while (true)
+		{
+			bool read_ok PG_USED_FOR_ASSERTS_ONLY;
+			read_ok = datumstreamread_block_info(ds);
+			Assert(read_ok);
+
+			if (rowNum <= ds->blockFirstRowNum + ds->blockRowCount - 1)
+			{
+				int64 blocksRead;
+				/* read a new buffer to consume */
+				datumstreamread_block_content(ds);
+
+				if (scan->blockDirectory)
+				{
+					AppendOnlyBlockDirectory_InsertEntry(scan->blockDirectory,
+														 attno,
+														 ds->blockFirstRowNum,
+														 ds->blockFileOffset,
+														 ds->blockRowCount);
+				}
+
+				AOCSScanDesc_UpdateTotalBytesRead(scan, attno);
+				blocksRead =
+					RelationGuessNumberOfBlocksFromSize(scan->totalBytesRead);
+				pgstat_count_buffer_read_ao(scan->rs_base.rs_rd,
+											blocksRead);
+
+				break;
+			}
+			else
+			{
+				bool save_gp_appendonly_verify_block_checksums = gp_appendonly_verify_block_checksums;
+				gp_appendonly_verify_block_checksums = false;
+				AppendOnlyStorageRead_SkipCurrentBlock(&ds->ao_read);
+				gp_appendonly_verify_block_checksums = save_gp_appendonly_verify_block_checksums;
+			}
+		}
+	}
+
+	err = datumstreamread_advance(ds);
+	Assert(err >= 0);
+
+	int32 rowNumInBlock = rowNum - ds->blockFirstRowNum;
+	while (rowNumInBlock > datumstreamread_nth(ds))
+	{
+		err = datumstreamread_advance(ds);
+		Assert(err > 0);
+	}
+
+	datumstreamread_get(ds, &d[attno], &null[attno]);
+
+	oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
+	slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
+	MemoryContextSwitchTo(oldContext);
+}
+
 static bool
 tts_virtual_aocs_gettargetattr(TupleTableSlot *slot, Bitmapset *attrs)
 {
 	Datum	   *d = slot->tts_values;
 	bool	   *null = slot->tts_isnull;
-	int			err PG_USED_FOR_ASSERTS_ONLY;
-	MemoryContext oldContext;
 
 	VirtualTupleTableSlotAOCS * slotAocs = (VirtualTupleTableSlotAOCS*)slot;
 	AOCSScanDesc scan = (AOCSScanDesc)slotAocs->current_scan;
@@ -173,97 +284,8 @@ tts_virtual_aocs_gettargetattr(TupleTableSlot *slot, Bitmapset *attrs)
 		if (unlikely(bms_is_member(attno, slotAocs->tts_is_valid)))
 			continue;
 
-		if (unlikely(AO_ATTR_VAL_IS_MISSING(rowNum,
-								attno,
-								curseginfo->segno,
-								scan->columnScanInfo.attnum_to_rownum)))
-		{
-			d[attno] = getmissingattr(slot->tts_tupleDescriptor, attno + 1, &null[attno]);
-
-			oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
-			slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
-			MemoryContextSwitchTo(oldContext);
-
-			continue;
-		}
-
-		DatumStreamRead *ds = scan->columnScanInfo.ds[attno];
-		Assert(ds);
-
-		if (unlikely(ds->noBlocksRead || rowNum > ds->blockFirstRowNum + ds->blockRowCount - 1))
-		{
-			if (!scan->blockDirectory && scan->aocsfetch)
-			{
-				AppendOnlyBlockDirectoryEntry dirEntry;
-				bool res PG_USED_FOR_ASSERTS_ONLY;
-				res = AppendOnlyBlockDirectory_GetEntry(
-									  &scan->aocsfetch->blockDirectory,
-									  tid,
-									  attno,
-									  &dirEntry,
-									  scan->columnScanInfo.attnum_to_rownum);
-				Assert(res);
-
-				Assert(dirEntry.range.fileOffset <= ds->ao_read.logicalEof);
-				AppendOnlyStorageRead_SetTemporaryStart(&ds->ao_read,
-														dirEntry.range.fileOffset,
-														dirEntry.range.afterFileOffset);
-			}
-
-			while (true)
-			{
-				bool read_ok PG_USED_FOR_ASSERTS_ONLY;
-				read_ok = datumstreamread_block_info(ds);
-				Assert(read_ok);
-
-				if (rowNum <= ds->blockFirstRowNum + ds->blockRowCount - 1)
-				{
-					int64 blocksRead;
-					/* read a new buffer to consume */
-					datumstreamread_block_content(ds);
-
-					if (scan->blockDirectory)
-					{
-						AppendOnlyBlockDirectory_InsertEntry(scan->blockDirectory,
-															 attno,
-															 ds->blockFirstRowNum,
-															 ds->blockFileOffset,
-															 ds->blockRowCount);
-					}
-
-					AOCSScanDesc_UpdateTotalBytesRead(scan, attno);
-					blocksRead =
-						RelationGuessNumberOfBlocksFromSize(scan->totalBytesRead);
-					pgstat_count_buffer_read_ao(scan->rs_base.rs_rd,
-												blocksRead);
-
-					break;
-				}
-				else
-				{
-					bool save_gp_appendonly_verify_block_checksums = gp_appendonly_verify_block_checksums;
-					gp_appendonly_verify_block_checksums = false;
-					AppendOnlyStorageRead_SkipCurrentBlock(&ds->ao_read);
-					gp_appendonly_verify_block_checksums = save_gp_appendonly_verify_block_checksums;
-				}
-			}
-		}
-
-		err = datumstreamread_advance(ds);
-		Assert(err >= 0);
-
-		int32 rowNumInBlock = rowNum - ds->blockFirstRowNum;
-		while (rowNumInBlock > datumstreamread_nth(ds))
-		{
-			err = datumstreamread_advance(ds);
-			Assert(err > 0);
-		}
-
-		datumstreamread_get(ds, &d[attno], &null[attno]);
-
-		oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
-		slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
-		MemoryContextSwitchTo(oldContext);
+		tts_virtual_aocs_fetch_attr(slotAocs, scan, curseginfo, tid, rowNum,
+									 attno, d, null);
 	}
 	return true;
 }
@@ -278,15 +300,8 @@ tts_virtual_aocs_is_attr_valid(TupleTableSlot *slot, int attnum)
 static void
 tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 {
-	/*
-	 * The content of this function is almost similar to
-	 * tts_virtual_aocs_gettargetattr(), but we do not remove this duplication
-	 * due to performance reasons.
-	 */
 	Datum	   *d = slot->tts_values;
 	bool	   *null = slot->tts_isnull;
-	int			err PG_USED_FOR_ASSERTS_ONLY;
-	MemoryContext oldContext;
 
 	VirtualTupleTableSlotAOCS * slotAocs = (VirtualTupleTableSlotAOCS*)slot;
 	AOCSScanDesc scan = (AOCSScanDesc)slotAocs->current_scan;
@@ -314,97 +329,8 @@ tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 			break;
 		}
 
-		if (unlikely(AO_ATTR_VAL_IS_MISSING(rowNum,
-								attno,
-								curseginfo->segno,
-								scan->columnScanInfo.attnum_to_rownum)))
-		{
-			d[attno] = getmissingattr(slot->tts_tupleDescriptor, attno + 1, &null[attno]);
-
-			oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
-			slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
-			MemoryContextSwitchTo(oldContext);
-
-			continue;
-		}
-
-		DatumStreamRead *ds = scan->columnScanInfo.ds[attno];
-		Assert(ds);
-
-		if (unlikely(ds->noBlocksRead || rowNum > ds->blockFirstRowNum + ds->blockRowCount - 1))
-		{
-			if (!scan->blockDirectory && scan->aocsfetch)
-			{
-				AppendOnlyBlockDirectoryEntry dirEntry;
-				bool res PG_USED_FOR_ASSERTS_ONLY;
-				res = AppendOnlyBlockDirectory_GetEntry(
-									  &scan->aocsfetch->blockDirectory,
-									  tid,
-									  attno,
-									  &dirEntry,
-									  scan->columnScanInfo.attnum_to_rownum);
-				Assert(res);
-
-				Assert(dirEntry.range.fileOffset <= ds->ao_read.logicalEof);
-				AppendOnlyStorageRead_SetTemporaryStart(&ds->ao_read,
-														dirEntry.range.fileOffset,
-														dirEntry.range.afterFileOffset);
-			}
-
-			while (true)
-			{
-				bool read_ok PG_USED_FOR_ASSERTS_ONLY;
-				read_ok = datumstreamread_block_info(ds);
-				Assert(read_ok);
-
-				if (rowNum <= ds->blockFirstRowNum + ds->blockRowCount - 1)
-				{
-					int64 blocksRead;
-					/* read a new buffer to consume */
-					datumstreamread_block_content(ds);
-
-					if (scan->blockDirectory)
-					{
-						AppendOnlyBlockDirectory_InsertEntry(scan->blockDirectory,
-															 attno,
-															 ds->blockFirstRowNum,
-															 ds->blockFileOffset,
-															 ds->blockRowCount);
-					}
-
-					AOCSScanDesc_UpdateTotalBytesRead(scan, attno);
-					blocksRead =
-						RelationGuessNumberOfBlocksFromSize(scan->totalBytesRead);
-					pgstat_count_buffer_read_ao(scan->rs_base.rs_rd,
-												blocksRead);
-
-					break;
-				}
-				else
-				{
-					bool save_gp_appendonly_verify_block_checksums = gp_appendonly_verify_block_checksums;
-					gp_appendonly_verify_block_checksums = false;
-					AppendOnlyStorageRead_SkipCurrentBlock(&ds->ao_read);
-					gp_appendonly_verify_block_checksums = save_gp_appendonly_verify_block_checksums;
-				}
-			}
-		}
-
-		err = datumstreamread_advance(ds);
-		Assert(err >= 0);
-
-		int32 rowNumInBlock = rowNum - ds->blockFirstRowNum;
-		while (rowNumInBlock > datumstreamread_nth(ds))
-		{
-			err = datumstreamread_advance(ds);
-			Assert(err > 0);
-		}
-
-		datumstreamread_get(ds, &d[attno], &null[attno]);
-
-		oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
-		slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
-		MemoryContextSwitchTo(oldContext);
+		tts_virtual_aocs_fetch_attr(slotAocs, scan, curseginfo, tid, rowNum,
+									 attno, d, null);
 	}
 
 	slot->tts_nvalid = natts;

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -278,31 +278,127 @@ tts_virtual_aocs_is_attr_valid(TupleTableSlot *slot, int attnum)
 static void
 tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 {
+	Datum	   *d = slot->tts_values;
+	bool	   *null = slot->tts_isnull;
+	int			err PG_USED_FOR_ASSERTS_ONLY;
+	MemoryContext oldContext;
+
 	VirtualTupleTableSlotAOCS * slotAocs = (VirtualTupleTableSlotAOCS*)slot;
 	AOCSScanDesc scan = (AOCSScanDesc)slotAocs->current_scan;
 	if (unlikely(scan == NULL))
 		return;
 
-	Bitmapset *attrs = NULL;
+	AOCSFileSegInfo * curseginfo = scan->seginfo[scan->cur_seg];
+	AOTupleId	*tid = (AOTupleId *)&slot->tts_tid;
+	int64		rowNum = AOTupleIdGet_rowNum(tid);
+	Assert(rowNum != InvalidAORowNum);
+
 	for (AttrNumber i = 1; i < scan->columnScanInfo.num_proj_atts; i++)
 	{
 		AttrNumber	attno = scan->columnScanInfo.proj_atts[i];
 
-		if (unlikely(attno < slot->tts_nvalid ||
-					bms_is_member(attno, slotAocs->tts_is_valid)))
+		if (bms_is_member(attno, slotAocs->tts_is_valid))
 			continue;
 
+		if (unlikely(attno < slot->tts_nvalid))
+			continue;
 		if (unlikely(attno >= natts))
 			break;
 
-		attrs = bms_add_member(attrs, attno);
+		if (unlikely(AO_ATTR_VAL_IS_MISSING(rowNum,
+								attno,
+								curseginfo->segno,
+								scan->columnScanInfo.attnum_to_rownum)))
+		{
+			d[attno] = getmissingattr(slot->tts_tupleDescriptor, attno + 1, &null[attno]);
 
+			oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
+			slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
+			MemoryContextSwitchTo(oldContext);
+
+			continue;
+		}
+
+		DatumStreamRead *ds = scan->columnScanInfo.ds[attno];
+		Assert(ds);
+
+		if (unlikely(ds->noBlocksRead || rowNum > ds->blockFirstRowNum + ds->blockRowCount - 1))
+		{
+			if (!scan->blockDirectory && scan->aocsfetch)
+			{
+				AppendOnlyBlockDirectoryEntry dirEntry;
+				bool res PG_USED_FOR_ASSERTS_ONLY;
+				res = AppendOnlyBlockDirectory_GetEntry(
+									  &scan->aocsfetch->blockDirectory,
+									  tid,
+									  attno,
+									  &dirEntry,
+									  scan->columnScanInfo.attnum_to_rownum);
+				Assert(res);
+
+				Assert(dirEntry.range.fileOffset <= ds->ao_read.logicalEof);
+				AppendOnlyStorageRead_SetTemporaryStart(&ds->ao_read,
+														dirEntry.range.fileOffset,
+														dirEntry.range.afterFileOffset);
+			}
+
+			while (true)
+			{
+				bool read_ok PG_USED_FOR_ASSERTS_ONLY;
+				read_ok = datumstreamread_block_info(ds);
+				Assert(read_ok);
+
+				if (rowNum <= ds->blockFirstRowNum + ds->blockRowCount - 1)
+				{
+					int64 blocksRead;
+					/* read a new buffer to consume */
+					datumstreamread_block_content(ds);
+
+					if (scan->blockDirectory)
+					{
+						AppendOnlyBlockDirectory_InsertEntry(scan->blockDirectory,
+															 attno,
+															 ds->blockFirstRowNum,
+															 ds->blockFileOffset,
+															 ds->blockRowCount);
+					}
+
+					AOCSScanDesc_UpdateTotalBytesRead(scan, attno);
+					blocksRead =
+						RelationGuessNumberOfBlocksFromSize(scan->totalBytesRead);
+					pgstat_count_buffer_read_ao(scan->rs_base.rs_rd,
+												blocksRead);
+
+					break;
+				}
+				else
+				{
+					bool save_gp_appendonly_verify_block_checksums = gp_appendonly_verify_block_checksums;
+					gp_appendonly_verify_block_checksums = false;
+					AppendOnlyStorageRead_SkipCurrentBlock(&ds->ao_read);
+					gp_appendonly_verify_block_checksums = save_gp_appendonly_verify_block_checksums;
+				}
+			}
+		}
+
+		err = datumstreamread_advance(ds);
+		Assert(err >= 0);
+
+		int32 rowNumInBlock = rowNum - ds->blockFirstRowNum;
+		while (rowNumInBlock > datumstreamread_nth(ds))
+		{
+			err = datumstreamread_advance(ds);
+			Assert(err > 0);
+		}
+
+		datumstreamread_get(ds, &d[attno], &null[attno]);
+
+		oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
+		slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
+		MemoryContextSwitchTo(oldContext);
 	}
 
-	if (tts_virtual_aocs_gettargetattr(slot, attrs))
-		slot->tts_nvalid = natts;
-
-	bms_free(attrs);
+	slot->tts_nvalid = natts;
 }
 
 /*

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -602,6 +602,7 @@ static HeapTuple
 tts_virtual_copy_heap_tuple(TupleTableSlot *slot)
 {
 	Assert(!TTS_EMPTY(slot));
+
 	return heap_form_tuple(slot->tts_tupleDescriptor,
 						   slot->tts_values,
 						   slot->tts_isnull);
@@ -611,6 +612,7 @@ static MinimalTuple
 tts_virtual_copy_minimal_tuple(TupleTableSlot *slot)
 {
 	Assert(!TTS_EMPTY(slot));
+
 	return heap_form_minimal_tuple(slot->tts_tupleDescriptor,
 								   slot->tts_values,
 								   slot->tts_isnull);

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -278,6 +278,11 @@ tts_virtual_aocs_is_attr_valid(TupleTableSlot *slot, int attnum)
 static void
 tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 {
+	/*
+	 * The content of this function is almost similar to
+	 * tts_virtual_aocs_gettargetattr(), but we do not remove this duplication
+	 * due to performance reasons.
+	 */
 	Datum	   *d = slot->tts_values;
 	bool	   *null = slot->tts_isnull;
 	int			err PG_USED_FOR_ASSERTS_ONLY;
@@ -297,11 +302,10 @@ tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 	{
 		AttrNumber	attno = scan->columnScanInfo.proj_atts[i];
 
-		if (bms_is_member(attno, slotAocs->tts_is_valid))
+		if (unlikely((attno < slot->tts_nvalid) ||
+					bms_is_member(attno, slotAocs->tts_is_valid)))
 			continue;
 
-		if (unlikely(attno < slot->tts_nvalid))
-			continue;
 		if (unlikely(attno >= natts))
 			break;
 

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -278,127 +278,31 @@ tts_virtual_aocs_is_attr_valid(TupleTableSlot *slot, int attnum)
 static void
 tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 {
-	Datum	   *d = slot->tts_values;
-	bool	   *null = slot->tts_isnull;
-	int			err PG_USED_FOR_ASSERTS_ONLY;
-	MemoryContext oldContext;
-
 	VirtualTupleTableSlotAOCS * slotAocs = (VirtualTupleTableSlotAOCS*)slot;
 	AOCSScanDesc scan = (AOCSScanDesc)slotAocs->current_scan;
 	if (unlikely(scan == NULL))
 		return;
 
-	AOCSFileSegInfo * curseginfo = scan->seginfo[scan->cur_seg];
-	AOTupleId	*tid = (AOTupleId *)&slot->tts_tid;
-	int64		rowNum = AOTupleIdGet_rowNum(tid);
-	Assert(rowNum != InvalidAORowNum);
-
+	Bitmapset *attrs = NULL;
 	for (AttrNumber i = 1; i < scan->columnScanInfo.num_proj_atts; i++)
 	{
 		AttrNumber	attno = scan->columnScanInfo.proj_atts[i];
 
-		if (bms_is_member(attno, slotAocs->tts_is_valid))
+		if (unlikely(attno < slot->tts_nvalid ||
+					bms_is_member(attno, slotAocs->tts_is_valid)))
 			continue;
 
-		if (unlikely(attno < slot->tts_nvalid))
-			continue;
 		if (unlikely(attno >= natts))
 			break;
 
-		if (unlikely(AO_ATTR_VAL_IS_MISSING(rowNum,
-								attno,
-								curseginfo->segno,
-								scan->columnScanInfo.attnum_to_rownum)))
-		{
-			d[attno] = getmissingattr(slot->tts_tupleDescriptor, attno + 1, &null[attno]);
+		attrs = bms_add_member(attrs, attno);
 
-			oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
-			slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
-			MemoryContextSwitchTo(oldContext);
-
-			continue;
-		}
-
-		DatumStreamRead *ds = scan->columnScanInfo.ds[attno];
-		Assert(ds);
-
-		if (unlikely(ds->noBlocksRead || rowNum > ds->blockFirstRowNum + ds->blockRowCount - 1))
-		{
-			if (!scan->blockDirectory && scan->aocsfetch)
-			{
-				AppendOnlyBlockDirectoryEntry dirEntry;
-				bool res PG_USED_FOR_ASSERTS_ONLY;
-				res = AppendOnlyBlockDirectory_GetEntry(
-									  &scan->aocsfetch->blockDirectory,
-									  tid,
-									  attno,
-									  &dirEntry,
-									  scan->columnScanInfo.attnum_to_rownum);
-				Assert(res);
-
-				Assert(dirEntry.range.fileOffset <= ds->ao_read.logicalEof);
-				AppendOnlyStorageRead_SetTemporaryStart(&ds->ao_read,
-														dirEntry.range.fileOffset,
-														dirEntry.range.afterFileOffset);
-			}
-
-			while (true)
-			{
-				bool read_ok PG_USED_FOR_ASSERTS_ONLY;
-				read_ok = datumstreamread_block_info(ds);
-				Assert(read_ok);
-
-				if (rowNum <= ds->blockFirstRowNum + ds->blockRowCount - 1)
-				{
-					int64 blocksRead;
-					/* read a new buffer to consume */
-					datumstreamread_block_content(ds);
-
-					if (scan->blockDirectory)
-					{
-						AppendOnlyBlockDirectory_InsertEntry(scan->blockDirectory,
-															 attno,
-															 ds->blockFirstRowNum,
-															 ds->blockFileOffset,
-															 ds->blockRowCount);
-					}
-
-					AOCSScanDesc_UpdateTotalBytesRead(scan, attno);
-					blocksRead =
-						RelationGuessNumberOfBlocksFromSize(scan->totalBytesRead);
-					pgstat_count_buffer_read_ao(scan->rs_base.rs_rd,
-												blocksRead);
-
-					break;
-				}
-				else
-				{
-					bool save_gp_appendonly_verify_block_checksums = gp_appendonly_verify_block_checksums;
-					gp_appendonly_verify_block_checksums = false;
-					AppendOnlyStorageRead_SkipCurrentBlock(&ds->ao_read);
-					gp_appendonly_verify_block_checksums = save_gp_appendonly_verify_block_checksums;
-				}
-			}
-		}
-
-		err = datumstreamread_advance(ds);
-		Assert(err >= 0);
-
-		int32 rowNumInBlock = rowNum - ds->blockFirstRowNum;
-		while (rowNumInBlock > datumstreamread_nth(ds))
-		{
-			err = datumstreamread_advance(ds);
-			Assert(err > 0);
-		}
-
-		datumstreamread_get(ds, &d[attno], &null[attno]);
-
-		oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
-		slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
-		MemoryContextSwitchTo(oldContext);
 	}
 
-	slot->tts_nvalid = natts;
+	if (tts_virtual_aocs_gettargetattr(slot, attrs))
+		slot->tts_nvalid = natts;
+
+	bms_free(attrs);
 }
 
 /*

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -277,6 +277,13 @@ tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 }
 
 static bool
+tts_virtual_aocs_is_attr_valid(TupleTableSlot *slot, int attnum)
+{
+	VirtualTupleTableSlotAOCS * slotAocs = (VirtualTupleTableSlotAOCS*)slot;
+	return bms_is_member(attnum, slotAocs->tts_is_valid);
+}
+
+static bool
 tts_virtual_aocs_gettargetattr(TupleTableSlot *slot, Bitmapset *attrs)
 {
 	VirtualTupleTableSlotAOCS * slotAocs = (VirtualTupleTableSlotAOCS*)slot;
@@ -1350,7 +1357,8 @@ const TupleTableSlotOps TTSOpsVirtual = {
 	.copy_heap_tuple = tts_virtual_copy_heap_tuple,
 	.copy_minimal_tuple = tts_virtual_copy_minimal_tuple,
 
-	.gettargetattr = NULL
+	.gettargetattr = NULL,
+	.is_attr_valid = NULL
 };
 
 const TupleTableSlotOps TTSOpsVirtualAOCS = {
@@ -1372,7 +1380,8 @@ const TupleTableSlotOps TTSOpsVirtualAOCS = {
 	.copy_heap_tuple = tts_virtual_copy_heap_tuple,
 	.copy_minimal_tuple = tts_virtual_copy_minimal_tuple,
 
-	.gettargetattr = tts_virtual_aocs_gettargetattr
+	.gettargetattr = tts_virtual_aocs_gettargetattr,
+	.is_attr_valid = tts_virtual_aocs_is_attr_valid
 };
 
 const TupleTableSlotOps TTSOpsHeapTuple = {
@@ -1391,7 +1400,8 @@ const TupleTableSlotOps TTSOpsHeapTuple = {
 	.copy_heap_tuple = tts_heap_copy_heap_tuple,
 	.copy_minimal_tuple = tts_heap_copy_minimal_tuple,
 
-	.gettargetattr = NULL
+	.gettargetattr = NULL,
+	.is_attr_valid = NULL
 };
 
 const TupleTableSlotOps TTSOpsMinimalTuple = {
@@ -1410,7 +1420,8 @@ const TupleTableSlotOps TTSOpsMinimalTuple = {
 	.copy_heap_tuple = tts_minimal_copy_heap_tuple,
 	.copy_minimal_tuple = tts_minimal_copy_minimal_tuple,
 
-	.gettargetattr = NULL
+	.gettargetattr = NULL,
+	.is_attr_valid = NULL
 };
 
 const TupleTableSlotOps TTSOpsBufferHeapTuple = {
@@ -1429,7 +1440,8 @@ const TupleTableSlotOps TTSOpsBufferHeapTuple = {
 	.copy_heap_tuple = tts_buffer_heap_copy_heap_tuple,
 	.copy_minimal_tuple = tts_buffer_heap_copy_minimal_tuple,
 
-	.gettargetattr = NULL
+	.gettargetattr = NULL,
+	.is_attr_valid = NULL
 };
 
 
@@ -2262,16 +2274,6 @@ slot_getsomeattrs_int(TupleTableSlot *slot, int attnum)
 		slot->tts_nvalid = attnum;
 	}
 }
-
-bool
-slot_gettargetattr_int(TupleTableSlot *slot, Bitmapset *attrs)
-{
-	if (NULL == slot->tts_ops->gettargetattr)
-		return false;
-
-	return slot->tts_ops->gettargetattr(slot, attrs);
-}
-
 
 /* ----------------------------------------------------------------
  *		ExecTypeFromTL

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -2211,6 +2211,22 @@ slot_getsomeattrs_int(TupleTableSlot *slot, int attnum)
 	}
 }
 
+/*
+ * slot_gettargetattr - fetch exactly the given (possibly sparse) set of
+ * attributes, for slot types that support it (see TupleTableSlotOps).
+ *
+ * Returns false, doing nothing, if the slot type has no gettargetattr
+ * callback, so the caller can fall back to slot_getsomeattrs().
+ */
+bool
+slot_gettargetattr(TupleTableSlot *slot, Bitmapset *attrs)
+{
+	if (NULL == slot->tts_ops->gettargetattr)
+		return false;
+
+	return slot->tts_ops->gettargetattr(slot, attrs);
+}
+
 /* ----------------------------------------------------------------
  *		ExecTypeFromTL
  *

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -127,15 +127,45 @@ tts_virtual_clear(TupleTableSlot *slot)
 }
 
 static void
+tts_virtual_aocs_init(TupleTableSlot *slot)
+{
+	VirtualTupleTableSlotAOCS *vslot_aocs = (VirtualTupleTableSlotAOCS *) slot;
+
+	//elog(LOG, "[RELOG][%s] slot %p", __FUNCTION__, slot);
+	if (slot->tts_tupleDescriptor)
+	{
+		//elog(LOG, "[RELOG][%s] slot %p, palloc0 for natts %d", __FUNCTION__, slot, slot->tts_tupleDescriptor->natts);
+		vslot_aocs->tts_is_valid = palloc0(
+			slot->tts_tupleDescriptor->natts * sizeof(bool));
+	}
+}
+
+static void
+tts_virtual_aocs_release(TupleTableSlot *slot)
+{
+	VirtualTupleTableSlotAOCS *vslot_aocs = (VirtualTupleTableSlotAOCS *) slot;
+	//elog(LOG, "[RELOG][%s] slot %p, vslot_aocs->tts_is_valid %p", __FUNCTION__, slot, vslot_aocs->tts_is_valid);
+	if (vslot_aocs->tts_is_valid)
+	{
+		pfree(vslot_aocs->tts_is_valid);
+		vslot_aocs->tts_is_valid = NULL;
+	}
+}
+
+static void
 tts_virtual_aocs_clear(TupleTableSlot *slot)
 {
-	if (unlikely(TTS_SHOULDFREE(slot)))
-	{
-		VirtualTupleTableSlotAOCS *vslot_aocs = (VirtualTupleTableSlotAOCS *) slot;
-		vslot_aocs->current_scan = NULL;
-	}
+	VirtualTupleTableSlotAOCS *vslot_aocs = (VirtualTupleTableSlotAOCS *) slot;
 
 	tts_virtual_clear(slot);
+
+	vslot_aocs->current_scan = NULL;
+
+	//elog(LOG, "[RELOG][%s] slot %p, vslot_aocs->tts_is_valid %p, slot->tts_tupleDescriptor %p", __FUNCTION__, slot, vslot_aocs->tts_is_valid, slot->tts_tupleDescriptor);
+
+	if (vslot_aocs->tts_is_valid && slot->tts_tupleDescriptor)
+		for (int i = 0; i < slot->tts_tupleDescriptor->natts; i++)
+			vslot_aocs->tts_is_valid[i] = false;
 }
 
 /*
@@ -165,9 +195,14 @@ tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 	int64		rowNum = AOTupleIdGet_rowNum(tid);
 	Assert(rowNum != InvalidAORowNum);
 
+	//elog(LOG, "[RELOG][%s] slot %p, natts = %d, slot->tts_nvalid %d", __FUNCTION__, slot, natts, slot->tts_nvalid);
+
 	for (AttrNumber i = 1; i < scan->columnScanInfo.num_proj_atts; i++)
 	{
 		AttrNumber	attno = scan->columnScanInfo.proj_atts[i];
+
+		if (slotAocs->tts_is_valid[attno])
+			continue;
 
 		if (unlikely(attno < slot->tts_nvalid))
 			continue;
@@ -180,6 +215,7 @@ tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 								scan->columnScanInfo.attnum_to_rownum)))
 		{
 			d[attno] = getmissingattr(slot->tts_tupleDescriptor, attno + 1, &null[attno]);
+			slotAocs->tts_is_valid[attno] = true;
 			continue;
 		}
 
@@ -256,9 +292,124 @@ tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 		}
 
 		datumstreamread_get(ds, &d[attno], &null[attno]);
+		slotAocs->tts_is_valid[attno] = true;
 	}
 
 	slot->tts_nvalid = natts;
+}
+
+static void
+tts_virtual_aocs_gettargetattr(TupleTableSlot *slot, int attnum)
+{
+	Datum	   *d = slot->tts_values;
+	bool	   *null = slot->tts_isnull;
+	int			err PG_USED_FOR_ASSERTS_ONLY;
+
+	//elog(LOG, "[RELOG][%s] attnum = %d", __FUNCTION__, attnum);
+
+	// TODO: fix the ugly naming fusion
+	AttrNumber	attno = attnum - 1;
+
+	VirtualTupleTableSlotAOCS * slotAocs = (VirtualTupleTableSlotAOCS*)slot;
+
+	if (slotAocs->tts_is_valid[attno])
+		return;
+
+	AOCSScanDesc scan = (AOCSScanDesc)slotAocs->current_scan;
+	if (unlikely(scan == NULL))
+		return;
+
+	AOCSFileSegInfo * curseginfo = scan->seginfo[scan->cur_seg];
+	AOTupleId	*tid = (AOTupleId *)&slot->tts_tid;
+	int64		rowNum = AOTupleIdGet_rowNum(tid);
+	Assert(rowNum != InvalidAORowNum);
+
+	if (unlikely(AO_ATTR_VAL_IS_MISSING(rowNum,
+							attno,
+							curseginfo->segno,
+							scan->columnScanInfo.attnum_to_rownum)))
+	{
+		d[attno] = getmissingattr(slot->tts_tupleDescriptor, attno + 1, &null[attno]);
+		slotAocs->tts_is_valid[attno] = true;
+		return;
+	}
+
+	DatumStreamRead *ds = scan->columnScanInfo.ds[attno];
+	Assert(ds);
+
+	if (unlikely(ds->noBlocksRead || rowNum > ds->blockFirstRowNum + ds->blockRowCount - 1))
+	{
+		if (!scan->blockDirectory && scan->aocsfetch)
+		{
+			AppendOnlyBlockDirectoryEntry dirEntry;
+			bool res PG_USED_FOR_ASSERTS_ONLY;
+			res = AppendOnlyBlockDirectory_GetEntry(
+								  &scan->aocsfetch->blockDirectory,
+								  tid,
+								  attno,
+								  &dirEntry,
+								  scan->columnScanInfo.attnum_to_rownum);
+			Assert(res);
+
+			Assert(dirEntry.range.fileOffset <= ds->ao_read.logicalEof);
+			AppendOnlyStorageRead_SetTemporaryStart(&ds->ao_read,
+													dirEntry.range.fileOffset,
+													dirEntry.range.afterFileOffset);
+		}
+
+		while (true)
+		{
+			bool read_ok PG_USED_FOR_ASSERTS_ONLY;
+			read_ok = datumstreamread_block_info(ds);
+			Assert(read_ok);
+
+			if (rowNum <= ds->blockFirstRowNum + ds->blockRowCount - 1)
+			{
+				int64 blocksRead;
+				/* read a new buffer to consume */
+				datumstreamread_block_content(ds);
+
+				if (scan->blockDirectory)
+				{
+					AppendOnlyBlockDirectory_InsertEntry(scan->blockDirectory,
+														 attno,
+														 ds->blockFirstRowNum,
+														 ds->blockFileOffset,
+														 ds->blockRowCount);
+				}
+
+				AOCSScanDesc_UpdateTotalBytesRead(scan, attno);
+				blocksRead =
+					RelationGuessNumberOfBlocksFromSize(scan->totalBytesRead);
+				pgstat_count_buffer_read_ao(scan->rs_base.rs_rd,
+											blocksRead);
+
+				break;
+			}
+			else
+			{
+				bool save_gp_appendonly_verify_block_checksums = gp_appendonly_verify_block_checksums;
+				gp_appendonly_verify_block_checksums = false;
+				AppendOnlyStorageRead_SkipCurrentBlock(&ds->ao_read);
+				gp_appendonly_verify_block_checksums = save_gp_appendonly_verify_block_checksums;
+			}
+		}
+	}
+
+	err = datumstreamread_advance(ds);
+	Assert(err >= 0);
+
+	int32 rowNumInBlock = rowNum - ds->blockFirstRowNum;
+	while (rowNumInBlock > datumstreamread_nth(ds))
+	{
+		err = datumstreamread_advance(ds);
+		Assert(err > 0);
+	}
+
+	datumstreamread_get(ds, &d[attno], &null[attno]);
+	slotAocs->tts_is_valid[attno] = true;
+
+	// slot->tts_nvalid = natts;
 }
 
 /*
@@ -429,6 +580,24 @@ tts_virtual_aocs_copyslot(TupleTableSlot *dstslot, TupleTableSlot *srcslot)
 	{
 		dstslot->tts_values[natt] = srcslot->tts_values[natt];
 		dstslot->tts_isnull[natt] = srcslot->tts_isnull[natt];
+	}
+
+	//elog(LOG, "[RELOG][%s] dstslot %p, srcslot %p [is_aocs %u]", __FUNCTION__, dstslot, srcslot, TTS_IS_VIRTUAL_AOCS(srcslot));
+
+	if (TTS_IS_VIRTUAL_AOCS(srcslot))
+	{
+		VirtualTupleTableSlotAOCS *dstslot_aocs = (VirtualTupleTableSlotAOCS *) dstslot;
+		VirtualTupleTableSlotAOCS *srcslot_aocs = (VirtualTupleTableSlotAOCS *) srcslot;
+
+		//elog(LOG, "[RELOG][%s] srcslot_aocs->tts_is_valid %p, srcdesc->natts %d", __FUNCTION__, srcslot_aocs->tts_is_valid, srcdesc->natts);
+
+		if (srcslot_aocs->tts_is_valid)
+		{
+			for (int natt = 0; natt < srcdesc->natts; natt++)
+			{
+				dstslot_aocs->tts_is_valid[natt] = srcslot_aocs->tts_is_valid[natt];
+			}
+		}
 	}
 
 	dstslot->tts_nvalid = srcdesc->natts;
@@ -1205,13 +1374,15 @@ const TupleTableSlotOps TTSOpsVirtual = {
 	.get_heap_tuple = NULL,
 	.get_minimal_tuple = NULL,
 	.copy_heap_tuple = tts_virtual_copy_heap_tuple,
-	.copy_minimal_tuple = tts_virtual_copy_minimal_tuple
+	.copy_minimal_tuple = tts_virtual_copy_minimal_tuple,
+
+	.gettargetattr = NULL
 };
 
 const TupleTableSlotOps TTSOpsVirtualAOCS = {
 	.base_slot_size = sizeof(VirtualTupleTableSlotAOCS),
-	.init = tts_virtual_init,
-	.release = tts_virtual_release,
+	.init = tts_virtual_aocs_init,
+	.release = tts_virtual_aocs_release,
 	.clear = tts_virtual_aocs_clear,
 	.getsomeattrs = tts_virtual_aocs_getsomeattrs,
 	.getsysattr = tts_virtual_getsysattr,
@@ -1225,7 +1396,9 @@ const TupleTableSlotOps TTSOpsVirtualAOCS = {
 	.get_heap_tuple = NULL,
 	.get_minimal_tuple = NULL,
 	.copy_heap_tuple = tts_virtual_copy_heap_tuple,
-	.copy_minimal_tuple = tts_virtual_copy_minimal_tuple
+	.copy_minimal_tuple = tts_virtual_copy_minimal_tuple,
+
+	.gettargetattr = tts_virtual_aocs_gettargetattr
 };
 
 const TupleTableSlotOps TTSOpsHeapTuple = {
@@ -1242,7 +1415,9 @@ const TupleTableSlotOps TTSOpsHeapTuple = {
 	/* A heap tuple table slot can not "own" a minimal tuple. */
 	.get_minimal_tuple = NULL,
 	.copy_heap_tuple = tts_heap_copy_heap_tuple,
-	.copy_minimal_tuple = tts_heap_copy_minimal_tuple
+	.copy_minimal_tuple = tts_heap_copy_minimal_tuple,
+
+	.gettargetattr = NULL
 };
 
 const TupleTableSlotOps TTSOpsMinimalTuple = {
@@ -1259,7 +1434,9 @@ const TupleTableSlotOps TTSOpsMinimalTuple = {
 	.get_heap_tuple = NULL,
 	.get_minimal_tuple = tts_minimal_get_minimal_tuple,
 	.copy_heap_tuple = tts_minimal_copy_heap_tuple,
-	.copy_minimal_tuple = tts_minimal_copy_minimal_tuple
+	.copy_minimal_tuple = tts_minimal_copy_minimal_tuple,
+
+	.gettargetattr = NULL
 };
 
 const TupleTableSlotOps TTSOpsBufferHeapTuple = {
@@ -1276,7 +1453,9 @@ const TupleTableSlotOps TTSOpsBufferHeapTuple = {
 	/* A buffer heap tuple table slot can not "own" a minimal tuple. */
 	.get_minimal_tuple = NULL,
 	.copy_heap_tuple = tts_buffer_heap_copy_heap_tuple,
-	.copy_minimal_tuple = tts_buffer_heap_copy_minimal_tuple
+	.copy_minimal_tuple = tts_buffer_heap_copy_minimal_tuple,
+
+	.gettargetattr = NULL
 };
 
 
@@ -2109,6 +2288,37 @@ slot_getsomeattrs_int(TupleTableSlot *slot, int attnum)
 		slot->tts_nvalid = attnum;
 	}
 }
+
+bool
+slot_gettargetattr_int(TupleTableSlot *slot, int attnum)
+{
+	/* Check for caller errors */
+	Assert(attnum > 0);
+
+	if (NULL == slot->tts_ops->gettargetattr)
+		return false;
+
+	if (unlikely(attnum > slot->tts_tupleDescriptor->natts))
+		elog(ERROR, "invalid attribute number %d", attnum);
+
+	slot->tts_ops->gettargetattr(slot, attnum);
+
+	return true;
+
+	// TODO: handle
+#if 0
+	/*
+	 * If the underlying tuple doesn't have enough attributes, tuple
+	 * descriptor must have the missing attributes.
+	 */
+	if (unlikely(slot->tts_nvalid < attnum))
+	{
+		slot_getmissingattrs(slot, slot->tts_nvalid, attnum);
+		slot->tts_nvalid = attnum;
+	}
+#endif
+}
+
 
 /* ----------------------------------------------------------------
  *		ExecTypeFromTL

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -297,6 +297,7 @@ tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 	AOTupleId	*tid = (AOTupleId *)&slot->tts_tid;
 	int64		rowNum = AOTupleIdGet_rowNum(tid);
 	Assert(rowNum != InvalidAORowNum);
+	AttrNumber anchor_attr = scan->columnScanInfo.proj_atts[ANCHOR_COL_IN_PROJ];
 
 	for (AttrNumber i = 1; i < scan->columnScanInfo.num_proj_atts; i++)
 	{
@@ -307,7 +308,11 @@ tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 			continue;
 
 		if (unlikely(attno >= natts))
+		{
+			if (attno < anchor_attr)
+				continue;
 			break;
+		}
 
 		if (unlikely(AO_ATTR_VAL_IS_MISSING(rowNum,
 								attno,

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -302,10 +302,8 @@ tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 	{
 		AttrNumber	attno = scan->columnScanInfo.proj_atts[i];
 
-		if (bms_is_member(attno, slotAocs->tts_is_valid))
-			continue;
-
-		if (unlikely(attno < slot->tts_nvalid))
+		if (unlikely((attno < slot->tts_nvalid) ||
+					bms_is_member(attno, slotAocs->tts_is_valid)))
 			continue;
 
 		if (unlikely(attno >= natts))

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -302,8 +302,10 @@ tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 	{
 		AttrNumber	attno = scan->columnScanInfo.proj_atts[i];
 
-		if (unlikely((attno < slot->tts_nvalid) ||
-					bms_is_member(attno, slotAocs->tts_is_valid)))
+		if (bms_is_member(attno, slotAocs->tts_is_valid))
+			continue;
+
+		if (unlikely(attno < slot->tts_nvalid))
 			continue;
 
 		if (unlikely(attno >= natts))

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -127,29 +127,6 @@ tts_virtual_clear(TupleTableSlot *slot)
 }
 
 static void
-tts_virtual_aocs_init(TupleTableSlot *slot)
-{
-	VirtualTupleTableSlotAOCS *vslot_aocs = (VirtualTupleTableSlotAOCS *) slot;
-
-	if (slot->tts_tupleDescriptor)
-	{
-		vslot_aocs->tts_is_valid = palloc0(
-			slot->tts_tupleDescriptor->natts * sizeof(bool));
-	}
-}
-
-static void
-tts_virtual_aocs_release(TupleTableSlot *slot)
-{
-	VirtualTupleTableSlotAOCS *vslot_aocs = (VirtualTupleTableSlotAOCS *) slot;
-	if (vslot_aocs->tts_is_valid)
-	{
-		pfree(vslot_aocs->tts_is_valid);
-		vslot_aocs->tts_is_valid = NULL;
-	}
-}
-
-static void
 tts_virtual_aocs_clear(TupleTableSlot *slot)
 {
 	VirtualTupleTableSlotAOCS *vslot_aocs = (VirtualTupleTableSlotAOCS *) slot;
@@ -158,9 +135,8 @@ tts_virtual_aocs_clear(TupleTableSlot *slot)
 
 	vslot_aocs->current_scan = NULL;
 
-	if (vslot_aocs->tts_is_valid && slot->tts_tupleDescriptor)
-		for (int i = 0; i < slot->tts_tupleDescriptor->natts; i++)
-			vslot_aocs->tts_is_valid[i] = false;
+	bms_free(vslot_aocs->tts_is_valid);
+	vslot_aocs->tts_is_valid = NULL;
 }
 
 /*
@@ -179,6 +155,7 @@ tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 	Datum	   *d = slot->tts_values;
 	bool	   *null = slot->tts_isnull;
 	int			err PG_USED_FOR_ASSERTS_ONLY;
+	MemoryContext oldContext;
 
 	VirtualTupleTableSlotAOCS * slotAocs = (VirtualTupleTableSlotAOCS*)slot;
 	AOCSScanDesc scan = (AOCSScanDesc)slotAocs->current_scan;
@@ -194,7 +171,7 @@ tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 	{
 		AttrNumber	attno = scan->columnScanInfo.proj_atts[i];
 
-		if (slotAocs->tts_is_valid[attno])
+		if (bms_is_member(attno, slotAocs->tts_is_valid))
 			continue;
 
 		if (unlikely(attno < slot->tts_nvalid))
@@ -208,7 +185,11 @@ tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 								scan->columnScanInfo.attnum_to_rownum)))
 		{
 			d[attno] = getmissingattr(slot->tts_tupleDescriptor, attno + 1, &null[attno]);
-			slotAocs->tts_is_valid[attno] = true;
+
+			oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
+			slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
+			MemoryContextSwitchTo(oldContext);
+
 			continue;
 		}
 
@@ -285,122 +266,133 @@ tts_virtual_aocs_getsomeattrs(TupleTableSlot *slot, int natts)
 		}
 
 		datumstreamread_get(ds, &d[attno], &null[attno]);
-		slotAocs->tts_is_valid[attno] = true;
+
+		oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
+		slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
+		MemoryContextSwitchTo(oldContext);
+
 	}
 
 	slot->tts_nvalid = natts;
 }
 
-static void
-tts_virtual_aocs_gettargetattr(TupleTableSlot *slot, int attnum)
+static bool
+tts_virtual_aocs_gettargetattr(TupleTableSlot *slot, Bitmapset *attrs)
 {
-	Datum	   *d = slot->tts_values;
-	bool	   *null = slot->tts_isnull;
-	int			err PG_USED_FOR_ASSERTS_ONLY;
-
-	// TODO: fix the ugly naming fusion
-	AttrNumber	attno = attnum - 1;
-
 	VirtualTupleTableSlotAOCS * slotAocs = (VirtualTupleTableSlotAOCS*)slot;
-
-	if (slotAocs->tts_is_valid[attno])
-		return;
-
 	AOCSScanDesc scan = (AOCSScanDesc)slotAocs->current_scan;
 	if (unlikely(scan == NULL))
-		return;
+		return false;
 
-	AOCSFileSegInfo * curseginfo = scan->seginfo[scan->cur_seg];
-	AOTupleId	*tid = (AOTupleId *)&slot->tts_tid;
-	int64		rowNum = AOTupleIdGet_rowNum(tid);
-	Assert(rowNum != InvalidAORowNum);
-
-	if (unlikely(AO_ATTR_VAL_IS_MISSING(rowNum,
-							attno,
-							curseginfo->segno,
-							scan->columnScanInfo.attnum_to_rownum)))
+ 	AttrNumber	attno = -1;
+	while ((attno = bms_next_member(attrs, attno)) >= 0)
 	{
-		d[attno] = getmissingattr(slot->tts_tupleDescriptor, attno + 1, &null[attno]);
-		slotAocs->tts_is_valid[attno] = true;
-		return;
-	}
+		Datum	   *d = slot->tts_values;
+		bool	   *null = slot->tts_isnull;
+		int			err PG_USED_FOR_ASSERTS_ONLY;
+		MemoryContext oldContext;
 
-	DatumStreamRead *ds = scan->columnScanInfo.ds[attno];
-	Assert(ds);
+		if (bms_is_member(attno, slotAocs->tts_is_valid))
+			continue;
 
-	if (unlikely(ds->noBlocksRead || rowNum > ds->blockFirstRowNum + ds->blockRowCount - 1))
-	{
-		if (!scan->blockDirectory && scan->aocsfetch)
+		AOCSFileSegInfo * curseginfo = scan->seginfo[scan->cur_seg];
+		AOTupleId	*tid = (AOTupleId *)&slot->tts_tid;
+		int64		rowNum = AOTupleIdGet_rowNum(tid);
+		Assert(rowNum != InvalidAORowNum);
+
+		if (unlikely(AO_ATTR_VAL_IS_MISSING(rowNum,
+								attno,
+								curseginfo->segno,
+								scan->columnScanInfo.attnum_to_rownum)))
 		{
-			AppendOnlyBlockDirectoryEntry dirEntry;
-			bool res PG_USED_FOR_ASSERTS_ONLY;
-			res = AppendOnlyBlockDirectory_GetEntry(
-								  &scan->aocsfetch->blockDirectory,
-								  tid,
-								  attno,
-								  &dirEntry,
-								  scan->columnScanInfo.attnum_to_rownum);
-			Assert(res);
+			d[attno] = getmissingattr(slot->tts_tupleDescriptor, attno + 1, &null[attno]);
 
-			Assert(dirEntry.range.fileOffset <= ds->ao_read.logicalEof);
-			AppendOnlyStorageRead_SetTemporaryStart(&ds->ao_read,
-													dirEntry.range.fileOffset,
-													dirEntry.range.afterFileOffset);
+			oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
+			slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
+			MemoryContextSwitchTo(oldContext);
+
+			continue;
 		}
 
-		while (true)
+		DatumStreamRead *ds = scan->columnScanInfo.ds[attno];
+		Assert(ds);
+
+		if (unlikely(ds->noBlocksRead || rowNum > ds->blockFirstRowNum + ds->blockRowCount - 1))
 		{
-			bool read_ok PG_USED_FOR_ASSERTS_ONLY;
-			read_ok = datumstreamread_block_info(ds);
-			Assert(read_ok);
-
-			if (rowNum <= ds->blockFirstRowNum + ds->blockRowCount - 1)
+			if (!scan->blockDirectory && scan->aocsfetch)
 			{
-				int64 blocksRead;
-				/* read a new buffer to consume */
-				datumstreamread_block_content(ds);
+				AppendOnlyBlockDirectoryEntry dirEntry;
+				bool res PG_USED_FOR_ASSERTS_ONLY;
+				res = AppendOnlyBlockDirectory_GetEntry(
+									  &scan->aocsfetch->blockDirectory,
+									  tid,
+									  attno,
+									  &dirEntry,
+									  scan->columnScanInfo.attnum_to_rownum);
+				Assert(res);
 
-				if (scan->blockDirectory)
+				Assert(dirEntry.range.fileOffset <= ds->ao_read.logicalEof);
+				AppendOnlyStorageRead_SetTemporaryStart(&ds->ao_read,
+														dirEntry.range.fileOffset,
+														dirEntry.range.afterFileOffset);
+			}
+
+			while (true)
+			{
+				bool read_ok PG_USED_FOR_ASSERTS_ONLY;
+				read_ok = datumstreamread_block_info(ds);
+				Assert(read_ok);
+
+				if (rowNum <= ds->blockFirstRowNum + ds->blockRowCount - 1)
 				{
-					AppendOnlyBlockDirectory_InsertEntry(scan->blockDirectory,
-														 attno,
-														 ds->blockFirstRowNum,
-														 ds->blockFileOffset,
-														 ds->blockRowCount);
+					int64 blocksRead;
+					/* read a new buffer to consume */
+					datumstreamread_block_content(ds);
+
+					if (scan->blockDirectory)
+					{
+						AppendOnlyBlockDirectory_InsertEntry(scan->blockDirectory,
+															 attno,
+															 ds->blockFirstRowNum,
+															 ds->blockFileOffset,
+															 ds->blockRowCount);
+					}
+
+					AOCSScanDesc_UpdateTotalBytesRead(scan, attno);
+					blocksRead =
+						RelationGuessNumberOfBlocksFromSize(scan->totalBytesRead);
+					pgstat_count_buffer_read_ao(scan->rs_base.rs_rd,
+												blocksRead);
+
+					break;
 				}
-
-				AOCSScanDesc_UpdateTotalBytesRead(scan, attno);
-				blocksRead =
-					RelationGuessNumberOfBlocksFromSize(scan->totalBytesRead);
-				pgstat_count_buffer_read_ao(scan->rs_base.rs_rd,
-											blocksRead);
-
-				break;
-			}
-			else
-			{
-				bool save_gp_appendonly_verify_block_checksums = gp_appendonly_verify_block_checksums;
-				gp_appendonly_verify_block_checksums = false;
-				AppendOnlyStorageRead_SkipCurrentBlock(&ds->ao_read);
-				gp_appendonly_verify_block_checksums = save_gp_appendonly_verify_block_checksums;
+				else
+				{
+					bool save_gp_appendonly_verify_block_checksums = gp_appendonly_verify_block_checksums;
+					gp_appendonly_verify_block_checksums = false;
+					AppendOnlyStorageRead_SkipCurrentBlock(&ds->ao_read);
+					gp_appendonly_verify_block_checksums = save_gp_appendonly_verify_block_checksums;
+				}
 			}
 		}
-	}
 
-	err = datumstreamread_advance(ds);
-	Assert(err >= 0);
-
-	int32 rowNumInBlock = rowNum - ds->blockFirstRowNum;
-	while (rowNumInBlock > datumstreamread_nth(ds))
-	{
 		err = datumstreamread_advance(ds);
-		Assert(err > 0);
+		Assert(err >= 0);
+
+		int32 rowNumInBlock = rowNum - ds->blockFirstRowNum;
+		while (rowNumInBlock > datumstreamread_nth(ds))
+		{
+			err = datumstreamread_advance(ds);
+			Assert(err > 0);
+		}
+
+		datumstreamread_get(ds, &d[attno], &null[attno]);
+
+		oldContext = MemoryContextSwitchTo(slot->tts_mcxt);
+		slotAocs->tts_is_valid = bms_add_member(slotAocs->tts_is_valid, attno);
+		MemoryContextSwitchTo(oldContext);
 	}
-
-	datumstreamread_get(ds, &d[attno], &null[attno]);
-	slotAocs->tts_is_valid[attno] = true;
-
-	// slot->tts_nvalid = natts;
+	return true;
 }
 
 /*
@@ -577,14 +569,11 @@ tts_virtual_aocs_copyslot(TupleTableSlot *dstslot, TupleTableSlot *srcslot)
 	{
 		VirtualTupleTableSlotAOCS *dstslot_aocs = (VirtualTupleTableSlotAOCS *) dstslot;
 		VirtualTupleTableSlotAOCS *srcslot_aocs = (VirtualTupleTableSlotAOCS *) srcslot;
+		MemoryContext oldContext;
 
-		if (srcslot_aocs->tts_is_valid)
-		{
-			for (int natt = 0; natt < srcdesc->natts; natt++)
-			{
-				dstslot_aocs->tts_is_valid[natt] = srcslot_aocs->tts_is_valid[natt];
-			}
-		}
+		oldContext = MemoryContextSwitchTo(dstslot->tts_mcxt);
+		dstslot_aocs->tts_is_valid = bms_copy(srcslot_aocs->tts_is_valid);
+		MemoryContextSwitchTo(oldContext);
 	}
 
 	dstslot->tts_nvalid = srcdesc->natts;
@@ -1366,8 +1355,8 @@ const TupleTableSlotOps TTSOpsVirtual = {
 
 const TupleTableSlotOps TTSOpsVirtualAOCS = {
 	.base_slot_size = sizeof(VirtualTupleTableSlotAOCS),
-	.init = tts_virtual_aocs_init,
-	.release = tts_virtual_aocs_release,
+	.init = tts_virtual_init,
+	.release = tts_virtual_release,
 	.clear = tts_virtual_aocs_clear,
 	.getsomeattrs = tts_virtual_aocs_getsomeattrs,
 	.getsysattr = tts_virtual_getsysattr,
@@ -2275,33 +2264,12 @@ slot_getsomeattrs_int(TupleTableSlot *slot, int attnum)
 }
 
 bool
-slot_gettargetattr_int(TupleTableSlot *slot, int attnum)
+slot_gettargetattr_int(TupleTableSlot *slot, Bitmapset *attrs)
 {
-	/* Check for caller errors */
-	Assert(attnum > 0);
-
 	if (NULL == slot->tts_ops->gettargetattr)
 		return false;
 
-	if (unlikely(attnum > slot->tts_tupleDescriptor->natts))
-		elog(ERROR, "invalid attribute number %d", attnum);
-
-	slot->tts_ops->gettargetattr(slot, attnum);
-
-	return true;
-
-	// TODO: handle
-#if 0
-	/*
-	 * If the underlying tuple doesn't have enough attributes, tuple
-	 * descriptor must have the missing attributes.
-	 */
-	if (unlikely(slot->tts_nvalid < attnum))
-	{
-		slot_getmissingattrs(slot, slot->tts_nvalid, attnum);
-		slot->tts_nvalid = attnum;
-	}
-#endif
+	return slot->tts_ops->gettargetattr(slot, attrs);
 }
 
 

--- a/src/backend/jit/llvm/llvmjit.c
+++ b/src/backend/jit/llvm/llvmjit.c
@@ -98,6 +98,7 @@ LLVMTypeRef StructAggState;
 LLVMTypeRef StructAggStatePerGroupData;
 LLVMTypeRef StructAggStatePerTransData;
 LLVMTypeRef StructPlanState;
+LLVMTypeRef StructBitmapset;
 
 LLVMValueRef AttributeTemplate;
 LLVMValueRef ExecEvalSubroutineTemplate;
@@ -1179,6 +1180,7 @@ llvm_create_types(void)
 	StructAggStatePerTransData = llvm_pg_var_type("StructAggStatePerTransData");
 	StructPlanState = llvm_pg_var_type("StructPlanState");
 	StructMinimalTupleData = llvm_pg_var_type("StructMinimalTupleData");
+	StructBitmapset = llvm_pg_var_type("StructBitmapset");
 
 	AttributeTemplate = LLVMGetNamedFunction(llvm_types_module, "AttributeTemplate");
 	ExecEvalSubroutineTemplate = LLVMGetNamedFunction(llvm_types_module, "ExecEvalSubroutineTemplate");

--- a/src/backend/jit/llvm/llvmjit_deform.c
+++ b/src/backend/jit/llvm/llvmjit_deform.c
@@ -106,7 +106,6 @@ slot_compile_deform(LLVMJitContext *context, TupleDesc desc,
 
 	int			attnum;
 
-	/* TODO: consider TTSOpsVirtualAOCS here? */
 	/* virtual tuples never need deforming, so don't generate code */
 	if (ops == &TTSOpsVirtual)
 		return NULL;

--- a/src/backend/jit/llvm/llvmjit_expr.c
+++ b/src/backend/jit/llvm/llvmjit_expr.c
@@ -322,6 +322,43 @@ llvm_compile_expr(ExprState *state)
 						v_slot = v_scanslot;
 
 					/*
+					 * For scan slots where the exact (possibly sparse) set
+					 * of required attnos is known, try slot_gettargetattr()
+					 * first: slot types that support it fetch just those
+					 * attributes and can skip the nvalid-prefix based deform
+					 * below entirely.
+					 * If the slot type doesn't support it,
+					 * slot_gettargetattr() returns false and we fall
+					 * through to the regular check, exactly mirroring the
+					 * EEOP_SCAN_FETCHSOME handling in ExecInterpExpr().
+					 */
+					if (opcode == EEOP_SCAN_FETCHSOME && op->d.fetch.all_vars)
+					{
+						LLVMBasicBlockRef b_nvalid_check;
+						LLVMValueRef v_params[2];
+						LLVMValueRef v_ret;
+
+						b_nvalid_check = l_bb_before_v(b_fetch,
+													   "op.%d.nvalid_check", i);
+
+						v_params[0] = v_slot;
+						v_params[1] = l_ptr_const(op->d.fetch.all_vars,
+												   l_ptr(StructBitmapset));
+
+						v_ret = l_call(b,
+									   llvm_pg_var_func_type("slot_gettargetattr"),
+									   llvm_pg_func(mod, "slot_gettargetattr"),
+									   v_params, lengthof(v_params), "");
+
+						LLVMBuildCondBr(b,
+										LLVMBuildICmp(b, LLVMIntNE, v_ret,
+													  LLVMConstNull(LLVMTypeOf(v_ret)), ""),
+										opblocks[i + 1], b_nvalid_check);
+
+						LLVMPositionBuilderAtEnd(b, b_nvalid_check);
+					}
+
+					/*
 					 * Check if all required attributes are available, or
 					 * whether deforming is required.
 					 *

--- a/src/backend/jit/llvm/llvmjit_types.c
+++ b/src/backend/jit/llvm/llvmjit_types.c
@@ -68,6 +68,7 @@ MinimalTupleTableSlot StructMinimalTupleTableSlot;
 TupleDescData StructTupleDescData;
 PlanState	StructPlanState;
 MinimalTupleData StructMinimalTupleData;
+Bitmapset	StructBitmapset;
 
 
 /*
@@ -125,6 +126,7 @@ void	   *referenced_functions[] =
 	strlen,
 	varsize_any,
 	slot_getsomeattrs_int,
+	slot_gettargetattr,
 	slot_getmissingattrs,
 	MakeExpandedObjectReadOnlyInternal,
 	ExecEvalSubscriptingRef,

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -306,12 +306,31 @@ typedef struct AOCSScanDescData
 	 */
 	bool 		partialScan;
 
+	/*
+	 * State for the "shortpass" scan (see gp_aocs_scan_shortpass and
+	 * initscan_with_colinfo()/aocs_getnext() in aocsam.c). When a scan only
+	 * needs to produce row identities (AOCS_PROJ_ANY, e.g. count(*)) and a
+	 * block directory is already available, we skip reading any column data
+	 * and instead derive row counts directly from the anchor column's block
+	 * directory minipages. This struct holds the per-scan cursor over that
+	 * block directory; it is torn down by aocs_sole_rowid_scan_finish(),
+	 * which must be called both when the scan ends (aocs_endscan()) and
+	 * before it is possibly reopened on rescan (initscan_with_colinfo()), so
+	 * that this state never leaks or survives across rescans.
+	 */
 	struct {
+		/* systable scan over pg_aoblkdir, filtered to the anchor column's
+		 * columngroupno; NULL when the shortpass scan is not active */
 		SysScanDesc					scan_blkdir;
+		/* minipage copied out of the current pg_aoblkdir tuple */
 		MinipagePerColumnGroup		curr_minipage;
+		/* entry within curr_minipage currently being consumed */
 		MinipageEntry				*minipage_entry;
+		/* whether curr_minipage holds unconsumed entries */
 		bool						curr_minipage_valid;
+		/* index of the next entry to consume within curr_minipage */
 		int							curr_minipage_entry_idx;
+		/* segno the current minipage/entry belongs to */
 		int							segno;
 	} soleRowIdScan;
 } AOCSScanDescData;

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -305,6 +305,15 @@ typedef struct AOCSScanDescData
 	 * CO table, starting at a certain logical heap block and ending in another.
 	 */
 	bool 		partialScan;
+
+	struct {
+		SysScanDesc					scan_blkdir;
+		MinipagePerColumnGroup		curr_minipage;
+		MinipageEntry				*minipage_entry;
+		bool						curr_minipage_valid;
+		int							curr_minipage_entry_idx;
+		int							segno;
+	} soleRowIdScan;
 } AOCSScanDescData;
 
 typedef AOCSScanDescData *AOCSScanDesc;

--- a/src/include/executor/execExpr.h
+++ b/src/include/executor/execExpr.h
@@ -283,6 +283,8 @@ typedef struct ExprEvalStep
 		{
 			/* attribute number up to which to fetch (inclusive) */
 			int			last_var;
+			/* all required att numbers (if NIL, use `last_var`) */
+			List	   *all_vars;
 			/* will the type of slot be the same for every invocation */
 			bool		fixed;
 			/* tuple descriptor, if known */

--- a/src/include/executor/execExpr.h
+++ b/src/include/executor/execExpr.h
@@ -283,14 +283,14 @@ typedef struct ExprEvalStep
 		{
 			/* attribute number up to which to fetch (inclusive) */
 			int			last_var;
-			/* all required att numbers (if NIL, use `last_var`) */
-			Bitmapset *all_vars;
 			/* will the type of slot be the same for every invocation */
 			bool		fixed;
 			/* tuple descriptor, if known */
 			TupleDesc	known_desc;
 			/* type of slot, can only be relied upon if fixed is set */
 			const TupleTableSlotOps *kind;
+			/* all required att numbers (if NIL, use `last_var`) */
+			Bitmapset *all_vars;
 		}			fetch;
 
 		/* for EEOP_INNER/OUTER/SCAN_[SYS]VAR[_FIRST] */

--- a/src/include/executor/execExpr.h
+++ b/src/include/executor/execExpr.h
@@ -284,7 +284,7 @@ typedef struct ExprEvalStep
 			/* attribute number up to which to fetch (inclusive) */
 			int			last_var;
 			/* all required att numbers (if NIL, use `last_var`) */
-			List	   *all_vars;
+			Bitmapset *all_vars;
 			/* will the type of slot be the same for every invocation */
 			bool		fixed;
 			/* tuple descriptor, if known */

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -253,10 +253,9 @@ typedef struct VirtualTupleTableSlotAOCS
 {
 	VirtualTupleTableSlot base;
 
+	// TODO: can we remove current_scan from tuple table slot?
 	void * current_scan;
-	// TODO: rework to bitmap?
-	// TODO: rework api to get target attrs
-	//bool	*tts_is_valid; /* per-attribute valid flag*/
+
 	Bitmapset *tts_is_valid; /* per-attribute valid flag*/
 } VirtualTupleTableSlotAOCS;
 

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -237,7 +237,7 @@ extern PGDLLIMPORT const TupleTableSlotOps TTSOpsHeapTuple;
 extern PGDLLIMPORT const TupleTableSlotOps TTSOpsMinimalTuple;
 extern PGDLLIMPORT const TupleTableSlotOps TTSOpsBufferHeapTuple;
 
-#define TTS_IS_VIRTUAL(slot) ((slot)->tts_ops == &TTSOpsVirtual || (slot)->tts_ops == &TTSOpsVirtualAOCS)
+#define TTS_IS_VIRTUAL(slot) ((slot)->tts_ops == &TTSOpsVirtual)
 #define TTS_IS_VIRTUAL_AOCS(slot) ((slot)->tts_ops == &TTSOpsVirtualAOCS)
 #define TTS_IS_HEAPTUPLE(slot) ((slot)->tts_ops == &TTSOpsHeapTuple)
 #define TTS_IS_MINIMALTUPLE(slot) ((slot)->tts_ops == &TTSOpsMinimalTuple)

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -214,6 +214,12 @@ struct TupleTableSlotOps
 	 * consumed by the slot.
 	 */
 	MinimalTuple (*copy_minimal_tuple) (TupleTableSlot *slot);
+
+	/*
+	 * Fill up target attnum entry of tts_values and tts_isnull arrays with
+	 * values from the tuple contained in the slot.
+	 */
+	void		(*gettargetattr) (TupleTableSlot *slot, int attnum);
 };
 
 /*
@@ -227,6 +233,7 @@ extern PGDLLIMPORT const TupleTableSlotOps TTSOpsMinimalTuple;
 extern PGDLLIMPORT const TupleTableSlotOps TTSOpsBufferHeapTuple;
 
 #define TTS_IS_VIRTUAL(slot) ((slot)->tts_ops == &TTSOpsVirtual || (slot)->tts_ops == &TTSOpsVirtualAOCS)
+#define TTS_IS_VIRTUAL_AOCS(slot) ((slot)->tts_ops == &TTSOpsVirtualAOCS)
 #define TTS_IS_HEAPTUPLE(slot) ((slot)->tts_ops == &TTSOpsHeapTuple)
 #define TTS_IS_MINIMALTUPLE(slot) ((slot)->tts_ops == &TTSOpsMinimalTuple)
 #define TTS_IS_BUFFERTUPLE(slot) ((slot)->tts_ops == &TTSOpsBufferHeapTuple)
@@ -247,6 +254,7 @@ typedef struct VirtualTupleTableSlotAOCS
 	VirtualTupleTableSlot base;
 
 	void * current_scan;
+	bool	*tts_is_valid; /* per-attribute valid flag*/
 } VirtualTupleTableSlotAOCS;
 
 typedef struct HeapTupleTableSlot
@@ -336,6 +344,7 @@ extern Datum ExecFetchSlotHeapTupleDatum(TupleTableSlot *slot);
 extern void slot_getmissingattrs(TupleTableSlot *slot, int startAttNum,
 								 int lastAttNum);
 extern void slot_getsomeattrs_int(TupleTableSlot *slot, int attnum);
+extern bool slot_gettargetattr_int(TupleTableSlot *slot, int attnum);
 
 extern MemTuple appendonly_form_memtuple(TupleTableSlot *slot, MemTupleBinding *mt_bind);
 extern void appendonly_free_memtuple(MemTuple tuple);
@@ -366,6 +375,19 @@ slot_getallattrs(TupleTableSlot *slot)
 	slot_getsomeattrs(slot, slot->tts_tupleDescriptor->natts);
 }
 
+
+/*
+ * This function forces the specific entry of the slot's Datum/isnull arrays to be
+ * valid.
+ */
+static inline bool
+slot_gettargetattr(TupleTableSlot *slot, int attnum)
+{
+	/* if somebody has already called slot_getsomeattrs, just return */
+	if (slot->tts_nvalid >= attnum)
+		return true;
+	return slot_gettargetattr_int(slot, attnum);
+}
 
 /*
  * slot_attisnull

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -258,10 +258,8 @@ typedef struct VirtualTupleTableSlotAOCS
 {
 	VirtualTupleTableSlot base;
 
-	// TODO: can we remove current_scan from tuple table slot?
-	void * current_scan;
-
-	Bitmapset *tts_is_valid; /* per-attribute valid flag*/
+	void * current_scan;			 /* scan for this tuple */
+	Bitmapset *tts_is_valid;		 /* per-attribute valid flag */
 } VirtualTupleTableSlotAOCS;
 
 typedef struct HeapTupleTableSlot

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -216,10 +216,15 @@ struct TupleTableSlotOps
 	MinimalTuple (*copy_minimal_tuple) (TupleTableSlot *slot);
 
 	/*
-	 * Fill up target attnum entry of tts_values and tts_isnull arrays with
+	 * Fill up target entries of tts_values and tts_isnull arrays with
 	 * values from the tuple contained in the slot.
 	 */
 	bool		(*gettargetattr) (TupleTableSlot *slot, Bitmapset *attrs);
+
+	/*
+	 * Check if value for attnum in tts_values and tts_isnull arrays is valid.
+	 */
+	bool		(*is_attr_valid) (TupleTableSlot *slot, int attnum);
 };
 
 /*
@@ -346,7 +351,6 @@ extern Datum ExecFetchSlotHeapTupleDatum(TupleTableSlot *slot);
 extern void slot_getmissingattrs(TupleTableSlot *slot, int startAttNum,
 								 int lastAttNum);
 extern void slot_getsomeattrs_int(TupleTableSlot *slot, int attnum);
-extern bool slot_gettargetattr_int(TupleTableSlot *slot, Bitmapset *attrs);
 
 extern MemTuple appendonly_form_memtuple(TupleTableSlot *slot, MemTupleBinding *mt_bind);
 extern void appendonly_free_memtuple(MemTuple tuple);
@@ -377,7 +381,6 @@ slot_getallattrs(TupleTableSlot *slot)
 	slot_getsomeattrs(slot, slot->tts_tupleDescriptor->natts);
 }
 
-
 /*
  * This function forces the specific entry of the slot's Datum/isnull arrays to be
  * valid.
@@ -385,7 +388,25 @@ slot_getallattrs(TupleTableSlot *slot)
 static inline bool
 slot_gettargetattr(TupleTableSlot *slot, Bitmapset *attrs)
 {
-	return slot_gettargetattr_int(slot, attrs);
+	if (NULL == slot->tts_ops->gettargetattr)
+		return false;
+
+	return slot->tts_ops->gettargetattr(slot, attrs);
+}
+
+/*
+ * This function checks if Datum/isnull array value for attnum is valid.
+ */
+static inline bool
+slot_is_attr_valid(TupleTableSlot *slot, int attnum)
+{
+	if (slot->tts_nvalid > attnum)
+		return true;
+
+	if (slot->tts_ops->is_attr_valid)
+		return slot->tts_ops->is_attr_valid(slot, attnum);
+
+	return false;
 }
 
 /*

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -349,6 +349,7 @@ extern Datum ExecFetchSlotHeapTupleDatum(TupleTableSlot *slot);
 extern void slot_getmissingattrs(TupleTableSlot *slot, int startAttNum,
 								 int lastAttNum);
 extern void slot_getsomeattrs_int(TupleTableSlot *slot, int attnum);
+extern bool slot_gettargetattr(TupleTableSlot *slot, Bitmapset *attrs);
 
 extern MemTuple appendonly_form_memtuple(TupleTableSlot *slot, MemTupleBinding *mt_bind);
 extern void appendonly_free_memtuple(MemTuple tuple);
@@ -377,19 +378,6 @@ static inline void
 slot_getallattrs(TupleTableSlot *slot)
 {
 	slot_getsomeattrs(slot, slot->tts_tupleDescriptor->natts);
-}
-
-/*
- * This function forces the specific entry of the slot's Datum/isnull arrays to be
- * valid.
- */
-static inline bool
-slot_gettargetattr(TupleTableSlot *slot, Bitmapset *attrs)
-{
-	if (NULL == slot->tts_ops->gettargetattr)
-		return false;
-
-	return slot->tts_ops->gettargetattr(slot, attrs);
 }
 
 /*

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -219,7 +219,7 @@ struct TupleTableSlotOps
 	 * Fill up target attnum entry of tts_values and tts_isnull arrays with
 	 * values from the tuple contained in the slot.
 	 */
-	void		(*gettargetattr) (TupleTableSlot *slot, int attnum);
+	bool		(*gettargetattr) (TupleTableSlot *slot, Bitmapset *attrs);
 };
 
 /*
@@ -254,7 +254,10 @@ typedef struct VirtualTupleTableSlotAOCS
 	VirtualTupleTableSlot base;
 
 	void * current_scan;
-	bool	*tts_is_valid; /* per-attribute valid flag*/
+	// TODO: rework to bitmap?
+	// TODO: rework api to get target attrs
+	//bool	*tts_is_valid; /* per-attribute valid flag*/
+	Bitmapset *tts_is_valid; /* per-attribute valid flag*/
 } VirtualTupleTableSlotAOCS;
 
 typedef struct HeapTupleTableSlot
@@ -344,7 +347,7 @@ extern Datum ExecFetchSlotHeapTupleDatum(TupleTableSlot *slot);
 extern void slot_getmissingattrs(TupleTableSlot *slot, int startAttNum,
 								 int lastAttNum);
 extern void slot_getsomeattrs_int(TupleTableSlot *slot, int attnum);
-extern bool slot_gettargetattr_int(TupleTableSlot *slot, int attnum);
+extern bool slot_gettargetattr_int(TupleTableSlot *slot, Bitmapset *attrs);
 
 extern MemTuple appendonly_form_memtuple(TupleTableSlot *slot, MemTupleBinding *mt_bind);
 extern void appendonly_free_memtuple(MemTuple tuple);
@@ -381,12 +384,9 @@ slot_getallattrs(TupleTableSlot *slot)
  * valid.
  */
 static inline bool
-slot_gettargetattr(TupleTableSlot *slot, int attnum)
+slot_gettargetattr(TupleTableSlot *slot, Bitmapset *attrs)
 {
-	/* if somebody has already called slot_getsomeattrs, just return */
-	if (slot->tts_nvalid >= attnum)
-		return true;
-	return slot_gettargetattr_int(slot, attnum);
+	return slot_gettargetattr_int(slot, attrs);
 }
 
 /*

--- a/src/include/jit/llvmjit.h
+++ b/src/include/jit/llvmjit.h
@@ -94,6 +94,7 @@ extern LLVMTypeRef StructExprState;
 extern LLVMTypeRef StructAggState;
 extern LLVMTypeRef StructAggStatePerTransData;
 extern LLVMTypeRef StructAggStatePerGroupData;
+extern LLVMTypeRef StructBitmapset;
 
 extern LLVMValueRef AttributeTemplate;
 extern LLVMValueRef ExecEvalSubroutineTemplate;


### PR DESCRIPTION
Adds a per-attribute column-fetch path for AOCS table scans

Summary 

Adds a lazy, per-attribute column-fetch path for AOCO/AOCS table scans. 
Previously, scanning an append-only column-oriented table via the generic 
virtual-slot machinery deformed/read every projected column eagerly. This 
introduces a dedicated slot type, TTSOpsVirtualAOCS, that fetches individual 
columns on demand — driven by exactly the attribute set a given expression 
actually needs — and wires that capability through both the plain interpreter 
and the LLVM JIT expression compiler. 

Motivation 

AOCS storage is already column-oriented on disk; the executor was throwing that 
advantage away by forcing a contiguous "deform everything up to the highest 
referenced attribute" model (tts_nvalid-prefix convention) onto it. For wide 
tables with predicates/projections touching only a few columns, this meant 
reading and decoding columns that were never used. 

Key changes 

New generic slot API (tuptable.h) - Two new optional TupleTableSlotOps 
callbacks: gettargetattr(slot, Bitmapset *attrs) and is_attr_valid(slot, 
attnum). Both are NULL for every existing slot type 
(Heap/Minimal/BufferHeap/Virtual) — purely additive, no behavior change 
outside AOCS. - slot_is_attr_valid() keeps the cheap tts_nvalid-prefix check as 
a fast path before consulting the callback; slot_gettargetattr() is a real 
out-of-line extern (not static inline) so it can be called by symbol name from 
JIT-generated code. 

AOCS lazy virtual slot (execTuples.c, cdbaocsam.h) - TTSOpsVirtualAOCS 
implementation: per-attribute fetch via datumstreamread_*/block-directory 
lookups, validity tracked in a Bitmapset (tts_is_valid) rather than a single 
high-water-mark counter, since the anchor/fetched columns are not necessarily a 
contiguous prefix. - Shared tts_virtual_aocs_fetch_attr() helper (always-inline) 
deduplicates the fetch body previously duplicated between gettargetattr and 
getsomeattrs. - aocsam.c/aocsam_handler.c: tts_nvalid explicitly reset to 0 
after ExecStoreVirtualTuple() (except for AOCS_PROJ_ANY, e.g. count(*)) so later 
attribute access is forced through the lazy-fetch path instead of trusting a 
stale full-row-valid assumption. - New "shortpass" scan mode (soleRowIdScan in 
AOCSScanDescData): when a scan only needs row identity (AOCS_PROJ_ANY) and a 
block directory is available, row counts are derived directly from the anchor 
column's block-directory minipages, skipping column data entirely. - 
aocs_getnext() reworked to remove static/global scan state. - ExecClearTuple() 
calls added at loop boundaries in aocs_compaction.c and aocsam_handler.c 
(relation clustering) to prevent a lazy AOCS slot from carrying stale 
per-attribute validity across tuples. 