### PR TITLE
GG-531: Fixup pg_dump array type name creation

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -12709,7 +12709,8 @@ truncate_array_type_name(char *typeName, int encoding, int limit)
 	int 	byte_len = 0;
 	int		char_len = 0;
 
-	while(byte_len < limit) {
+	while(byte_len < limit)
+	{
 		char_len = PQmblen(typeName + byte_len, encoding);
 		/* Non-valid encoding or broken string */
 		Assert(char_len > 0);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -96,13 +96,13 @@ typedef struct
 	int			objsubid;		/* subobject (table column #) */
 } SecLabelItem;
 
-typedef struct TypeNamesCache {
+typedef struct TypeNamesList {
 	Oid 	schema_oid;
 	char  **names;
 	int 	count;
 	int 	capacity;
-	struct 	TypeNamesCache *next;
-} TypeNamesCache;
+	struct 	TypeNamesList *next;
+} TypeNamesList;
 
 typedef enum OidOptions
 {
@@ -12715,15 +12715,15 @@ format_function_signature(Archive *fout, const FuncInfo *finfo, bool honor_quote
  * 
  * Analogous to makeArrayTypeName() from pg_type.c, but does not use
  * backend functions.
- * Also manages its own cache of assigned names, which lives till
+ * Also manages its own list of assigned names, which lives till
  * the end of pg_dump.
  */
 static char *
 make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 {
-	static TypeNamesCache *type_names_cache = NULL;
-	TypeNamesCache *cache = NULL;
-	TypeNamesCache *prev = NULL;
+	static TypeNamesList *type_names_list = NULL;
+	TypeNamesList *list = NULL;
+	TypeNamesList *prev = NULL;
 	char 		   *arr;
 	int 			namelen = strlen(typeName);
 	int 			i;
@@ -12737,14 +12737,14 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 	if (!arr)
 		fatal("out of memory");
 
-	/* Search for schema's cache */
-	cache = type_names_cache;
-	while (cache)
+	/* Search for schema's list */
+	list = type_names_list;
+	while (list)
 	{
-		if (cache->schema_oid == typeNamespace)
+		if (list->schema_oid == typeNamespace)
 			break;
-		prev = cache;
-		cache = cache->next;
+		prev = list;
+		list = list->next;
 	}
 
 	/* Try to find a unique name */
@@ -12772,9 +12772,9 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 
 		/* Check if dump already assigned such name for this schema */
 		is_assigned = false;
-		for (j = 0; cache && j < cache->count; j++)
+		for (j = 0; list && j < list->count; j++)
 		{
-			if (strcmp(cache->names[j], arr) == 0)
+			if (strcmp(list->names[j], arr) == 0)
 			{
 				is_assigned = true;
 				break;
@@ -12789,37 +12789,37 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 	if (i >= NAMEDATALEN - 1)
 		fatal("could not form array type name for type \"%s\"", typeName);
 
-	/* If no cache found for this schema, create one */
-	if (!cache)
+	/* If no list found for this schema, create one */
+	if (!list)
 	{
-		cache = (TypeNamesCache *) pg_malloc0(sizeof(TypeNamesCache));
-		if (!cache)
+		list = (TypeNamesList *) pg_malloc0(sizeof(TypeNamesList));
+		if (!list)
 			fatal("out of memory");
-		cache->schema_oid = typeNamespace;
-		cache->capacity = 16;
-		cache->count = 0;
-		cache->names = (char **) pg_malloc(cache->capacity * sizeof(char *));
-		if (!cache->names)
+		list->schema_oid = typeNamespace;
+		list->capacity = 16;
+		list->count = 0;
+		list->names = (char **) pg_malloc(list->capacity * sizeof(char *));
+		if (!list->names)
 			fatal("out of memory");
-		cache->next = NULL;
+		list->next = NULL;
 
 		/* Add to linked list */
 		if (prev)
-			prev->next = cache;
+			prev->next = list;
 		else
-			type_names_cache = cache;
+			type_names_list = list;
 	}
 
-	if (cache->count == cache->capacity)
+	if (list->count == list->capacity)
 	{
-		cache->capacity = cache->capacity * 2;
-		cache->names = (char **) pg_realloc(cache->names,
-											cache->capacity * sizeof(char *));
-		if (!cache->names)
+		list->capacity = list->capacity * 2;
+		list->names = (char **) pg_realloc(list->names,
+											list->capacity * sizeof(char *));
+		if (!list->names)
 			fatal("out of memory");
 	}
-	cache->names[cache->count] = arr;
-	cache->count++;
+	list->names[list->count] = arr;
+	list->count++;
 
 	return arr;
 }

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -301,7 +301,7 @@ static char *format_function_arguments(const FuncInfo *finfo, const char *funcar
 									   bool is_agg);
 static char *format_function_signature(Archive *fout,
 									   const FuncInfo *finfo, bool honor_quotes);
-static void truncate_array_type_name(char *typeName, int encoding);
+static void truncate_array_type_name(char *typeName, int encoding, int limit);
 static char *make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout);
 static char *convertRegProcReference(const char *proc);
 static char *getFormattedOperatorName(const char *oproid);
@@ -12711,16 +12711,16 @@ format_function_signature(Archive *fout, const FuncInfo *finfo, bool honor_quote
 }
 
 static void
-truncate_array_type_name(char *typeName, int encoding)
+truncate_array_type_name(char *typeName, int encoding, int limit)
 {
 	int 	byte_len = 0;
 	int		char_len = 0;
 
-	while(byte_len < NAMEDATALEN - 1) {
+	while(byte_len < limit) {
 		char_len = PQmblen(typeName + byte_len, encoding);
 		/* Non-valid encoding or broken string */
 		Assert(char_len > 0);
-		if (byte_len + char_len > NAMEDATALEN - 1)
+		if (byte_len + char_len > limit)
 			break;
 		byte_len += char_len;
 	}
@@ -12744,16 +12744,13 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 	TypeNamesList  *prev = NULL;
 	char		   *arr;
 	int				namelen = strlen(typeName);
-	int				i;
-	int				j;
+	int				i, j;
 	PGresult	   *res;
 	PQExpBuffer		query;
 	bool			is_dup;
 	bool			is_assigned;
 
 	arr = (char *) pg_malloc(NAMEDATALEN);
-	if (!arr)
-		fatal("out of memory");
 
 	/* Search for schema's list */
 	list = type_names_list;
@@ -12781,7 +12778,7 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 			 * inside pg_upgrade (with --binary-upgrade), which uses default
 			 * database encoding.
 			 */
-			truncate_array_type_name(arr, fout->encoding);
+			truncate_array_type_name(arr, fout->encoding, NAMEDATALEN - 1);
 		}
 
 		/* Check existence in pg_type */
@@ -12821,14 +12818,10 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 	if (!list)
 	{
 		list = (TypeNamesList *) pg_malloc0(sizeof(TypeNamesList));
-		if (!list)
-			fatal("out of memory");
 		list->schema_oid = typeNamespace;
 		list->capacity = 16;
 		list->count = 0;
 		list->names = (char **) pg_malloc(list->capacity * sizeof(char *));
-		if (!list->names)
-			fatal("out of memory");
 		list->next = NULL;
 
 		/* Add to linked list */
@@ -12843,8 +12836,6 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 		list->capacity = list->capacity * 2;
 		list->names = (char **) pg_realloc(list->names,
 											list->capacity * sizeof(char *));
-		if (!list->names)
-			fatal("out of memory");
 	}
 	list->names[list->count] = arr;
 	list->count++;

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -12769,7 +12769,8 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 		arr[i - 1] = '_';
 		if (i + namelen < NAMEDATALEN)
 			strcpy(arr + i, typeName);
-		else {
+		else 
+		{
 			memcpy(arr + i, typeName, NAMEDATALEN - i);
 			/*
 			 * Be aware, that if archive's encoding is passed with --encoding

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -96,14 +96,6 @@ typedef struct
 	int			objsubid;		/* subobject (table column #) */
 } SecLabelItem;
 
-typedef struct TypeNamesList {
-	Oid 	schema_oid;
-	char  **names;
-	int 	count;
-	int 	capacity;
-	struct 	TypeNamesList *next;
-} TypeNamesList;
-
 typedef enum OidOptions
 {
 	zeroAsOpaque = 1,
@@ -4942,6 +4934,7 @@ binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 						  "'%u'::pg_catalog.oid, $_GPDB_$%s$_GPDB_$::text);\n\n",
 						  pg_type_array_oid, pg_type_array_ns_oid,
 						  pg_type_array_name);
+		pg_free(pg_type_array_name);
 	}
 
 	destroyPQExpBuffer(upgrade_query);
@@ -12734,32 +12727,34 @@ truncate_array_type_name(char *typeName, int encoding, int limit)
  * Analogous to makeArrayTypeName() from pg_type.c, but does not use
  * backend functions.
  * Also manages its own list of assigned names, which lives till
- * the end of pg_dump.
+ * the end of current schema dump.
  */
 static char *
 make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 {
-	static TypeNamesList *type_names_list = NULL;
-	TypeNamesList  *list = NULL;
-	TypeNamesList  *prev = NULL;
-	char		   *arr;
-	int				namelen = strlen(typeName);
-	int				i, j;
-	PGresult	   *res;
-	PQExpBuffer		query;
-	bool			is_dup;
-	bool			is_assigned;
+	static SimpleStringList	   *type_names = NULL;
+	static Oid 					names_schema_oid = InvalidOid;
+	SimpleStringListCell	   *next;
+	SimpleStringListCell	   *cell;
+	char					   *arr;
+	int							namelen = strlen(typeName);
+	int							i;
+	PGresult				   *res;
+	PQExpBuffer					query;
+	bool						is_dup, is_assigned;
 
 	arr = (char *) pg_malloc(NAMEDATALEN);
 
-	/* Search for schema's list */
-	list = type_names_list;
-	while (list)
+	/* We have encountered new schema, have to clear the old list */
+	if (type_names && names_schema_oid != typeNamespace)
 	{
-		if (list->schema_oid == typeNamespace)
-			break;
-		prev = list;
-		list = list->next;
+		names_schema_oid = typeNamespace;
+		for(cell = type_names->head; cell; cell = next)
+		{
+			next = cell->next;
+			pg_free(cell);
+		}
+		type_names = NULL;
 	}
 
 	/* Try to find a unique name */
@@ -12797,13 +12792,14 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 
 		/* Check if dump already assigned such name for this schema */
 		is_assigned = false;
-		for (j = 0; list && j < list->count; j++)
+		if (type_names)
 		{
-			if (strcmp(list->names[j], arr) == 0)
-			{
-				is_assigned = true;
-				break;
-			}
+			for (cell = type_names->head; cell; cell = cell->next)
+				if (strcmp(cell->val, arr) == 0)
+				{
+					is_assigned = true;
+					break;
+				}
 		}
 		if (is_assigned)
 			continue;
@@ -12814,31 +12810,22 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 	if (i >= NAMEDATALEN - 1)
 		fatal("could not form array type name for type \"%s\"", typeName);
 
+	/* Store the name */
+	cell = (SimpleStringListCell *) pg_malloc0(sizeof(SimpleStringListCell) + 
+										   sizeof(char) * (strlen(arr) + 1));
+	strcpy(cell->val, arr);
+
 	/* If no list found for this schema, create one */
-	if (!list)
+	if (!type_names)
 	{
-		list = (TypeNamesList *) pg_malloc0(sizeof(TypeNamesList));
-		list->schema_oid = typeNamespace;
-		list->capacity = 16;
-		list->count = 0;
-		list->names = (char **) pg_malloc(list->capacity * sizeof(char *));
-		list->next = NULL;
-
-		/* Add to linked list */
-		if (prev)
-			prev->next = list;
-		else
-			type_names_list = list;
+		names_schema_oid = typeNamespace;
+		type_names = (SimpleStringList *) pg_malloc0(sizeof(SimpleStringList));
+		type_names->head = cell;
 	}
+	else
+		type_names->tail->next = cell;
 
-	if (list->count == list->capacity)
-	{
-		list->capacity = list->capacity * 2;
-		list->names = (char **) pg_realloc(list->names,
-											list->capacity * sizeof(char *));
-	}
-	list->names[list->count] = arr;
-	list->count++;
+	type_names->tail = cell;
 
 	return arr;
 }

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -293,6 +293,7 @@ static char *format_function_arguments(const FuncInfo *finfo, const char *funcar
 									   bool is_agg);
 static char *format_function_signature(Archive *fout,
 									   const FuncInfo *finfo, bool honor_quotes);
+static char *make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout);
 static char *convertRegProcReference(const char *proc);
 static char *getFormattedOperatorName(const char *oproid);
 static char *convertTSFunction(Archive *fout, Oid funcOid);
@@ -4917,7 +4918,9 @@ binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 
 		pg_type_array_oid = next_possible_free_oid;
 		pg_type_array_ns_oid = tyinfo->dobj.namespace->dobj.catId.oid;
-		pg_type_array_name = psprintf("_%s", tyinfo->dobj.name);
+		pg_type_array_name = make_array_type_name(tyinfo->dobj.name, 
+													  tyinfo->dobj.namespace->dobj.catId.oid,
+													  fout);
 	}
 
 	if (OidIsValid(pg_type_array_oid))
@@ -12651,6 +12654,57 @@ format_function_signature(Archive *fout, const FuncInfo *finfo, bool honor_quote
 	return fn.data;
 }
 
+/*
+ * make_array_type_name
+ * 		given a base type name, make an array type name for it
+ * 
+ * 	Analogous to makeArrayTypeName() from pg_type.c, but does not use
+ * 	backend functions.
+ */
+static char *
+make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
+{
+    char *arr;
+    int namelen = strlen(typeName);
+    PGresult *res;
+    PQExpBuffer query = createPQExpBuffer();
+	bool is_dup;
+    int i;
+
+    arr = (char *) pg_malloc(NAMEDATALEN);
+
+    for (i = 1; i < NAMEDATALEN - 1; i++)
+    {
+        arr[i - 1] = '_';
+        if (i + namelen < NAMEDATALEN)
+            strcpy(arr + i, typeName);
+        else
+        {
+            memcpy(arr + i, typeName, NAMEDATALEN - i - 1);
+            arr[NAMEDATALEN - 1] = '\0';
+        }
+
+        /* Check if this name already exists in the target namespace */
+        printfPQExpBuffer(query,
+                          "SELECT EXISTS(SELECT 1 "
+                          "FROM pg_catalog.pg_type "
+                          "WHERE typname = '%s' AND typnamespace = '%u'::pg_catalog.oid);",
+                          arr, typeNamespace);
+        res = ExecuteSqlQueryForSingleRow(fout, query->data);
+        is_dup = (PQgetvalue(res, 0, 0)[0] == 't');
+        PQclear(res);
+
+        if (!is_dup)
+            break;
+    }
+
+    destroyPQExpBuffer(query);
+
+    if (i >= NAMEDATALEN - 1)
+        fatal("could not form array type name for type \"%s\"", typeName);
+
+    return arr;
+}
 
 /*
  * dumpFunc:

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -301,6 +301,7 @@ static char *format_function_arguments(const FuncInfo *finfo, const char *funcar
 									   bool is_agg);
 static char *format_function_signature(Archive *fout,
 									   const FuncInfo *finfo, bool honor_quotes);
+static void truncate_array_type_name(char *typeName, int encoding);
 static char *make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout);
 static char *convertRegProcReference(const char *proc);
 static char *getFormattedOperatorName(const char *oproid);
@@ -12709,6 +12710,23 @@ format_function_signature(Archive *fout, const FuncInfo *finfo, bool honor_quote
 	return fn.data;
 }
 
+static void
+truncate_array_type_name(char *typeName, int encoding)
+{
+	int 	byte_len = 0;
+	int		char_len = 0;
+
+	while(byte_len < NAMEDATALEN - 1) {
+		char_len = PQmblen(typeName + byte_len, encoding);
+		/* Non-valid encoding or broken string */
+		Assert(char_len > 0);
+		if (byte_len + char_len > NAMEDATALEN - 1)
+			break;
+		byte_len += char_len;
+	}
+	typeName[byte_len] = '\0';
+}
+
 /*
  * make_array_type_name
  * 		given a base type name, make an array type name for it
@@ -12722,16 +12740,16 @@ static char *
 make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 {
 	static TypeNamesList *type_names_list = NULL;
-	TypeNamesList *list = NULL;
-	TypeNamesList *prev = NULL;
-	char 		   *arr;
-	int 			namelen = strlen(typeName);
-	int 			i;
-	int 			j;
-	PGresult 	   *res;
-	PQExpBuffer 	query;
-	bool 			is_dup;
-	bool 			is_assigned;
+	TypeNamesList  *list = NULL;
+	TypeNamesList  *prev = NULL;
+	char		   *arr;
+	int				namelen = strlen(typeName);
+	int				i;
+	int				j;
+	PGresult	   *res;
+	PQExpBuffer		query;
+	bool			is_dup;
+	bool			is_assigned;
 
 	arr = (char *) pg_malloc(NAMEDATALEN);
 	if (!arr)
@@ -12755,7 +12773,7 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 			strcpy(arr + i, typeName);
 		else {
 			memcpy(arr + i, typeName, NAMEDATALEN - i);
-			arr[PQmblen(arr, fout->encoding) - 1] = '\0';
+			truncate_array_type_name(arr, fout->encoding);
 		}
 
 		/* Check existence in pg_type */

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -96,6 +96,14 @@ typedef struct
 	int			objsubid;		/* subobject (table column #) */
 } SecLabelItem;
 
