### PR TITLE
GG-606: Add pg_upgrade pre-check for gp_default_storage_options GUC

### DIFF
--- a/src/bin/pg_upgrade/greengage/check_gp.c
+++ b/src/bin/pg_upgrade/greengage/check_gp.c
@@ -36,6 +36,7 @@ static void check_for_disallowed_pg_operator(void);
 static void check_views_with_changed_function_signatures(void);
 static void check_execute_on_master_functions(void);
 static void check_for_missing_support_function_for_partitions(void);
+static void check_for_incompatible_guc_settings(void);
 
 /*
  *	check_greengage
@@ -63,6 +64,7 @@ check_greengage(void)
 	check_views_with_changed_function_signatures();
 	check_execute_on_master_functions();
 	check_for_missing_support_function_for_partitions();
+	check_for_incompatible_guc_settings();
 }
 
 /*
@@ -1446,4 +1448,96 @@ check_for_missing_support_function_for_partitions()
 	}
 
 	check_ok();
+}
+
+static void
+check_for_incompatible_guc_settings(void)
+{
+	char		output_path[MAXPGPATH];
+	FILE	   *script = NULL;
+	bool		found = false;
+	PGresult   *res;
+	PGconn	   *conn;
+	int			ntups;
+	int			i_datname;
+	int			i_rolname;
+	int			i_setting;
+	int			i_option_name;
+
+	if (GET_MAJOR_VERSION(old_cluster.major_version) > 904)
+		return;
+
+	prep_status("Checking for incompatible GUC settings");
+
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir, "incompatible_guc_settings.txt");
+
+	/*
+	 * pg_db_role_setting is a shared catalog, so checking it once is enough
+	 * for ALTER DATABASE/ROLE SET and ALTER ROLE IN DATABASE SET values.
+	 */
+	conn = connectToServer(&old_cluster, old_cluster.dbarr.dbs[0].db_name);
+	res = executeQueryOrDie(conn,
+							"WITH settings AS ("
+							"    SELECT d.datname, r.rolname, u.setting,"
+							"           pg_catalog.lower(pg_catalog.substr(u.setting, 1, pg_catalog.strpos(u.setting, '=') - 1)) AS guc_name,"
+							"           pg_catalog.substr(u.setting, pg_catalog.strpos(u.setting, '=') + 1) AS guc_value "
+							"    FROM pg_catalog.pg_db_role_setting s "
+							"    LEFT JOIN pg_catalog.pg_database d ON d.oid = s.setdatabase "
+							"    LEFT JOIN pg_catalog.pg_roles r ON r.oid = s.setrole "
+							"    CROSS JOIN pg_catalog.unnest(s.setconfig) AS u(setting) "
+							"    WHERE pg_catalog.strpos(u.setting, '=') > 0"
+							"), options AS ("
+							"    SELECT datname, rolname, setting,"
+							"           pg_catalog.lower(pg_catalog.btrim(pg_catalog.split_part(opt, '=', 1))) AS option_name "
+							"    FROM settings, pg_catalog.regexp_split_to_table(guc_value, ',') AS o(opt) "
+							"    WHERE guc_name = 'gp_default_storage_options' "
+							"      AND pg_catalog.btrim(opt) <> ''"
+							") "
+							"SELECT coalesce(datname, '<none>') AS datname,"
+							"       coalesce(rolname, '<none>') AS rolname,"
+							"       setting,"
+							"       option_name "
+							"FROM options "
+							"WHERE option_name NOT IN ('blocksize', 'compresstype', 'compresslevel', 'checksum') "
+							"ORDER BY datname, rolname, option_name;");
+
+	ntups = PQntuples(res);
+	i_datname = PQfnumber(res, "datname");
+	i_rolname = PQfnumber(res, "rolname");
+	i_setting = PQfnumber(res, "setting");
+	i_option_name = PQfnumber(res, "option_name");
+
+	for (int rowno = 0; rowno < ntups; rowno++)
+	{
+		found = true;
+		if (script == NULL && (script = fopen(output_path, "w")) == NULL)
+			pg_fatal("could not open file \"%s\": %s\n",
+					 output_path, strerror(errno));
+
+		fprintf(script, "Database: %s\n", PQgetvalue(res, rowno, i_datname));
+		fprintf(script, "Role: %s\n", PQgetvalue(res, rowno, i_rolname));
+		fprintf(script, "GUC: gp_default_storage_options\n");
+		fprintf(script, "Setting: %s\n", PQgetvalue(res, rowno, i_setting));
+		fprintf(script, "Invalid option: %s\n\n",
+				PQgetvalue(res, rowno, i_option_name));
+	}
+
+	PQclear(res);
+	PQfinish(conn);
+
+	if (script)
+		fclose(script);
+
+	if (found)
+	{
+		pg_log(PG_REPORT, "fatal\n");
+		gp_fatal_log(
+			"| Your installation contains incompatible gp_default_storage_options settings.\n"
+			"| Remove unsupported storage options from gp_default_storage_options before\n"
+			"| upgrade can continue. A list of the problem settings is in the file:\n"
+			"|     %s\n\n", output_path);
+	}
+	else
+		check_ok();
 }


### PR DESCRIPTION
gp_default_storage_options stopped supporting appendonly, appendoptimized, and 
orientation in 7.x. As a result, pg_upgrade from 6.x to 7.x could fail during the dump
phase after doing a significant amount of work. 

Add pg_upgrade pre-check to detect such incompatible GUC settings earlier and
report the affected database/role entries.

Don't add tests because they belong to the ggupgrade repo and will be added there
after this patch.

Ticket: GG-606