### PR TITLE
ADBDEV-9961: Research why Orca don't use index scan after exsits transformation

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPatternNode.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPatternNode.h
@@ -98,6 +98,7 @@ public:
 		{
 			case EmtMatchInnerOrLeftOuterJoin:
 				return COperator::EopLogicalInnerJoin == opid ||
+					   COperator::EopLogicalLeftSemiJoin == opid ||
 					   COperator::EopLogicalLeftOuterJoin == opid;
 
 			default:

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalLeftSemiJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalLeftSemiJoin.cpp
@@ -50,6 +50,8 @@ CLogicalLeftSemiJoin::PxfsCandidates(CMemoryPool *mp) const
 {
 	CXformSet *xform_set = GPOS_NEW(mp) CXformSet(mp);
 
+	(void) xform_set->ExchangeSet(CXform::ExfJoin2IndexGetApply);
+	(void) xform_set->ExchangeSet(CXform::ExfJoin2BitmapIndexGetApply);
 	(void) xform_set->ExchangeSet(CXform::ExfSemiJoinSemiJoinSwap);
 	(void) xform_set->ExchangeSet(CXform::ExfSemiJoinAntiSemiJoinSwap);
 	(void) xform_set->ExchangeSet(CXform::ExfSemiJoinAntiSemiJoinNotInSwap);

--- a/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
@@ -242,6 +242,7 @@ CXformJoin2IndexApply::CreateAlternativesForBtreeIndex(
 		switch (joinOp->Eopid())
 		{
 			case COperator::EopLogicalInnerJoin:
+			case COperator::EopLogicalLeftSemiJoin:
 				isOuterJoin = false;
 				break;
 


### PR DESCRIPTION
There exists a simple query with exists in it, for which ORCA doesn't use index scan.

Add LeftSemiJoin to Join2IndexApply transform to fix that.