### PR TITLE
Avoid shallow-copying duplicated subplan roots

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -3184,20 +3184,21 @@ fixup_subplan_walker(Node *node, SubPlanWalkerContext *context)
 			 * there is more than one subplan node which refer to the same
 			 * plan_id. In this case create a duplicate subplan, append it to
 			 * the glob->subplans and update the plan_id of the subplan to
-			 * refer to the new copy of the subplan node. Note since subroot
-			 * is not used there is no need of new subroot, and initplans are
+			 * refer to the new copy of the subplan node. glob->subroots must
+			 * stay aligned with glob->subplans (same length, indexed by
+			 * plan_id); the duplicate's subroot is only ever read (e.g. by
+			 * apply_shareinput_xslice), never mutated through this slot, so we
+			 * reuse the original subroot instead of copying it. Initplans are
 			 * not needed to be duplicated.
 			 */
 			PlannerInfo *root = (PlannerInfo *) context->base.node;
 			Plan	    *dupsubplan = (Plan *) copyObject(planner_subplan_get_plan(root, subplan));
+			PlannerInfo *subroot = planner_subplan_get_root(root, subplan);
 			int			 newplan_id = list_length(root->glob->subplans) + 1;
-			PlannerInfo *dupsubroot = makeNode(PlannerInfo);
-
-			memcpy(dupsubroot, planner_subplan_get_root(root, subplan), sizeof(PlannerInfo));
-			root->glob->subroots = lappend(root->glob->subroots, dupsubroot);
 
 			subplan->plan_id = newplan_id;
 			root->glob->subplans = lappend(root->glob->subplans, dupsubplan);
+			root->glob->subroots = lappend(root->glob->subroots, subroot);
 			context->bms_subplans = bms_add_member(context->bms_subplans, newplan_id);
 			return false;
 		}

--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -1845,14 +1845,18 @@ nested_subplan_mutator(Node *node, plan_tree_base_prefix *context)
 		{
 			PlannerInfo *root = (PlannerInfo*)context->node;
 			Plan *newsubplan = (Plan *) copyObject(planner_subplan_get_plan(root, sp));
-			PlannerInfo *newsubroot = makeNode(PlannerInfo);
-
-			memcpy(newsubroot, planner_subplan_get_root(root, sp), sizeof(PlannerInfo));
+			/*
+			 * glob->subroots must stay aligned with glob->subplans (same
+			 * length, indexed by plan_id). The duplicated subplan's subroot is
+			 * only ever read (never mutated through this slot), so reuse the
+			 * original subroot instead of a makeNode + memcpy shallow copy.
+			 */
+			PlannerInfo *subroot = planner_subplan_get_root(root, sp);
 
 			plan_tree_walker((Node *) newsubplan, nested_subplan_mutator, context);
 
 			root->glob->subplans = lappend(root->glob->subplans, newsubplan);
-			root->glob->subroots = lappend(root->glob->subroots, newsubroot);
+			root->glob->subroots = lappend(root->glob->subroots, subroot);
 
 			/*
 			 * expression_tree_mutator made a copy of the SubPlan already, so


### PR DESCRIPTION
Avoid shallow-copying duplicated subplan roots

The duplicated subplan's subroot is only read (never mutated through its
glob->subroots slot), and makeNode+memcpy produced only a shallow copy
anyway.  Append the existing subroot to keep glob->subroots aligned with
glob->subplans, dropping the allocation.  Apply the same change to both
fixup_subplan_walker() (cdbmutate.c) and nested_subplan_mutator()
(prepunion.c).

Co-Authored-By: Andrey Sokolov <sokolov.andrey.yurevich@gmail.com>