### PR TITLE
[GG-604] Install transitions library via pip and fix unit tests

### DIFF
--- a/README.Ubuntu.bash
+++ b/README.Ubuntu.bash
@@ -55,7 +55,6 @@ apt-get install -y \
 	python3-yaml \
 	rsync \
 	sudo \
-	python3-transitions \
 	zlib1g-dev
 
 tee -a /etc/sysctl.conf << EOF

--- a/gpMgmt/.gitignore
+++ b/gpMgmt/.gitignore
@@ -1,2 +1,3 @@
 /config_file
 /gpcheckcat.verify*sql
+.ext-pip-deps

--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -2,7 +2,18 @@ top_builddir = ..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/gpMgmt/Makefile.behave
 
-SUBDIRS= sbin bin doc
+SUBDIRS = sbin bin doc
+PIP ?= python3 -m pip
+PYLIB_TARGET_DIR = $(DESTDIR)$(prefix)/lib/python
+PIP_TARGET = $(PYLIB_TARGET_DIR)/vendor
+
+.ext-pip-deps: requirements.txt
+	mkdir -p $(PIP_TARGET)
+	$(PIP) install \
+	--no-compile \
+	--target $(PIP_TARGET) \
+	-r $<
+	touch $@
 
 $(recurse)
 
@@ -11,13 +22,15 @@ generate_greengage_path_file:
 	unset LIBPATH; \
 	bin/generate-greengage-path.sh > $(DESTDIR)$(prefix)/greengage_path.sh
 
-install: generate_greengage_path_file
-	mkdir -p $(DESTDIR)$(prefix)/lib/python
+install: generate_greengage_path_file .ext-pip-deps
+	mkdir -p $(PYLIB_TARGET_DIR)
 
 	# Setup /lib/python contents
 	if [ -e bin/ext/__init__.py ]; then \
-	    cp -rp bin/ext/__init__.py $(DESTDIR)$(prefix)/lib/python ; \
+	    cp -rp bin/ext/__init__.py $(PYLIB_TARGET_DIR) ; \
 	fi
 
 clean distclean:
+	rm -f .ext-pip-deps
+	rm -rf $(PIP_TARGET)
 	$(MAKE) -C bin $@

--- a/gpMgmt/bin/generate-greengage-path.sh
+++ b/gpMgmt/bin/generate-greengage-path.sh
@@ -27,7 +27,7 @@ fi
 EOF
 
 cat <<"EOF"
-PYTHONPATH="${GPHOME}/lib/python"
+PYTHONPATH="${GPHOME}/lib/python:${GPHOME}/lib/python/vendor"
 PATH="${GPHOME}/bin:${PATH}"
 LD_LIBRARY_PATH="${GPHOME}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 

--- a/gpMgmt/bin/ggrebalance_modules/test/test_unit_ggrebalance.py
+++ b/gpMgmt/bin/ggrebalance_modules/test/test_unit_ggrebalance.py
@@ -28,10 +28,20 @@ def rebalance_only(numsegs):
         return wrapper
     return inner
 
-def check_query(conn, query):
-    if  "SELECT COUNT(1) FROM pg_namespace WHERE nspname =" in query:
+def make_mock_cursor(rowcount=0, rows=None):
+    cursor = MagicMock()
+    cursor.rowcount = rowcount
+    cursor.fetchone.return_value = rows[0] if rows else None
+    cursor.__iter__ = Mock(return_value=iter(rows or []))
+    return cursor
+
+def mock_queryRow(conn, query):
+    if "COUNT(1)" in query or "COUNT(*)" in query:
         return [0]
-    return None
+    return ["dummy"]
+
+def mock_query(conn, query_string):
+    return make_mock_cursor(rowcount=0)
 
 class TestRebalanceUtilityCLI(GpTestCase):
     def setUp(self):
@@ -46,6 +56,7 @@ class TestRebalanceUtilityCLI(GpTestCase):
             spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal', 'exception'])
 
         self.subject.check_running_gputils = Mock(return_value=False)
