### PR TITLE
GG-562: Improve Hash Aggregate performance

### DIFF
--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -1163,7 +1163,6 @@ add_second_stage_hash_agg_path(PlannerInfo *root,
 	CdbPathLocus group_locus;
 	bool		needs_redistribute;
 	double		dNumGroups;
-	Size		hashentrysize;
 
 	group_locus = choose_grouping_locus(root,
 										initial_agg_path,
@@ -1181,30 +1180,21 @@ add_second_stage_hash_agg_path(PlannerInfo *root,
 	else
 		dNumGroups = ctx->dNumGroupsTotal;
 
-	/* Would the hash table fit in memory? */
-	hashentrysize = MAXALIGN(initial_agg_path->pathtarget->width) + MAXALIGN(SizeofMinimalTupleHeader);
+	Path *path = cdbpath_create_motion_path(root, initial_agg_path, NIL, false,
+											group_locus);
 
-	if (enable_hashagg_disk ||
-		hashentrysize * dNumGroups < work_mem * 1024L)
-	{
-		Path	   *path;
-
-		path = cdbpath_create_motion_path(root, initial_agg_path, NIL, false,
-										  group_locus);
-
-		path = (Path *) create_agg_path(root,
-										output_rel,
-										path,
-										ctx->target,
-										AGG_HASHED,
-										ctx->hasAggs ? AGGSPLIT_FINAL_DESERIAL : AGGSPLIT_SIMPLE,
-										false, /* streaming */
-										ctx->final_groupClause,
-										ctx->havingQual,
-										ctx->agg_final_costs,
-										dNumGroups);
-		add_path(output_rel, path);
-	}
+	path = (Path *) create_agg_path(root,
+									output_rel,
+									path,
+									ctx->target,
+									AGG_HASHED,
+									ctx->hasAggs ? AGGSPLIT_FINAL_DESERIAL : AGGSPLIT_SIMPLE,
+									false, /* streaming */
+									ctx->final_groupClause,
+									ctx->havingQual,
+									ctx->agg_final_costs,
+									dNumGroups);
+	add_path(output_rel, path);
 
 	/*
 	 * Like in the Group Agg case, if the final result needs to be brough to
@@ -1220,28 +1210,22 @@ add_second_stage_hash_agg_path(PlannerInfo *root,
 		CdbPathLocus singleQE_locus;
 		CdbPathLocus_MakeSingleQE(&singleQE_locus, getgpsegmentCount());
 
-		hashentrysize = MAXALIGN(initial_agg_path->pathtarget->width) + MAXALIGN(SizeofMinimalTupleHeader);
-		if (hashentrysize * ctx->dNumGroupsTotal <= work_mem * 1024L)
-		{
-			Path	   *path;
+		Path *path = cdbpath_create_motion_path(root, initial_agg_path,
+												NIL, false,
+												singleQE_locus);
 
-			path = cdbpath_create_motion_path(root, initial_agg_path,
-											  NIL, false,
-											  singleQE_locus);
-
-			path = (Path *) create_agg_path(root,
-											output_rel,
-											path,
-											ctx->target,
-											AGG_HASHED,
-											ctx->hasAggs ? AGGSPLIT_FINAL_DESERIAL : AGGSPLIT_SIMPLE,
-											false, /* streaming */
-											ctx->final_groupClause,
-											ctx->havingQual,
-											ctx->agg_final_costs,
-											ctx->dNumGroupsTotal);
-			add_path(output_rel, path);
-		}
+		path = (Path *) create_agg_path(root,
+										output_rel,
+										path,
+										ctx->target,
+										AGG_HASHED,
+										ctx->hasAggs ? AGGSPLIT_FINAL_DESERIAL : AGGSPLIT_SIMPLE,
+										false, /* streaming */
+										ctx->final_groupClause,
+										ctx->havingQual,
+										ctx->agg_final_costs,
+										ctx->dNumGroupsTotal);
+		add_path(output_rel, path);
 	}
 }
 

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -434,7 +434,7 @@ static void hashagg_recompile_expressions(AggState *aggstate, bool minslot,
 static long hash_choose_num_buckets(double hashentrysize,
 									long estimated_nbuckets,
 									Size memory);
-static int hash_choose_num_partitions(AggState *aggstate,
+static int hash_choose_num_partitions(Size mem_limit,
 									  double input_groups,
 									  double hashentrysize,
 									  int used_bits,
@@ -1856,30 +1856,23 @@ hashagg_recompile_expressions(AggState *aggstate, bool minslot, bool nullcheck)
  * ngroups limit becomes important when we expect transition values to grow
  * substantially larger than the initial value.
  */
-void
-hash_agg_set_limits(AggState *aggstate, double hashentrysize, double input_groups, int used_bits,
-					Size *mem_limit, uint64 *ngroups_limit,
+Size
+hash_agg_set_limits2(AggState *aggstate, double hashentrysize, double input_groups, int used_bits,
+					Size mem_limit, uint64 *ngroups_limit,
 					int *num_partitions)
 {
+	Assert(mem_limit > 0);
 	int npartitions;
 	Size partition_mem;
-	uint64 strict_memlimit = work_mem;
-
-	if (aggstate)
-	{
-		uint64 operator_mem = PlanStateOperatorMemKB((PlanState *) aggstate);
-		if (operator_mem < strict_memlimit)
-			strict_memlimit = operator_mem;
-	}
 
 	/* if not expected to spill, use all of work_mem */
-	if (input_groups * hashentrysize < strict_memlimit * 1024L)
+	/* streaming is never spill */
+	if ((aggstate && aggstate->streaming) || input_groups * hashentrysize < mem_limit)
 	{
 		if (num_partitions != NULL)
 			*num_partitions = 0;
-		*mem_limit = strict_memlimit * 1024L;
-		*ngroups_limit = *mem_limit / hashentrysize;
-		return;
+		*ngroups_limit = mem_limit / hashentrysize;
+		return mem_limit;
 	}
 
 	/*
@@ -1888,7 +1881,7 @@ hash_agg_set_limits(AggState *aggstate, double hashentrysize, double input_group
 	 * once. Then, subtract that from the memory available for holding hash
 	 * tables.
 	 */
-	npartitions = hash_choose_num_partitions(aggstate,
+	npartitions = hash_choose_num_partitions(mem_limit,
 											 input_groups,
 											 hashentrysize,
 											 used_bits,
@@ -1905,15 +1898,39 @@ hash_agg_set_limits(AggState *aggstate, double hashentrysize, double input_group
 	 * minimum number of partitions, so we aren't going to dramatically exceed
 	 * work mem anyway.
 	 */
-	if (strict_memlimit * 1024L > 4 * partition_mem)
-		*mem_limit = strict_memlimit * 1024L - partition_mem;
+	Size adjusted_mem_limit;
+	if (mem_limit > 4 * partition_mem)
+		adjusted_mem_limit = mem_limit - partition_mem;
 	else
-		*mem_limit = strict_memlimit * 1024L * 0.75;
+		adjusted_mem_limit = mem_limit * 0.75;
 
-	if (*mem_limit > hashentrysize)
-		*ngroups_limit = *mem_limit / hashentrysize;
+	if (adjusted_mem_limit > hashentrysize)
+		*ngroups_limit = adjusted_mem_limit / hashentrysize;
 	else
 		*ngroups_limit = 1;
+
+	return adjusted_mem_limit;
+}
+
+/*
+ * Use hash_agg_set_limits2 instead. Left for ABI compatibility.
+ */
+void
+hash_agg_set_limits(AggState *aggstate, double hashentrysize, double input_groups, int used_bits,
+					Size *mem_limit, uint64 *ngroups_limit,
+					int *num_partitions)
+{
+	uint64 strict_memlimit = work_mem;
+
+	if (aggstate)
+	{
+		uint64 operator_mem = PlanStateOperatorMemKB((PlanState *) aggstate);
+		if (operator_mem < strict_memlimit)
+			strict_memlimit = operator_mem;
+	}
+	*mem_limit = hash_agg_set_limits2(aggstate, hashentrysize, input_groups,
+									  used_bits, strict_memlimit * 1024,
+									  ngroups_limit, num_partitions);
 }
 
 /*
@@ -2128,34 +2145,27 @@ hash_choose_num_buckets(double hashentrysize, long ngroups, Size memory)
  * *log2_npartitions to the log2() of the number of partitions.
  */
 static int
-hash_choose_num_partitions(AggState *aggstate, double input_groups, double hashentrysize,
+hash_choose_num_partitions(Size mem_limit, double input_groups, double hashentrysize,
 						   int used_bits, int *log2_npartitions)
 {
+	Assert(mem_limit > 0);
 	Size	mem_wanted;
 	int		partition_limit;
 	int		npartitions;
 	int		partition_bits;
-	uint64	strict_memlimit = work_mem;
-
-	if (aggstate)
-	{
-		uint64 operator_mem = PlanStateOperatorMemKB((PlanState *) aggstate);
-		if (operator_mem < strict_memlimit)
-			strict_memlimit = operator_mem;
-	}
 
 	/*
 	 * Avoid creating so many partitions that the memory requirements of the
 	 * open partition files are greater than 1/4 of work_mem.
 	 */
 	partition_limit =
-		(strict_memlimit * 1024L * 0.25 - HASHAGG_READ_BUFFER_SIZE) /
+		(mem_limit * 0.25 - HASHAGG_READ_BUFFER_SIZE) /
 		HASHAGG_WRITE_BUFFER_SIZE;
 
 	mem_wanted = HASHAGG_PARTITION_FACTOR * input_groups * hashentrysize;
 
 	/* make enough partitions so that each one is likely to fit in memory */
-	npartitions = 1 + (mem_wanted / (strict_memlimit * 1024L));
+	npartitions = 1 + (mem_wanted / mem_limit);
 
 	if (npartitions > partition_limit)
 		npartitions = partition_limit;
@@ -2787,8 +2797,8 @@ agg_refill_hash_table(AggState *aggstate)
 	batch = linitial(aggstate->hash_batches);
 	aggstate->hash_batches = list_delete_first(aggstate->hash_batches);
 
-	hash_agg_set_limits(aggstate, aggstate->hashentrysize, batch->input_card,
-						batch->used_bits, &aggstate->hash_mem_limit,
+	aggstate->hash_mem_limit = hash_agg_set_limits2(aggstate, aggstate->hashentrysize, batch->input_card,
+						batch->used_bits, PlanStateOperatorMemKB((PlanState *) aggstate) * 1024,
 						&aggstate->hash_ngroups_limit, NULL);
 
 	/*
@@ -3194,7 +3204,7 @@ hashagg_spill_init(AggState *aggstate, HashAggSpill *spill, HashTapeInfo *tapein
 	int		npartitions;
 	int     partition_bits;
 
-	npartitions = hash_choose_num_partitions(aggstate,
+	npartitions = hash_choose_num_partitions(aggstate->hash_mem_limit,
 		input_groups, hashentrysize, used_bits, &partition_bits);
 
 	spill->partitions = palloc0(sizeof(int) * npartitions);
@@ -3940,10 +3950,11 @@ ExecInitAgg(Agg *node, EState *estate, int eflags)
 		for (i = 0; i < aggstate->num_hashes; i++)
 			totalGroups += aggstate->perhash[i].aggnode->numGroups;
 
-		hash_agg_set_limits(aggstate, aggstate->hashentrysize, totalGroups, 0,
-							&aggstate->hash_mem_limit,
-							&aggstate->hash_ngroups_limit,
-							&aggstate->hash_planned_partitions);
+		aggstate->hash_mem_limit =
+				hash_agg_set_limits2(aggstate, aggstate->hashentrysize, totalGroups, 0,
+									PlanStateOperatorMemKB((PlanState *) aggstate) * 1024,
+									&aggstate->hash_ngroups_limit,
+									&aggstate->hash_planned_partitions);
 		find_hash_columns(aggstate);
 
 		/* Skip massive memory allocation if we are just doing EXPLAIN */

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -2539,6 +2539,7 @@ cost_agg(Path *path, PlannerInfo *root,
 		double	pages;
 		double	pages_written = 0.0;
 		double	pages_read	  = 0.0;
+		double	spill_cost;
 		double	hashentrysize;
 		double	nbatches;
 		Size	mem_limit;
@@ -2576,9 +2577,21 @@ cost_agg(Path *path, PlannerInfo *root,
 		pages = relation_byte_size(input_tuples, input_width) / BLCKSZ;
 		pages_written = pages_read = pages * depth;
 
+		/*
+		 * HashAgg has somewhat worse IO behavior than Sort on typical
+		 * hardware/OS combinations. Account for this with a generic penalty.
+		 */
+		pages_read *= 2.0;
+		pages_written *= 2.0;
+
 		startup_cost += pages_written * random_page_cost;
 		total_cost += pages_written * random_page_cost;
 		total_cost += pages_read * seq_page_cost;
+
+		/* account for CPU cost of spilling a tuple and reading it back */
+		spill_cost = depth * input_tuples * 2.0 * cpu_tuple_cost;
+		startup_cost += spill_cost;
+		total_cost += spill_cost;
 	}
 
 	/*

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -2554,8 +2554,9 @@ cost_agg(Path *path, PlannerInfo *root,
 		 */
 		hashentrysize = hash_agg_entry_size(
 			aggcosts->numAggs, input_width, aggcosts->transitionSpace);
-		hash_agg_set_limits(NULL, hashentrysize, numGroups, 0, &mem_limit,
-							&ngroups_limit, &num_partitions);
+		mem_limit = hash_agg_set_limits2(NULL, hashentrysize, numGroups, 0,
+										 global_work_mem(root), &ngroups_limit,
+										 &num_partitions);
 
 		nbatches = Max( (numGroups * hashentrysize) / mem_limit,
 						numGroups / ngroups_limit );

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -7556,8 +7556,6 @@ add_paths_to_grouping_rel(PlannerInfo *root, RelOptInfo *input_rel,
 
 	if (can_hash)
 	{
-		double		hashaggtablesize;
-
 		if (parse->groupingSets)
 		{
 			/*
@@ -7590,42 +7588,26 @@ add_paths_to_grouping_rel(PlannerInfo *root, RelOptInfo *input_rel,
 			else
 				dNumGroups = dNumGroupsTotal;
 
-			hashaggtablesize = estimate_hashagg_tablesize(cheapest_path,
-														  agg_costs,
-														  dNumGroups);
-
 			/*
-			 * Provided that the estimated size of the hashtable does not
-			 * exceed work_mem, we'll generate a HashAgg Path, although if we
-			 * were unable to sort above, then we'd better generate a Path, so
-			 * that we at least have one.
+			 * We just need an Agg over the cheapest-total input path,
+			 * since input order won't matter.
 			 */
-			if (enable_hashagg_disk ||
-				hashaggtablesize < work_mem * 1024L ||
-				grouped_rel->pathlist == NIL)
-			{
-				/*
-				 * We just need an Agg over the cheapest-total input path,
-				 * since input order won't matter.
-				 */
-				add_path(grouped_rel, (Path *)
-						 create_agg_path(root, grouped_rel,
-										 path,
-										 grouped_rel->reltarget,
-										 AGG_HASHED,
-										 AGGSPLIT_SIMPLE,
-										 false,
-										 parse->groupClause,
-										 havingQual,
-										 agg_costs,
-										 dNumGroups));
-			}
+			add_path(grouped_rel, (Path *)
+					create_agg_path(root, grouped_rel,
+									path,
+									grouped_rel->reltarget,
+									AGG_HASHED,
+									AGGSPLIT_SIMPLE,
+									false,
+									parse->groupClause,
+									havingQual,
+									agg_costs,
+									dNumGroups));
 		}
 
 		/*
 		 * Generate a Finalize HashAgg Path atop of the cheapest partially
-		 * grouped path, assuming there is one. Once again, we'll only do this
-		 * if it looks as though the hash table won't exceed work_mem.
+		 * grouped path, assuming there is one
 		 */
 		if (partially_grouped_rel && partially_grouped_rel->pathlist)
 		{
@@ -7649,26 +7631,18 @@ add_paths_to_grouping_rel(PlannerInfo *root, RelOptInfo *input_rel,
 			else
 				dNumGroups = dNumGroupsTotal;
 
-			hashaggtablesize = estimate_hashagg_tablesize(path,
-														  agg_final_costs,
-														  dNumGroups);
-
-			if (enable_hashagg_disk ||
-				hashaggtablesize < work_mem * 1024L)
-			{
-				add_path(grouped_rel, (Path *)
-						 create_agg_path(root,
-										 grouped_rel,
-										 path,
-										 grouped_rel->reltarget,
-										 AGG_HASHED,
-										 AGGSPLIT_FINAL_DESERIAL,
-										 false,
-										 parse->groupClause,
-										 havingQual,
-										 agg_final_costs,
-										 dNumGroups));
-			}
+			add_path(grouped_rel, (Path *)
+					create_agg_path(root,
+									grouped_rel,
+									path,
+									grouped_rel->reltarget,
+									AGG_HASHED,
+									AGGSPLIT_FINAL_DESERIAL,
+									false,
+									parse->groupClause,
+									havingQual,
+									agg_final_costs,
+									dNumGroups));
 		}
 	}
 
@@ -8046,64 +8020,40 @@ create_partial_grouping_paths(PlannerInfo *root,
 
     if (can_hash && cheapest_total_path != NULL)
 	{
-		double		hashaggtablesize;
-
 		/* Checked above */
 		Assert(parse->hasAggs || parse->groupClause);
 
-		hashaggtablesize =
-			estimate_hashagg_tablesize(cheapest_total_path,
-									   agg_partial_costs,
-									   dNumPartialGroups);
-
-		/*
-		 * Tentatively produce a partial HashAgg Path, depending on if it
-		 * looks as if the hash table will fit in work_mem.
-		 */
-		if ((enable_hashagg_disk || hashaggtablesize < work_mem * 1024L) &&
-			cheapest_total_path != NULL)
-		{
-			add_path(partially_grouped_rel, (Path *)
-					 create_agg_path(root,
-									 partially_grouped_rel,
-									 cheapest_total_path,
-									 partially_grouped_rel->reltarget,
-									 AGG_HASHED,
-									 AGGSPLIT_INITIAL_SERIAL,
-									 false,
-									 parse->groupClause,
-									 NIL,
-									 agg_partial_costs,
-									 dNumPartialGroups));
-		}
+		add_path(partially_grouped_rel, (Path *)
+				create_agg_path(root,
+								partially_grouped_rel,
+								cheapest_total_path,
+								partially_grouped_rel->reltarget,
+								AGG_HASHED,
+								AGGSPLIT_INITIAL_SERIAL,
+								false,
+								parse->groupClause,
+								NIL,
+								agg_partial_costs,
+								dNumPartialGroups));
 	}
 
+	/*
+	 * Now add a partially-grouped HashAgg partial Path where possible
+	 */
 	if (can_hash && cheapest_partial_path != NULL)
 	{
-		double		hashaggtablesize;
-
-		hashaggtablesize =
-			estimate_hashagg_tablesize(cheapest_partial_path,
-									   agg_partial_costs,
-									   dNumPartialPartialGroups);
-
-		/* Do the same for partial paths. */
-		if ((enable_hashagg_disk || hashaggtablesize < work_mem * 1024L) &&
-			cheapest_partial_path != NULL)
-		{
-			add_partial_path(partially_grouped_rel, (Path *)
-							 create_agg_path(root,
-											 partially_grouped_rel,
-											 cheapest_partial_path,
-											 partially_grouped_rel->reltarget,
-											 AGG_HASHED,
-											 AGGSPLIT_INITIAL_SERIAL,
-											 false,
-											 parse->groupClause,
-											 NIL,
-											 agg_partial_costs,
-											 dNumPartialPartialGroups));
-		}
+		add_partial_path(partially_grouped_rel, (Path *)
+				create_agg_path(root,
+								partially_grouped_rel,
+								cheapest_partial_path,
+								partially_grouped_rel->reltarget,
+								AGG_HASHED,
+								AGGSPLIT_INITIAL_SERIAL,
+								false,
+								parse->groupClause,
+								NIL,
+								agg_partial_costs,
+								dNumPartialPartialGroups));
 	}
 
 	/*

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1040,7 +1040,7 @@ static struct config_bool ConfigureNamesBool[] =
 		NULL, NULL, NULL
 	},
 	{
-		{"enable_hashagg_disk", PGC_USERSET, QUERY_TUNING_METHOD,
+		{"enable_hashagg_disk", PGC_USERSET, DEFUNCT_OPTIONS,
 			gettext_noop("Enables the planner's use of hashed aggregation plans that are expected to exceed work_mem."),
 			NULL,
 			GUC_EXPLAIN

--- a/src/include/executor/nodeAgg.h
+++ b/src/include/executor/nodeAgg.h
@@ -345,6 +345,9 @@ extern Size hash_agg_entry_size(int numTrans, Size tupleWidth,
 extern void hash_agg_set_limits(AggState *aggstate, double hashentrysize, double input_groups,
 								int used_bits, Size *mem_limit,
 								uint64 *ngroups_limit, int *num_partitions);
+extern Size hash_agg_set_limits2(AggState *aggstate, double hashentrysize, double input_groups,
+								int used_bits, Size mem_limit,
+								uint64 *ngroups_limit, int *num_partitions);
 
 extern Datum aggregate_dummy(PG_FUNCTION_ARGS);
 

--- a/src/test/regress/expected/workfile/hashagg_spill.out
+++ b/src/test/regress/expected/workfile/hashagg_spill.out
@@ -132,10 +132,25 @@ INSERT INTO spill_temptblspace SELECT avg(col2) col2 FROM hashagg_spill GROUP BY
 RESET temp_tablespaces;
 RESET statement_mem;
 RESET gp_workfile_compression;
+-- Check that the value of work_mem does not affect spill.
+-- start_ignore
+-- end_ignore
+CREATE TABLE t1 (a int, b int) DISTRIBUTED BY (a);
+INSERT INTO t1 SELECT a, a FROM generate_series(1, 100000)a;
+ANALYSE t1;
+SET work_mem = '512kB';
+SELECT * FROM hashagg_spill.is_workfile_created('explain (analyze, verbose) SELECT avg(a) FROM t1 GROUP BY b;');
+ is_workfile_created 
+---------------------
+                   0
+(1 row)
+
+RESET work_mem;
 drop schema hashagg_spill cascade;
-NOTICE:  drop cascades to 5 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to function is_workfile_created(text)
 drop cascades to table testhagg
 drop cascades to table aggspill
 drop cascades to table hashagg_spill
 drop cascades to table spill_temptblspace
+drop cascades to table t1

--- a/src/test/regress/sql/workfile/hashagg_spill.sql
+++ b/src/test/regress/sql/workfile/hashagg_spill.sql
@@ -95,5 +95,17 @@ RESET temp_tablespaces;
 RESET statement_mem;
 RESET gp_workfile_compression;
 
+-- Check that the value of work_mem does not affect spill.
+-- start_ignore
+DROP TABLE IF EXISTS t1;
+-- end_ignore
+CREATE TABLE t1 (a int, b int) DISTRIBUTED BY (a);
+
+INSERT INTO t1 SELECT a, a FROM generate_series(1, 100000)a;
+ANALYSE t1;
+
+SET work_mem = '512kB';
+SELECT * FROM hashagg_spill.is_workfile_created('explain (analyze, verbose) SELECT avg(a) FROM t1 GROUP BY b;');
+RESET work_mem;
 
 drop schema hashagg_spill cascade;


### PR DESCRIPTION
Improve Hash Aggregate performance:
1. Improves Hash Aggregate estimation with spill to disk.
2. Always consider the aggregation path with the hash table, even if it is expected to spill. This reduces the dependence of planning on the value of `work_mem`, which may not have a sane value.
3. Removes the use of `work_mem` in the Hash Aggregate during execution.

---

Merge with rebase