+typedef struct TypeNamesCache {
+	Oid 	schema_oid;
+	char  **names;
+	int 	count;
+	int 	capacity;
+	struct 	TypeNamesCache *next;
+} TypeNamesCache;
+
 typedef enum OidOptions
 {
 	zeroAsOpaque = 1,
@@ -4919,8 +4927,8 @@ binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 		pg_type_array_oid = next_possible_free_oid;
 		pg_type_array_ns_oid = tyinfo->dobj.namespace->dobj.catId.oid;
 		pg_type_array_name = make_array_type_name(tyinfo->dobj.name, 
-													  tyinfo->dobj.namespace->dobj.catId.oid,
-													  fout);
+												  tyinfo->dobj.namespace->dobj.catId.oid,
+												  fout);
 	}
 
 	if (OidIsValid(pg_type_array_oid))
@@ -12705,33 +12713,51 @@ format_function_signature(Archive *fout, const FuncInfo *finfo, bool honor_quote
  * make_array_type_name
  * 		given a base type name, make an array type name for it
  * 
- * 	Analogous to makeArrayTypeName() from pg_type.c, but does not use
- * 	backend functions.
+ * Analogous to makeArrayTypeName() from pg_type.c, but does not use
+ * backend functions.
+ * Also manages its own cache of assigned names, which lives till
+ * the end of pg_dump.
  */
 static char *
 make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 {
-    char *arr;
-    int namelen = strlen(typeName);
-    PGresult *res;
-    PQExpBuffer query = createPQExpBuffer();
-	bool is_dup;
-    int i;
+	static TypeNamesCache *type_names_cache = NULL;
+	TypeNamesCache *cache = NULL;
+	TypeNamesCache *prev = NULL;
+	char 		   *arr;
+	int 			namelen = strlen(typeName);
+	int 			i;
+	int 			j;
+	PGresult 	   *res;
+	PQExpBuffer 	query;
+	bool 			is_dup;
+	bool 			is_assigned;
 
     arr = (char *) pg_malloc(NAMEDATALEN);
+	if (!arr)
+		fatal("out of memory");
 
+	/* Search for schema's cache */
+	cache = type_names_cache;
+	while (cache)
+	{
+		if (cache->schema_oid == typeNamespace)
+			break;
+		prev = cache;
+		cache = cache->next;
+	}
+
+	/* Try to find a unique name */
     for (i = 1; i < NAMEDATALEN - 1; i++)
     {
         arr[i - 1] = '_';
         if (i + namelen < NAMEDATALEN)
             strcpy(arr + i, typeName);
         else
-        {
-            memcpy(arr + i, typeName, NAMEDATALEN - i - 1);
-            arr[NAMEDATALEN - 1] = '\0';
-        }
+			strlcpy(arr + i, typeName, NAMEDATALEN - i);
 
-        /* Check if this name already exists in the target namespace */
+		/* Check existence in pg_type */
+		query = createPQExpBuffer();
         printfPQExpBuffer(query,
                           "SELECT EXISTS(SELECT 1 "
                           "FROM pg_catalog.pg_type "
@@ -12740,15 +12766,60 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
         res = ExecuteSqlQueryForSingleRow(fout, query->data);
         is_dup = (PQgetvalue(res, 0, 0)[0] == 't');
         PQclear(res);
+		destroyPQExpBuffer(query);
+		if (is_dup)
+			continue;
 
-        if (!is_dup)
-            break;
-    }
+		/* Check if dump already assigned such name for this schema */
+		is_assigned = false;
+		for (j = 0; cache && j < cache->count; j++)
+		{
+			if (strcmp(cache->names[j], arr) == 0)
+			{
+				is_assigned = true;
+				break;
+			}
+		}
+		if (is_assigned)
+			continue;
 
-    destroyPQExpBuffer(query);
+		break;
+	}
 
     if (i >= NAMEDATALEN - 1)
         fatal("could not form array type name for type \"%s\"", typeName);
+
+	/* If no cache found for this schema, create one */
+	if (!cache)
+	{
+		cache = (TypeNamesCache *) pg_malloc0(sizeof(TypeNamesCache));
+		if (!cache)
+			fatal("out of memory");
+		cache->schema_oid = typeNamespace;
+		cache->capacity = 16;
+		cache->count = 0;
+		cache->names = (char **) pg_malloc(cache->capacity * sizeof(char *));
+		if (!cache->names)
+			fatal("out of memory");
+		cache->next = NULL;
+
+		/* Add to linked list */
+		if (prev)
+			prev->next = cache;
+		else
+			type_names_cache = cache;
+	}
+
+	if (cache->count == cache->capacity)
+	{
+		cache->capacity = cache->capacity * 2;
+		cache->names = (char **) pg_realloc(cache->names,
+											cache->capacity * sizeof(char *));
+		if (!cache->names)
+			fatal("out of memory");
+	}
+	cache->names[cache->count] = arr;
+	cache->count++;
 
     return arr;
 }

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -12753,8 +12753,10 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 		arr[i - 1] = '_';
 		if (i + namelen < NAMEDATALEN)
 			strcpy(arr + i, typeName);
-		else
-			strlcpy(arr + i, typeName, NAMEDATALEN - i);
+		else {
+			memcpy(arr + i, typeName, NAMEDATALEN - i);
+			arr[PQmblen(arr, fout->encoding) - 1] = '\0';
+		}
 
 		/* Check existence in pg_type */
 		query = createPQExpBuffer();

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -12733,7 +12733,7 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 	bool 			is_dup;
 	bool 			is_assigned;
 
-    arr = (char *) pg_malloc(NAMEDATALEN);
+	arr = (char *) pg_malloc(NAMEDATALEN);
 	if (!arr)
 		fatal("out of memory");
 
@@ -12748,24 +12748,24 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 	}
 
 	/* Try to find a unique name */