+        self.subject.remove_pid_file = Mock()
 
         self.apply_patches([
             patch('builtins.open', mock_open(), create=True),
@@ -78,53 +89,92 @@ class TestRebalanceUtilityCLI(GpTestCase):
         sys.argv = self.old_sys_argv
         super(TestRebalanceUtilityCLI, self).tearDown()
 
+    @patch('gppylib.db.dbconn.query', side_effect=mock_query)
+    @patch('gppylib.db.dbconn.execSQL')
+    @patch('gppylib.db.dbconn.connect', return_value=MagicMock())
+    @patch('gppylib.db.dbconn.queryRow', side_effect=mock_queryRow)
     @patch('ggrebalance.GpArray.initFromCatalog',
-           return_value=initGparrayFromFile("balanced_grouped_6"))
-    @patch('os.path.exists', side_effect=lambda path: path not in ['/tmp/dirdoesnotexist/gparraydump'])
-    @patch('gppylib.db.dbconn.queryRow', side_effect=check_query)
-    @patch('ggrebalance.check_down_segments')
-    @rebalance_only(numsegs = 6)
-    def test_already_balanced_grouped(self, mockCatalog, mockOsPath, mockCursor, mock_down):
+            return_value=initGparrayFromFile("balanced_grouped_6"))
+    @patch('os.path.exists',
+            side_effect=lambda path: path not in ['/tmp/dirdoesnotexist/gparraydump'])
+    @rebalance_only(numsegs=6)
+    def test_already_balanced_grouped(self,
+                                      mockOsPath,
+                                      mockArray,
+                                      mockQueryRow,
+                                      mockConnect,
+                                      mockExecSQL,
+                                      mockQuery):
         with self.assertRaises(SystemExit):
             self.subject.main(self.options, self.args, self.parser)
         self.subject.logger.info.assert_any_call(
             "Cluster is already balanced, no segment moves will be held.")
     
-    @patch('ggrebalance.GpArray.initFromCatalog',
-           return_value=initGparrayFromFile("seg_down"))
-    @patch('os.path.exists', side_effect=lambda path: path not in ['/tmp/dirdoesnotexist/gparraydump'])
-    @patch('gppylib.db.dbconn.queryRow', side_effect=check_query)
-    @patch('ggrebalance.check_down_segments')
-    @rebalance_only(numsegs = 4)
-    def test_segment_down(self, mockCatalog, mockOsPath, mockCursor, mock_down):
+    @patch('gppylib.db.dbconn.execSQL')
+    @patch('gppylib.db.dbconn.connect', return_value=MagicMock())
+    @patch('gppylib.db.dbconn.queryRow', side_effect=lambda conn, query: [1])
+    @patch('os.path.exists',
+            side_effect=lambda path: path not in ['/tmp/dirdoesnotexist/gparraydump'])
+    @rebalance_only(numsegs=6)
+    def test_segment_down(self,
+                          mockOsPath,
+                          mockQueryRow,
+                          mockConnect,
+                          mockExecSQL):
         with self.assertRaises(SystemExit):
             self.subject.main(self.options, self.args, self.parser)
         self.subject.logger.error.assert_any_call(
-            "ggrebalance failed: Some segments in 'down' status. ggrebalance can't proceed further \n\nExiting...")
+            "ggrebalance failed: Detected some primary segments are down, please recover manually \n\nExiting...")
 
+    @patch('gppylib.db.dbconn.query',    side_effect=mock_query)
+    @patch('gppylib.db.dbconn.execSQL')
+    @patch('gppylib.db.dbconn.connect',  return_value=MagicMock())
+    @patch('gppylib.db.dbconn.queryRow', side_effect=mock_queryRow)
+    @patch('ggrebalance.check_running_gputils')
     @patch('ggrebalance.GpArray.initFromCatalog',
-           return_value=initGparrayFromFile("balanced_spread_24"))
-    @patch('os.path.exists', side_effect=lambda path: path not in ['/tmp/dirdoesnotexist/gparraydump'])
-    @patch('gppylib.db.dbconn.queryRow', side_effect=check_query)
+            return_value=initGparrayFromFile("balanced_spread_24"))
+    @patch('os.path.exists',
+            side_effect=lambda path: path not in ['/tmp/dirdoesnotexist/gparraydump'])
     @patch('ggrebalance.check_down_segments')
-    @rebalance_only(numsegs = 24)
-    def test_invalid_target_datadir(self, mockCatalog, mockOsPath, mockCursor, mock_down):
-        self.options.target_hosts = "sdw1, sdw2, sdw3"
+    @rebalance_only(numsegs=24)
+    def test_invalid_target_datadir(self,
+                                    mockCheckDown,
+                                    mockOsPath,
+                                    mockArray,
+                                    mockCheckRunning,
+                                    mockQueryRow,
+                                    mockConnect,
+                                    mockExecSQL,
+                                    mockQuery):
+        self.options.target_hosts   = "sdw1, sdw2, sdw3"
         self.options.target_datadirs = '/data/primary/gpseg{content}'
         with self.assertRaises(SystemExit):
             self.subject.main(self.options, self.args, self.parser)
         self.subject.logger.error.assert_any_call(
             'ggrebalance failed: --target-datadirs should have format: '
-                '"/data/primary/gpseg{content}, /data/mirror/gpseg{content}". '
-                'Available templated parameters: {hostname}, {content} \n\nExiting...')
+            '"/data/primary/gpseg{content}, /data/mirror/gpseg{content}". '
+            'Available templated parameters: {hostname}, {content} \n\nExiting...')
     
