### PR TITLE
CI-5955 Bump regression workflow 6.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -73,7 +73,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v46
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v49
     with:
       version: 6
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
## Bump regression workflow 6.x (#527)

Regression workflow was bumped.

Heredoc script removed from regression workflow due to silent failures.

Task: CI-5943