-    for (i = 1; i < NAMEDATALEN - 1; i++)
-    {
-        arr[i - 1] = '_';
-        if (i + namelen < NAMEDATALEN)
-            strcpy(arr + i, typeName);
-        else
+	for (i = 1; i < NAMEDATALEN - 1; i++)
+	{
+		arr[i - 1] = '_';
+		if (i + namelen < NAMEDATALEN)
+			strcpy(arr + i, typeName);
+		else
 			strlcpy(arr + i, typeName, NAMEDATALEN - i);
 
 		/* Check existence in pg_type */
 		query = createPQExpBuffer();
-        printfPQExpBuffer(query,
-                          "SELECT EXISTS(SELECT 1 "
-                          "FROM pg_catalog.pg_type "
-                          "WHERE typname = '%s' AND typnamespace = '%u'::pg_catalog.oid);",
-                          arr, typeNamespace);
-        res = ExecuteSqlQueryForSingleRow(fout, query->data);
-        is_dup = (PQgetvalue(res, 0, 0)[0] == 't');
-        PQclear(res);
+		printfPQExpBuffer(query,
+						  "SELECT EXISTS(SELECT 1 "
+						  "FROM pg_catalog.pg_type "
+						  "WHERE typname = '%s' AND typnamespace = '%u'::pg_catalog.oid);",
+						  arr, typeNamespace);
+		res = ExecuteSqlQueryForSingleRow(fout, query->data);
+		is_dup = (PQgetvalue(res, 0, 0)[0] == 't');
+		PQclear(res);
 		destroyPQExpBuffer(query);
 		if (is_dup)
 			continue;
@@ -12786,8 +12786,8 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 		break;
 	}
 
-    if (i >= NAMEDATALEN - 1)
-        fatal("could not form array type name for type \"%s\"", typeName);
+	if (i >= NAMEDATALEN - 1)
+		fatal("could not form array type name for type \"%s\"", typeName);
 
 	/* If no cache found for this schema, create one */
 	if (!cache)
@@ -12821,7 +12821,7 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 	cache->names[cache->count] = arr;
 	cache->count++;
 
-    return arr;
+	return arr;
 }
 
 /*

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -12773,6 +12773,14 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 			strcpy(arr + i, typeName);
 		else {
 			memcpy(arr + i, typeName, NAMEDATALEN - i);
+			/*
+			 * Be aware, that if archive's encoding is passed with --encoding
+			 * and the database has diffrent one - this function can fail.
+			 *
+			 * Yet, it does not matter much as this function is intended to be used
+			 * inside pg_upgrade (with --binary-upgrade), which uses default
+			 * database encoding.
+			 */
 			truncate_array_type_name(arr, fout->encoding);
 		}
 

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -96,6 +96,14 @@ typedef struct
 	int			objsubid;		/* subobject (table column #) */
 } SecLabelItem;
 