+    @patch('gppylib.db.dbconn.query',    side_effect=mock_query)
+    @patch('gppylib.db.dbconn.execSQL')
+    @patch('gppylib.db.dbconn.connect',  return_value=MagicMock())
+    @patch('gppylib.db.dbconn.queryRow', side_effect=mock_queryRow)
+    @patch('ggrebalance.check_running_gputils')
     @patch('ggrebalance.GpArray.initFromCatalog',
-           return_value=initGparrayFromFile("role_mismatch"))
-    @patch('os.path.exists', side_effect=lambda path: path not in ['/tmp/dirdoesnotexist/gparraydump'])
-    @patch('gppylib.db.dbconn.queryRow', side_effect=check_query)
+            return_value=initGparrayFromFile("role_mismatch"))
+    @patch('os.path.exists',
+            side_effect=lambda path: path not in ['/tmp/dirdoesnotexist/gparraydump'])
     @patch('ggrebalance.check_down_segments')
-    @rebalance_only(numsegs = 4)
-    def test_role_mistmatch(self, mockCatalog, mockOsPath, mockCursor, mock_down):
+    @rebalance_only(numsegs=4)
+    def test_role_mistmatch(self,
+                            mockCheckDown,
+                            mockOsPath,
+                            mockArray,
+                            mockCheckRunning,
+                            mockQueryRow,
+                            mockConnect,
+                            mockExecSQL,
+                            mockQuery):
         with self.assertRaises(SystemExit):
             self.subject.main(self.options, self.args, self.parser)
         self.subject.logger.error.assert_any_call(

--- a/gpMgmt/bin/ggrebalance_modules/test/test_unit_resources.py
+++ b/gpMgmt/bin/ggrebalance_modules/test/test_unit_resources.py
@@ -975,7 +975,7 @@ class TestResourceEstimator(GpTestCase):
     @patch('ggrebalance_modules.planner.DiskSpaceChecker')
     @patch('ggrebalance_modules.planner.HostResolver.resolve_hostname')
     @patch('ggrebalance_modules.planner.HostResolver.get_address')
-    @patch('ggrebalance_modules.planner.GreedySolver')
+    @patch('ggrebalance_modules.planner.LNS')
     @patch('ggrebalance_modules.rebalance_schema.dbconn.queryRow', side_effect=check_query)
     @patch('ggrebalance_modules.planner.dbconn')
     def test_planner_with_resource_estimation(self, mock_dbconn, mock_schema, mock_solver, 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -17,6 +17,7 @@ class GpCheckCatTestCase(GpTestCase):
         gpcheckcat_file = os.path.abspath(os.path.dirname(__file__) + "/../../../gpcheckcat")
         self.subject = imp.load_source('gpcheckcat', gpcheckcat_file)
         self.subject.check_gpexpand = lambda : (True, "")
+        self.subject.check_ggrebalance = lambda : (True, "")
 
         self.db_connection = Mock(spec=['close', 'cursor', 'set_session'])
         self.unique_index_violation_check = Mock(spec=['runCheck'])

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
@@ -42,6 +42,7 @@ class GpConfig(GpTestCase):
         self.subject = imp.load_source('gpconfig', gpconfig_file)
         self.subject.LOGGER = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
         self.subject.check_gpexpand = lambda : (True, "")
+        self.subject.check_ggrebalance = lambda : (True, "")
 
         self.conn = Mock()
         self.cursor = FakeCursor()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand.py
@@ -30,6 +30,7 @@ class GpExpand(GpTestCase):
 
         # All we're doing here is checking files using open, which doesn't seem worth the effort to fully mock out
         self.subject.is_gpexpand_running = Mock(return_value=False)
+        self.subject.is_ggrebalance_running = Mock(return_value=False)
 
         self.gparray = self.createGpArrayWith2Primary2Mirrors()
         self.apply_patches([

--- a/gpMgmt/requirements.txt
+++ b/gpMgmt/requirements.txt
@@ -1,0 +1,1 @@
+transitions==0.9.3


### PR DESCRIPTION
Currently, using distro packaging for python tools may lead to
dependency version inconsistencies among various systems or even
to package absence in some distros. Thus, it would be better for
portability to use pip for some python dependencies.

This patch adds the infrastructure, which installs packages required for
Greengage cluster utilities into Greengage's PYTHONPATH. Since the
need for such changes arose specifically for ggrebalance, other python
modules (psutil, pyaml, psycopg) are still retrieved from distros
mirrors.

The gpMgmt/Makefile is updated with a new target, which calls pip
install modules from requirements.txt

Last several patches broke the unit tests.
Second commit restores their functionality.

-----
Merge with rebase