### PR TITLE
GG-570: Implement 'rows out' in EXPLAIN ANALYZE [6.x]

### DIFF
--- a/.abi-check/6.31.0/postgres.symbols.ignore
+++ b/.abi-check/6.31.0/postgres.symbols.ignore
@@ -1,0 +1,1 @@
+ConfigureNamesBool_gp

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -278,6 +278,7 @@ int			gp_motion_slice_noop = 0;
 
 /* Greengage Database Experimental Feature GUCs */
 int			gp_distinct_grouping_sets_threshold = 32;
+bool		gp_enable_explain_rows_out = FALSE;
 bool		gp_enable_explain_allstat = FALSE;
 bool		gp_enable_motion_deadlock_sanity = FALSE;	/* planning time sanity
 														 * check */

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1858,6 +1858,75 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 	pfree(extraData.data);
 
 	/*
+	 * Print "Rows out"
+	 */
+	if (gp_enable_explain_rows_out && es->analyze && ns->ninst > 0)
+	{
+		double		alltuples = 0;
+		double		maxtuples = 0;
+		int			maxseg = -1;
+		double		mintuples = 0;
+		int			minseg = -1;
+		int			workercount = 0;
+		double		avgtuples;
+
+		for (i = 0; i < ns->ninst; i++)
+		{
+			CdbExplain_StatInst *nsi = &ns->insts[i];
+			double		rows;
+
+			if (nsi->pstype == T_Invalid)
+				continue;
+
+			rows = nsi->nloops > 0 ? nsi->ntuples / nsi->nloops : 0;
+
+			if (workercount == 0 || rows > maxtuples)
+			{
+				maxtuples = rows;
+				maxseg = ns->segindex0 + i;
+			}
+
+			if (workercount == 0 || rows < mintuples)
+			{
+				mintuples = rows;
+				minseg = ns->segindex0 + i;
+			}
+
+			alltuples += rows;
+			workercount++;
+		}
+
+		if (workercount > 0)
+		{
+			avgtuples = alltuples / workercount;
+
+			if (es->format == EXPLAIN_FORMAT_TEXT)
+			{
+				appendStringInfoSpaces(es->str, es->indent * 2);
+				appendStringInfoString(es->str, "Rows out: ");
+
+				appendStringInfo(es->str,
+								 "%.2f rows avg x %d workers, %.0f rows max (seg%d), %.0f rows min (seg%d).\n",
+								 avgtuples,
+								 workercount,
+								 maxtuples,
+								 maxseg,
+								 mintuples,
+								 minseg);
+			}
+			else
+			{
+				ExplainPropertyInteger("Workers", workercount, es);
+				ExplainPropertyFloat("Average Rows", avgtuples, 2, es);
+				ExplainPropertyFloat("Max Rows", maxtuples, 0, es);
+				ExplainPropertyInteger("Max Rows Segment", maxseg, es);
+				ExplainPropertyFloat("Min Rows", mintuples, 0, es);
+				ExplainPropertyInteger("Min Rows Segment", minseg, es);
+			}
+		}
+	}
+
+	/*
 	 * Dump stats for all workers.
 	 */
 	if (gp_enable_explain_allstat && ns->segindex0 >= 0 && ns->ninst > 0)

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -891,6 +891,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
+		{"gp_enable_explain_rows_out", PGC_USERSET, CLIENT_CONN_OTHER,
+			gettext_noop("Experimental feature: print avg, min and max rows out in segments in EXPLAIN ANALYZE."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_enable_explain_rows_out,
+		false,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"gp_enable_sort_limit", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable LIMIT operation to be performed while sorting."),
 			gettext_noop("Sort more efficiently when plan requires the first <n> rows at most.")

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -744,6 +744,12 @@ extern bool gp_enable_preunique;
  */
 extern bool gp_eager_preunique;
 
+/*
+ * May Greengage print statistics as average, minimum and maximum rows out
+ * during EXPLAIN ANALYZE?
+ */
+extern bool gp_enable_explain_rows_out;
+
 /* May Greengage dump statistics for all segments as a huge ugly string
  * during EXPLAIN ANALYZE?
  *

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -176,6 +176,7 @@
 		"gp_enable_direct_dispatch",
 		"gp_enable_exchange_default_partition",
 		"gp_enable_explain_allstat",
+		"gp_enable_explain_rows_out",
 		"gp_enable_fast_sri",
 		"gp_enable_global_deadlock_detector",
 		"gp_enable_gpperfmon",

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -29,13 +29,27 @@ begin
   end loop;
 end;
 $$ language plpgsql;
+-- Return EXPLAIN ANALYZE result as xml to manipulate it further.
+create or replace function get_explain_analyze_xml_output(explain_query text)
+returns xml as
+$$
+declare
+  x xml;
+begin
+  execute 'EXPLAIN (ANALYZE, VERBOSE, FORMAT XML) ' || explain_query
+  into x;
+  return x;
+end;
+$$ language plpgsql;
 --
 -- Test explain_memory_verbosity option
 -- 
+set gp_use_legacy_hashops=off;
 CREATE TABLE explaintest (id int4);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greengage Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO explaintest SELECT generate_series(1, 10);
+reset gp_use_legacy_hashops;
 EXPLAIN ANALYZE SELECT * FROM explaintest;
                                                                QUERY PLAN                                                               
 ----------------------------------------------------------------------------------------------------------------------------------------
@@ -337,21 +351,46 @@ explain analyze SELECT * FROM explaintest;
 (8 rows)
 
 set gp_enable_explain_allstat=DEFAULT;
+-- Test explain rows out.
+set gp_enable_explain_rows_out=on;
+\pset format unaligned
+\pset tuples_only on
+WITH query_plan (et) AS
+(
+  select get_explain_analyze_output($$
+    SELECT * FROM explaintest;
+  $$)
+)
+SELECT trim(et) FROM query_plan WHERE et like '%Rows out:%' AND et not like '%(seg-1)%';
+Rows out: 3.33 rows avg x 3 workers, 5 rows max (seg0), 1 rows min (seg1).
+-- Rows out on a skewed distribution, so max and min land on different segments.
+set gp_use_legacy_hashops=off;
+CREATE TABLE explain_rows_skew (id int) DISTRIBUTED BY (id);
+INSERT INTO explain_rows_skew SELECT 2 FROM generate_series(1, 100);
+INSERT INTO explain_rows_skew SELECT 1 FROM generate_series(1, 10);
+INSERT INTO explain_rows_skew VALUES (5);
+reset gp_use_legacy_hashops;
+ANALYZE explain_rows_skew;
+SELECT xpath(
+  '//*[local-name()="Relation-Name" and text()="explain_rows_skew"]/..
+    /*[local-name()="Workers"
+       or local-name()="Average-Rows"
+       or local-name()="Max-Rows"
+       or local-name()="Max-Rows-Segment"
+       or local-name()="Min-Rows"
+       or local-name()="Min-Rows-Segment"]/text()',
+  x)
+FROM get_explain_analyze_xml_output($$
+    SELECT * FROM explain_rows_skew;
+  $$) AS query_plan(x);
+{3,37.00,100,0,1,2}
+\pset tuples_only off
+\pset format aligned
+reset gp_enable_explain_rows_out;
+DROP TABLE explain_rows_skew;
 --
 -- Test output of EXPLAIN ANALYZE for Bitmap index scan's actual rows.
 --
--- Return EXPLAIN ANALYZE result as xml to manipulate it further.
-create or replace function get_explain_analyze_xml_output(explain_query text)
-returns xml as
-$$
-declare
-  x xml;
-begin
-  execute 'EXPLAIN (ANALYZE, VERBOSE, FORMAT XML) ' || explain_query
-  into x;
-  return x;
-end;
-$$ language plpgsql;
 -- force (Dynamic) Bitmap Index Scan
 set optimizer_enable_dynamictablescan=off;
 set enable_seqscan=off;

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -29,13 +29,27 @@ begin
   end loop;
 end;
 $$ language plpgsql;
+-- Return EXPLAIN ANALYZE result as xml to manipulate it further.
+create or replace function get_explain_analyze_xml_output(explain_query text)
+returns xml as
+$$
+declare
+  x xml;
+begin
+  execute 'EXPLAIN (ANALYZE, VERBOSE, FORMAT XML) ' || explain_query
+  into x;
+  return x;
+end;
+$$ language plpgsql;
 --
 -- Test explain_memory_verbosity option
 -- 
+set gp_use_legacy_hashops=off;
 CREATE TABLE explaintest (id int4);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greengage Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO explaintest SELECT generate_series(1, 10);
+reset gp_use_legacy_hashops;
 EXPLAIN ANALYZE SELECT * FROM explaintest;
                                                         QUERY PLAN                                                        
 --------------------------------------------------------------------------------------------------------------------------
@@ -368,21 +382,46 @@ explain analyze SELECT * FROM explaintest;
 (8 rows)
 
 set gp_enable_explain_allstat=DEFAULT;
+-- Test explain rows out.
+set gp_enable_explain_rows_out=on;
+\pset format unaligned
+\pset tuples_only on
+WITH query_plan (et) AS
+(
+  select get_explain_analyze_output($$
+    SELECT * FROM explaintest;
+  $$)
+)
+SELECT trim(et) FROM query_plan WHERE et like '%Rows out:%' AND et not like '%(seg-1)%';
+Rows out: 3.33 rows avg x 3 workers, 5 rows max (seg0), 1 rows min (seg1).
+-- Rows out on a skewed distribution, so max and min land on different segments.
+set gp_use_legacy_hashops=off;
+CREATE TABLE explain_rows_skew (id int) DISTRIBUTED BY (id);
+INSERT INTO explain_rows_skew SELECT 2 FROM generate_series(1, 100);
+INSERT INTO explain_rows_skew SELECT 1 FROM generate_series(1, 10);
+INSERT INTO explain_rows_skew VALUES (5);
+reset gp_use_legacy_hashops;
+ANALYZE explain_rows_skew;
+SELECT xpath(
+  '//*[local-name()="Relation-Name" and text()="explain_rows_skew"]/..
+    /*[local-name()="Workers"
+       or local-name()="Average-Rows"
+       or local-name()="Max-Rows"
+       or local-name()="Max-Rows-Segment"
+       or local-name()="Min-Rows"
+       or local-name()="Min-Rows-Segment"]/text()',
+  x)
+FROM get_explain_analyze_xml_output($$
+    SELECT * FROM explain_rows_skew;
+  $$) AS query_plan(x);
+{3,37.00,100,0,1,2}
+\pset tuples_only off
+\pset format aligned
+reset gp_enable_explain_rows_out;
+DROP TABLE explain_rows_skew;
 --
 -- Test output of EXPLAIN ANALYZE for Bitmap index scan's actual rows.
 --
--- Return EXPLAIN ANALYZE result as xml to manipulate it further.
-create or replace function get_explain_analyze_xml_output(explain_query text)
-returns xml as
-$$
-declare
-  x xml;
-begin
-  execute 'EXPLAIN (ANALYZE, VERBOSE, FORMAT XML) ' || explain_query
-  into x;
-  return x;
-end;
-$$ language plpgsql;
 -- force (Dynamic) Bitmap Index Scan
 set optimizer_enable_dynamictablescan=off;
 set enable_seqscan=off;

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -34,12 +34,27 @@ begin
 end;
 $$ language plpgsql;
 
+-- Return EXPLAIN ANALYZE result as xml to manipulate it further.
+create or replace function get_explain_analyze_xml_output(explain_query text)
+returns xml as
+$$
+declare
+  x xml;
+begin
+  execute 'EXPLAIN (ANALYZE, VERBOSE, FORMAT XML) ' || explain_query
+  into x;
+  return x;
+end;
+$$ language plpgsql;
+
 
 --
 -- Test explain_memory_verbosity option
 -- 
+set gp_use_legacy_hashops=off;
 CREATE TABLE explaintest (id int4);
 INSERT INTO explaintest SELECT generate_series(1, 10);
+reset gp_use_legacy_hashops;
 
 EXPLAIN ANALYZE SELECT * FROM explaintest;
 
@@ -162,22 +177,49 @@ set gp_enable_explain_allstat=on;
 explain analyze SELECT * FROM explaintest;
 set gp_enable_explain_allstat=DEFAULT;
 
+-- Test explain rows out.
+set gp_enable_explain_rows_out=on;
+
+\pset format unaligned
+\pset tuples_only on
+WITH query_plan (et) AS
+(
+  select get_explain_analyze_output($$
+    SELECT * FROM explaintest;
+  $$)
+)
+SELECT trim(et) FROM query_plan WHERE et like '%Rows out:%' AND et not like '%(seg-1)%';
+
+-- Rows out on a skewed distribution, so max and min land on different segments.
+set gp_use_legacy_hashops=off;
+CREATE TABLE explain_rows_skew (id int) DISTRIBUTED BY (id);
+INSERT INTO explain_rows_skew SELECT 2 FROM generate_series(1, 100);
+INSERT INTO explain_rows_skew SELECT 1 FROM generate_series(1, 10);
+INSERT INTO explain_rows_skew VALUES (5);
+reset gp_use_legacy_hashops;
+ANALYZE explain_rows_skew;
+
+SELECT xpath(
+  '//*[local-name()="Relation-Name" and text()="explain_rows_skew"]/..
+    /*[local-name()="Workers"
+       or local-name()="Average-Rows"
+       or local-name()="Max-Rows"
+       or local-name()="Max-Rows-Segment"
+       or local-name()="Min-Rows"
+       or local-name()="Min-Rows-Segment"]/text()',
+  x)
+FROM get_explain_analyze_xml_output($$
+    SELECT * FROM explain_rows_skew;
+  $$) AS query_plan(x);
+
+\pset tuples_only off
+\pset format aligned
+reset gp_enable_explain_rows_out;
+DROP TABLE explain_rows_skew;
+
 --
 -- Test output of EXPLAIN ANALYZE for Bitmap index scan's actual rows.
 --
-
--- Return EXPLAIN ANALYZE result as xml to manipulate it further.
-create or replace function get_explain_analyze_xml_output(explain_query text)
-returns xml as
-$$
-declare
-  x xml;
-begin
-  execute 'EXPLAIN (ANALYZE, VERBOSE, FORMAT XML) ' || explain_query
-  into x;
-  return x;
-end;
-$$ language plpgsql;
 
 -- force (Dynamic) Bitmap Index Scan
 set optimizer_enable_dynamictablescan=off;


### PR DESCRIPTION
Implement 'rows out' in EXPLAIN ANALYZE

Backport the gp_enable_explain_rows_out GUC, off by default. When it is
on, EXPLAIN ANALYZE reports the spread of rows produced across segments
for each plan node. The figures make uneven data distribution visible
per node.

Changes:

1. Add the gp_enable_explain_rows_out boolean GUC in the experimental
   feature group, exposed as USERSET and hidden from SHOW ALL.
2. Emit a "Rows out" line in cdbexplain_showExecStats when the GUC is
   on, reporting the average rows across workers with the maximum and
   minimum rows and the segments that produced them, in both text and
   structured output formats.
3. Compute the figures as per-loop rows (ntuples/nloops) to match the
   row count already shown on the node.
4. Skip non-participating (T_Invalid) segment slots, taking the
   average, the worker count, and the minimum only over the segments
   that ran the node.
5. Cover the feature in the gp_explain regression test on a uniform and
   a skewed table, and assert the line is emitted.

EXPLAIN ANALYZE now reports per-node row-count skew across segments.

Backported from GreengageDB/greengage@cc5a070, originally taken from
open-gpdb/gpdb@1d41230.

Co-authored-by: Vladimir Rachkin \<33569237+robozmey@users.noreply.github.com\>

---

This commit will be rebased onto the target branch to preserve authorship.