### PR TITLE
CI-5957 Bump regression and jit workflows next

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -59,7 +59,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v41
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v49
     with:
       version: 8
       target_os: ${{ matrix.target_os }}
@@ -113,7 +113,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-jit.yml@v41
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-jit.yml@v49
     with:
       version: 8
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
## Bump regression and jit workflows next (#526)

Regression and jit workflows were bumped.

Heredoc script removed from jit and regression workflows due to
silent failures.

Task: CI-5943