+typedef struct TypeNamesList {
+	Oid 	schema_oid;
+	char  **names;
+	int 	count;
+	int 	capacity;
+	struct 	TypeNamesList *next;
+} TypeNamesList;
+
 typedef enum OidOptions
 {
 	zeroAsOpaque = 1,
@@ -4934,7 +4942,6 @@ binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 						  "'%u'::pg_catalog.oid, $_GPDB_$%s$_GPDB_$::text);\n\n",
 						  pg_type_array_oid, pg_type_array_ns_oid,
 						  pg_type_array_name);
-		pg_free(pg_type_array_name);
 	}
 
 	destroyPQExpBuffer(upgrade_query);
@@ -12728,34 +12735,32 @@ truncate_array_type_name(char *typeName, int encoding, int limit)
  * Analogous to makeArrayTypeName() from pg_type.c, but does not use
  * backend functions.
  * Also manages its own list of assigned names, which lives till
- * the end of current schema dump.
+ * the end of pg_dump.
  */
 static char *
 make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 {
-	static SimpleStringList	   *type_names = NULL;
-	static Oid 					names_schema_oid = InvalidOid;
-	SimpleStringListCell	   *next;
-	SimpleStringListCell	   *cell;
-	char					   *arr;
-	int							namelen = strlen(typeName);
-	int							i;
-	PGresult				   *res;
-	PQExpBuffer					query;
-	bool						is_dup, is_assigned;
+	static TypeNamesList *type_names_list = NULL;
+	TypeNamesList  *list = NULL;
+	TypeNamesList  *prev = NULL;
+	char		   *arr;
+	int				namelen = strlen(typeName);
+	int				i, j;
+	PGresult	   *res;
+	PQExpBuffer		query;
+	bool			is_dup;
+	bool			is_assigned;
 
 	arr = (char *) pg_malloc(NAMEDATALEN);
 
-	/* We have encountered new schema, have to clear the old list */
-	if (type_names && names_schema_oid != typeNamespace)
+	/* Search for schema's list */
+	list = type_names_list;
+	while (list)
 	{
-		names_schema_oid = typeNamespace;
-		for(cell = type_names->head; cell; cell = next)
-		{
-			next = cell->next;
-			pg_free(cell);
-		}
-		type_names = NULL;
+		if (list->schema_oid == typeNamespace)
+			break;
+		prev = list;
+		list = list->next;
 	}
 
 	/* Try to find a unique name */
@@ -12793,14 +12798,13 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 
 		/* Check if dump already assigned such name for this schema */
 		is_assigned = false;
-		if (type_names)
+		for (j = 0; list && j < list->count; j++)
 		{
-			for (cell = type_names->head; cell; cell = cell->next)
-				if (strcmp(cell->val, arr) == 0)
-				{
-					is_assigned = true;
-					break;
-				}
+			if (strcmp(list->names[j], arr) == 0)
+			{
+				is_assigned = true;
+				break;
+			}
 		}
 		if (is_assigned)
 			continue;
@@ -12811,22 +12815,31 @@ make_array_type_name(const char *typeName, Oid typeNamespace, Archive *fout)
 	if (i >= NAMEDATALEN - 1)
 		fatal("could not form array type name for type \"%s\"", typeName);
 
-	/* Store the name */
-	cell = (SimpleStringListCell *) pg_malloc0(sizeof(SimpleStringListCell) + 
-										   sizeof(char) * (strlen(arr) + 1));
-	strcpy(cell->val, arr);
-
 	/* If no list found for this schema, create one */
-	if (!type_names)
+	if (!list)
 	{
-		names_schema_oid = typeNamespace;
-		type_names = (SimpleStringList *) pg_malloc0(sizeof(SimpleStringList));
-		type_names->head = cell;
-	}
-	else
-		type_names->tail->next = cell;
+		list = (TypeNamesList *) pg_malloc0(sizeof(TypeNamesList));
+		list->schema_oid = typeNamespace;
+		list->capacity = 16;
+		list->count = 0;
+		list->names = (char **) pg_malloc(list->capacity * sizeof(char *));
+		list->next = NULL;
 
-	type_names->tail = cell;
+		/* Add to linked list */
+		if (prev)
+			prev->next = list;
+		else
+			type_names_list = list;
+	}
+
+	if (list->count == list->capacity)
+	{
+		list->capacity = list->capacity * 2;
+		list->names = (char **) pg_realloc(list->names,
+											list->capacity * sizeof(char *));
+	}
+	list->names[list->count] = arr;
+	list->count++;
 
 	return arr;
 }

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -96,7 +96,8 @@ typedef struct
 	int			objsubid;		/* subobject (table column #) */
 } SecLabelItem;
 
-typedef struct TypeNamesList {
+typedef struct TypeNamesList 
+{
 	Oid 	schema_oid;
 	char  **names;
 	int 	count;


### PR DESCRIPTION
What happened?
Dumping 6.x with forceful array type creation option leads to type names
collision and otherwise impossible type names in 7.x. When trying to restore
from dump, they lead to errors.

Why it happens?
Array type name creation logic inside pg_dump.c is much simpler and not
consistent with the one in pg_type.c.  

How do we fix this?
Let's resolve name collisions like we do in makeArrayTypeName() from pg_type.c,
but without using backend specific code. Also, we need to store names assigned
by the dump.

Performance considerations?
Running a query each time to check collision seems like a major slowdown. HTAB
could be a nice way to speed up things, but it cannot be used in frontend code
because of missing memory contexts code. Comparing current type name against
array of strings with all type names is kind of slow. So, making an assumption
that collisions are pretty rare, running the query 1 or 2 times does not seem
that bad.

Tests?
No auto tests as this is the one of many to fix them. Testing could be done by
manually dumping and looking and resulting type names.

Ticket: GG-531