### PR TITLE
GG-627: metadata exchange communication channel (#440)

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -93,6 +93,7 @@
 #include "utils/workfile_mgr.h"
 #include "utils/vmem_tracker.h"
 #include "cdb/cdbdisp.h"
+#include "cdb/cdbconn.h"
 #include "postmaster/autovacuum.h"
 
 /*
@@ -2978,6 +2979,8 @@ CommitTransaction(void)
 	if(Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_UTILITY)
 		MoveDbSessionLockRelease();
 
+	AtCommit_MetadataQueues();
+
 	AtCommit_TablespaceStorage();
 
 	AtCommit_Notify();
@@ -3587,6 +3590,8 @@ AbortTransaction(void)
 
 		DoPendingDbDeletes(false);
 		DatabaseStorageResetSessionLock();
+
+		AtAbort_MetadataQueues();
 
 		AtAbort_TablespaceStorage();
 		gp_guc_need_restore = true;

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -1049,6 +1049,10 @@ PQCreateMetadataQueue(ggMetadataQueueId queue_id)
 {
 	Assert(TopTransactionContext != NULL);
 
+	if (Gp_role != GP_ROLE_DISPATCH)
+		ereport(ERROR, (errcode(ERRCODE_GP_COMMAND_ERROR),
+						errmsg("Metadata queue can only be created on QD")));
+
 	MemoryContext oldcontext = MemoryContextSwitchTo(TopTransactionContext);
 
 	ggMetadataQueue *queue = palloc0(sizeof(ggMetadataQueue));

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -1047,6 +1047,8 @@ AtAbort_MetadataQueues(void)
 void
 PQCreateMetadataQueue(ggMetadataQueueId queue_id)
 {
+	Assert(TopTransactionContext != NULL);
+
 	MemoryContext oldcontext = MemoryContextSwitchTo(TopTransactionContext);
 
 	ggMetadataQueue *queue = palloc0(sizeof(ggMetadataQueue));
@@ -1068,6 +1070,6 @@ PQDeleteMetadataQueue(ggMetadataQueueId queue_id)
 
 	PQCleanMetadataInternal(queue);
 
-	ggMetadataQueues = list_delete(ggMetadataQueues, queue);
+	ggMetadataQueues = list_delete_ptr(ggMetadataQueues, queue);
 	pfree(queue);
 }

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -35,6 +35,7 @@ static uint32 cdbconn_get_motion_listener_port(PGconn *conn);
 static void cdbconn_disconnect(SegmentDatabaseDescriptor *segdbDesc);
 
 static void MPPnoticeReceiver(void *arg, const PGresult *res);
+static void MPPmetadataReceiver(void *arg, ggMetadataChunk *metadata_chunk, ggMetadataQueueId queue_id);
 
 static const char *
 transStatusToString(PGTransactionStatusType status)
@@ -284,10 +285,28 @@ cdbconn_doConnectStart(SegmentDatabaseDescriptor *segdbDesc,
 	return;
 }
 
+static PQmetadataReceiver
+PQsetMetadataReceiver(PGconn *conn, PQmetadataReceiver proc, void *arg)
+{
+	PQmetadataReceiver old;
+
+	if (conn == NULL)
+		return NULL;
+
+	old = conn->metadataHooks.metadataRec;
+	if (proc)
+	{
+		conn->metadataHooks.metadataRec = proc;
+		conn->metadataHooks.metadataRecArg = arg;
+	}
+	return old;
+}
+
 void
 cdbconn_doConnectComplete(SegmentDatabaseDescriptor *segdbDesc)
 {
 	PQsetNoticeReceiver(segdbDesc->conn, &MPPnoticeReceiver, segdbDesc);
+	PQsetMetadataReceiver(segdbDesc->conn, &MPPmetadataReceiver, segdbDesc);
 
 	/*
 	 * Command the QE to initialize its motion layer. Wait for it to respond
@@ -870,4 +889,185 @@ forwardQENotices(void)
 	}
 	if (hasNotices)
 		pq_flush();
+}
+
+typedef struct ggMetadataQueue
+{
+	ggMetadataQueueId id;
+	int			count;
+	ggMetadataChunk *chunks;
+}	ggMetadataQueue;
+
+/* List of ggMetadataQueue */
+static List *ggMetadataQueues = NIL;
+
+static ggMetadataQueue *
+PQMetadataFindQueue(ggMetadataQueueId queue_id)
+{
+	ListCell   *lc;
+
+	foreach(lc, ggMetadataQueues)
+	{
+		ggMetadataQueue *queue = lfirst(lc);
+
+		if (queue->id == queue_id)
+			return queue;
+	}
+	return NULL;
+}
+
+static void
+MPPmetadataReceiver(void *arg, ggMetadataChunk *metadata_chunk, ggMetadataQueueId queue_id)
+{
+	SegmentDatabaseDescriptor *segdbDesc = arg;
+
+	ggMetadataQueue *queue = PQMetadataFindQueue(queue_id);
+
+	/* 
+	 * queue is expected to be created by the extension
+	 */
+	if (queue == NULL)
+	{
+		elog(WARNING, "Could not recieve chunk. No metadata queue with id %u", queue_id);
+		pqPfree(metadata_chunk);
+		return;
+	}
+
+	metadata_chunk->next = queue->chunks;
+	metadata_chunk->segindex = segdbDesc->segindex;
+	queue->chunks = metadata_chunk;
+	queue->count++;
+}
+
+ggMetadataChunkIterator
+PQMetadataWalk(ggMetadataQueueId queue_id)
+{
+	ggMetadataQueue *queue = PQMetadataFindQueue(queue_id);
+
+	if (!queue)
+		elog(ERROR, "No metadata queue with id %u", queue_id);
+	return queue->chunks;
+}
+
+ggMetadataChunkIterator
+PQgetNextMetadata(ggMetadataChunkIterator it)
+{
+	if (!it)
+		return NULL;
+
+	ggMetadataChunk *chunk = (ggMetadataChunk *) it;
+
+	return chunk->next;
+}
+
+void
+PQgetMetadata(ggMetadataChunkIterator it, ggMetadataDescriptor *out_desc)
+{
+	Assert(it != NULL);
+	Assert(out_desc != NULL);
+
+	ggMetadataChunk *chunk = (ggMetadataChunk *) it;
+
+	out_desc->metadataLen = chunk->metadataLen;
+	out_desc->segindex = chunk->segindex;
+	out_desc->data = chunk->payload;
+}
+
+int
+PQgetMetadataCount(ggMetadataQueueId queue_id)
+{
+	ggMetadataQueue *queue = PQMetadataFindQueue(queue_id);
+
+	if (!queue)
+		elog(ERROR, "No metadata queue with id %u", queue_id);
+	return queue->count;
+}
+
+static void
+PQCleanMetadataInternal(ggMetadataQueue *queue)
+{
+	ggMetadataChunk *chunk = queue->chunks;
+
+	while (chunk)
+	{
+		ggMetadataChunkIterator next = chunk->next;
+
+		pqPfree(chunk);
+		chunk = next;
+	}
+	queue->chunks = NULL;
+	queue->count = 0;
+}
+
+void
+PQCleanMetadata(ggMetadataQueueId queue_id)
+{
+	ggMetadataQueue *queue = PQMetadataFindQueue(queue_id);
+
+	if (!queue)
+		elog(ERROR, "No metadata queue with id %u", queue_id);
+
+	PQCleanMetadataInternal(queue);
+}
+
+
+ggMetadataQueueId
+PQMetadataNextQueueId(void)
+{
+	static ggMetadataQueueId queueId = 0;
+	return queueId++;
+}
+
+/* Callback executed at transaction end */
+static void
+PQDeleteMetadataQueues(void)
+{
+	while (ggMetadataQueues)
+	{
+		ListCell   *lc = list_head(ggMetadataQueues);
+		ggMetadataQueue *queue = lfirst(lc);
+
+		elog(WARNING, "Metadata queue %u was not deleted in transaction after use", queue->id);
+		PQDeleteMetadataQueue(queue->id);
+	}
+}
+
+void
+AtCommit_MetadataQueues(void)
+{
+	PQDeleteMetadataQueues();
+}
+
+void
+AtAbort_MetadataQueues(void)
+{
+	PQDeleteMetadataQueues();
+}
+
+void
+PQCreateMetadataQueue(ggMetadataQueueId queue_id)
+{
+	MemoryContext oldcontext = MemoryContextSwitchTo(TopTransactionContext);
+
+	ggMetadataQueue *queue = palloc0(sizeof(ggMetadataQueue));
+
+	queue->id = queue_id;
+
+	ggMetadataQueues = lappend(ggMetadataQueues, queue);
+
+	MemoryContextSwitchTo(oldcontext);
+}
+
+void
+PQDeleteMetadataQueue(ggMetadataQueueId queue_id)
+{
+	ggMetadataQueue *queue = PQMetadataFindQueue(queue_id);
+
+	if (!queue)
+		elog(ERROR, "No metadata queue with id %u", queue_id);
+
+	PQCleanMetadataInternal(queue);
+
+	ggMetadataQueues = list_delete(ggMetadataQueues, queue);
+	pfree(queue);
 }

--- a/src/backend/libpq/pqformat.c
+++ b/src/backend/libpq/pqformat.c
@@ -77,6 +77,7 @@
 #include "libpq/pqformat.h"
 #include "mb/pg_wchar.h"
 #include "port/pg_bswap.h"
+#include "cdb/cdbconn.h"
 
 
 /* --------------------------------
@@ -668,3 +669,44 @@ pq_sendint(StringInfo buf, uint32 i, int b)
 	}
 }
 #endif
+
+/*
+ * pq_metadatasend - Send a custom metadata message to the frontend.
+ *
+ * data: pointer to the opaque buffer
+ * len: length of the buffer in bytes
+ *
+ * NOTE: You must choose a message type char (below 'm') that does not
+ * conflict with the official Frontend/Backend protocol.
+ */
+void
+pq_metadatasend(const void *data, size_t len, int32 queue_id)
+{
+	StringInfoData buf;
+
+	/*
+	 * Safety check: The protocol message length field is a 32-bit signed int.
+	 * We must ensure the payload + header doesn't overflow it.
+	 */
+	if (len > (size_t)(INT_MAX - sizeof(int32) - sizeof(int)))
+		ereport(ERROR,
+				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				 errmsg("custom metadata message too large")));
+
+	/*
+	 * Initialize the message buffer. 'M' is the message type tag.
+	 */
+	pq_beginmessage(&buf, 'M');
+
+	pq_sendint(&buf, queue_id, sizeof(queue_id));
+	/* Append the opaque data */
+	pq_sendbytes(&buf, (const char *)data, (int)len);
+
+	/*
+	 * Finalize and queue the message. This does NOT necessarily flush to the
+	 * socket immediately.
+	 */
+	pq_endmessage(&buf);
+
+	pq_flush();
+}

--- a/src/include/cdb/cdbconn.h
+++ b/src/include/cdb/cdbconn.h
@@ -16,6 +16,10 @@
 #ifndef CDBCONN_H
 #define CDBCONN_H
 
+/*
+ * allow usage of this header from the core code
+ */
+typedef struct pg_conn PGconn;
 
 /* --------------------------------------------------------------------------------------------------
  * Structure for segment database definition and working values
@@ -105,5 +109,33 @@ void cdbconn_setQEIdentifier(SegmentDatabaseDescriptor *segdbDesc, int sliceInde
 bool cdbconn_signalQE(SegmentDatabaseDescriptor *segdbDesc, char *errbuf, bool isCancel);
 
 extern void forwardQENotices(void);
+
+extern void 		AtCommit_MetadataQueues(void);
+extern void 		AtAbort_MetadataQueues(void);
+
+/*
+ * Send custom metadata to frontend
+ */
+extern void pq_metadatasend(const void *data, size_t len, int32 queue_id);
+
+typedef void *ggMetadataChunkIterator;
+typedef unsigned int ggMetadataQueueId;
+
+typedef struct ggMetadataDescriptor
+{
+	int			metadataLen;
+	int			segindex;		/* source segment */
+	void	   *data;
+}	ggMetadataDescriptor;
+
+extern ggMetadataChunkIterator PQMetadataWalk(ggMetadataQueueId queue_id);
+extern ggMetadataChunkIterator PQgetNextMetadata(ggMetadataChunkIterator it);
+extern void PQgetMetadata(ggMetadataChunkIterator it, ggMetadataDescriptor *out_desc);
+extern int	PQgetMetadataCount(ggMetadataQueueId queue_id);
+extern void PQCleanMetadata(ggMetadataQueueId queue_id);
+
+extern ggMetadataQueueId PQMetadataNextQueueId(void);
+extern void PQCreateMetadataQueue(ggMetadataQueueId queue_id);
+extern void PQDeleteMetadataQueue(ggMetadataQueueId queue_id);
 
 #endif   /* CDBCONN_H */

--- a/src/interfaces/libpq/fe-protocol3.c
+++ b/src/interfaces/libpq/fe-protocol3.c
@@ -2414,6 +2414,8 @@ pgGetMetadataMessage(PGconn *conn, int length)
 		return 1;
 	}
 
+	Assert(length >= sizeof(ggMetadataQueueId));
+
 	int payload_len = length - sizeof(ggMetadataQueueId);
 
 	/*

--- a/src/interfaces/libpq/fe-protocol3.c
+++ b/src/interfaces/libpq/fe-protocol3.c
@@ -54,7 +54,7 @@
 #define VALID_LONG_MESSAGE_TYPE(id) \
 	((id) == 'T' || (id) == 'D' || (id) == 'd' || (id) == 'V' || \
 	 (id) == 'E' || (id) == 'N' || (id) == 'A' || (id) == 'Y' || \
-	 (id) == 'y' || (id) == 'o')
+	 (id) == 'y' || (id) == 'o' || (id) == 'M')
 
 #define PQmblenBounded(s, e)  strnlen(s, PQmblen(s, e))
 
@@ -72,6 +72,10 @@ static void reportErrorPosition(PQExpBuffer msg, const char *query,
 								int loc, int encoding);
 static int	build_startup_packet(const PGconn *conn, char *packet,
 								 const PQEnvironmentOption *options);
+
+#ifndef FRONTEND
+static int pgGetMetadataMessage(PGconn *conn, int length);
+#endif
 
 
 /*
@@ -255,6 +259,12 @@ pqParseInput3(PGconn *conn)
 						return;
 					conn->asyncStatus = PGASYNC_READY;
 					break;
+#ifndef FRONTEND
+				case 'M':       /* CDB: backend sends metadata 'M' message */
+					if (pgGetMetadataMessage(conn, msgLength))
+						return;
+					break;
+#endif
 				case 'Z':		/* backend is ready for new query */
 					if (getReadyForQuery(conn))
 						return;
@@ -2380,3 +2390,54 @@ build_startup_packet(const PGconn *conn, char *packet,
 
 	return packet_len;
 }
+
+#ifndef FRONTEND
+
+/*
+ * Read a Metadata response message.
+ * Entry: 'M' message type has already been consumed.
+ * Exit: returns 0 if successfully consumed message.
+ *		 returns 1 otherwise.
+ */
+static int
+pgGetMetadataMessage(PGconn *conn, int length)
+{
+	if (conn->metadataHooks.metadataRec == NULL)
+	{
+		return pqSkipnchar(length, conn);
+	}
+
+	int32 queue_id;
+
+	if (pqGetInt(&queue_id, sizeof(ggMetadataQueueId), conn))
+	{
+		return 1;
+	}
+
+	int payload_len = length - sizeof(ggMetadataQueueId);
+
+	/*
+	 * Since the metadata might be pretty long, we create an own buffer
+	 * rather than using conn->workBuffer.  workBuffer is intended
+	 * for stuff that is expected to be short.
+	 */
+
+	ggMetadataChunk *chunk = pqPalloc(sizeof(ggMetadataChunk) + payload_len);
+	if (chunk == NULL)
+		return 1;
+
+	chunk->next = NULL;
+	chunk->metadataLen = payload_len;
+
+	if (pqGetnchar(chunk->payload, payload_len, conn))
+	{
+		pqPfree(chunk);
+		return 1;
+	}
+
+	/* pass ownership of the link too the handler */
+	conn->metadataHooks.metadataRec(conn->metadataHooks.metadataRecArg, chunk, queue_id);
+
+	return 0;
+}
+#endif

--- a/src/interfaces/libpq/libpq-fe.h
+++ b/src/interfaces/libpq/libpq-fe.h
@@ -30,6 +30,13 @@ extern "C"
 #include "postgres_ext.h"
 
 /*
+ * These symbols may be used in compile-time #ifdef tests for the availability
+ * of Greengage libpq features.
+ */
+/* Indicates presence of external metadata commit v1 */
+#define LIBPQ_HAS_EXT_METADATA_COMMIT_V1 1
+
+/*
  * Option flags for PQcopyResult
  */
 #define PG_COPYRES_ATTRS		  0x01

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -195,6 +195,26 @@ typedef struct
 	void	   *noticeProcArg;
 } PGNoticeHooks;
 
+#ifndef FRONTEND
+/* Fields needed for metadata handling */
+typedef struct ggMetadataChunk
+{
+	struct ggMetadataChunk *next;
+	int    segindex;      /* source segment */
+	int    metadataLen;    /* Length of metadata buffer */
+	char   payload[];
+} ggMetadataChunk;
+
+typedef unsigned int ggMetadataQueueId;
+typedef void (*PQmetadataReceiver) (void *arg, ggMetadataChunk *, ggMetadataQueueId);
+
+typedef struct
+{
+	PQmetadataReceiver metadataRec; /* metadata message receiver */
+	void	   *metadataRecArg;
+} PGMetadataHooks;
+#endif
+
 typedef struct PGEvent
 {
 	PGEventProc proc;			/* the function to call on events */
@@ -604,6 +624,11 @@ struct pg_conn
 
 	/* Buffer for receiving various parts of messages */
 	PQExpBufferData workBuffer; /* expansible string */
+
+#ifndef FRONTEND
+	/* Callback procedures for metadata message processing */
+	PGMetadataHooks metadataHooks;
+#endif
 };
 
 /* PGcancel stores all data necessary to cancel a connection. A copy of this

--- a/src/test/modules/Makefile
+++ b/src/test/modules/Makefile
@@ -25,5 +25,6 @@ SUBDIRS = \
 
 # GPDB subdirs
 SUBDIRS += test_planner
+SUBDIRS += test_metadata
 
 $(recurse)

--- a/src/test/modules/test_metadata/Makefile
+++ b/src/test/modules/test_metadata/Makefile
@@ -1,0 +1,27 @@
+# src/test/modules/test_metadata/Makefile
+
+MODULE_big = test_metadata
+PGFILEDESC = "test_metadata - test extension for custom protocol metadata"
+
+EXTENSION = test_metadata
+DATA = test_metadata--1.0.sql
+CONTROL_FILE = test_metadata.control
+
+OBJS = test_metadata.o $(WIN32RES)
+REGRESS = test_metadata
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = src/test/modules/test_metadata
+top_builddir = ../../../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
+
+
+installcheck: install
+test: clean all install
+	psql postgres -f sql/test_metadata.sql 2>&1

--- a/src/test/modules/test_metadata/expected/test_metadata.out
+++ b/src/test/modules/test_metadata/expected/test_metadata.out
@@ -1,0 +1,229 @@
+create extension if not exists test_metadata;
+begin;
+-- Create two queues
+SELECT test_create_metadata_queue() as queue1
+\gset
+SELECT test_create_metadata_queue() as queue2
+\gset
+-- Test on all segments
+SELECT gp_segment_id, test_send_metadata(150, gp_segment_id, :queue1)
+    FROM gp_dist_random('gp_id');
+WARNING:  Sending custom metadata...
+WARNING:  Custom metadata sent!
+ gp_segment_id | test_send_metadata 
+---------------+--------------------
+             0 |                150
+             1 |                150
+             2 |                150
+(3 rows)
+
+-- Read metadata collected on coordinator
+SELECT test_check_metadata(:queue1);
+WARNING:  Custom metadata received, len=150, id=0
+WARNING:  Custom metadata received, len=150, id=1
+WARNING:  Custom metadata received, len=150, id=2
+ test_check_metadata 
+---------------------
+                   3
+(1 row)
+
+SELECT test_check_metadata(:queue2);
+ test_check_metadata 
+---------------------
+                   0
+(1 row)
+
+-- Clean metadata on coordinator
+SELECT test_clean_metadata(:queue1);
+ test_clean_metadata 
+---------------------
+                   0
+(1 row)
+
+-- Check that metadata has been cleaned on coordinator
+SELECT test_check_metadata(:queue1);
+ test_check_metadata 
+---------------------
+                   0
+(1 row)
+
+-- Test longer metadata
+SELECT gp_segment_id, test_send_metadata(150000, gp_segment_id, :queue1)
+    FROM gp_dist_random('gp_id');
+WARNING:  Sending custom metadata...
+WARNING:  Custom metadata sent!
+ gp_segment_id | test_send_metadata 
+---------------+--------------------
+             0 |             150000
+             1 |             150000
+             2 |             150000
+(3 rows)
+
+SELECT gp_segment_id, test_send_metadata(1500000, gp_segment_id, :queue2)
+    FROM gp_dist_random('gp_id');
+WARNING:  Sending custom metadata...
+WARNING:  Custom metadata sent!
+ gp_segment_id | test_send_metadata 
+---------------+--------------------
+             0 |            1500000
+             1 |            1500000
+             2 |            1500000
+(3 rows)
+
+SELECT gp_segment_id, test_send_metadata(15000000, gp_segment_id, :queue1)
+    FROM gp_dist_random('gp_id');
+WARNING:  Sending custom metadata...
+WARNING:  Custom metadata sent!
+ gp_segment_id | test_send_metadata 
+---------------+--------------------
+             0 |           15000000
+             1 |           15000000
+             2 |           15000000
+(3 rows)
+
+SELECT gp_segment_id, test_send_metadata(150000000, gp_segment_id, :queue2)
+    FROM gp_dist_random('gp_id');
+WARNING:  Sending custom metadata...
+WARNING:  Custom metadata sent!
+ gp_segment_id | test_send_metadata 
+---------------+--------------------
+             0 |          150000000
+             1 |          150000000
+             2 |          150000000
+(3 rows)
+
+SELECT gp_segment_id, test_send_empty_metadata(:queue1)
+    FROM gp_dist_random('gp_id');
+WARNING:  Sending empty metadata...
+WARNING:  Empty metadata sent!
+ gp_segment_id | test_send_empty_metadata 
+---------------+--------------------------
+             0 |                        0
+             1 |                        0
+             2 |                        0
+(3 rows)
+
+-- Read metadata collected on coordinator
+SELECT test_check_metadata(:queue1);
+WARNING:  Custom metadata received, len=0, id=-1
+WARNING:  Custom metadata received, len=0, id=-1
+WARNING:  Custom metadata received, len=0, id=-1
+WARNING:  Custom metadata received, len=15000000, id=0
+WARNING:  Custom metadata received, len=150000, id=0
+WARNING:  Custom metadata received, len=15000000, id=1
+WARNING:  Custom metadata received, len=150000, id=1
+WARNING:  Custom metadata received, len=15000000, id=2
+WARNING:  Custom metadata received, len=150000, id=2
+ test_check_metadata 
+---------------------
+                   9
+(1 row)
+
+SELECT test_check_metadata(:queue2);
+WARNING:  Custom metadata received, len=150000000, id=0
+WARNING:  Custom metadata received, len=1500000, id=0
+WARNING:  Custom metadata received, len=150000000, id=1
+WARNING:  Custom metadata received, len=1500000, id=1
+WARNING:  Custom metadata received, len=150000000, id=2
+WARNING:  Custom metadata received, len=1500000, id=2
+ test_check_metadata 
+---------------------
+                   6
+(1 row)
+
+SELECT test_count_metadata(:queue1);
+ test_count_metadata 
+---------------------
+                   9
+(1 row)
+
+SELECT test_count_metadata(:queue2);
+ test_count_metadata 
+---------------------
+                   6
+(1 row)
+
+SELECT test_clean_metadata(:queue1);
+ test_clean_metadata 
+---------------------
+                   0
+(1 row)
+
+SELECT test_clean_metadata(:queue2);
+ test_clean_metadata 
+---------------------
+                   0
+(1 row)
+
+SELECT test_check_metadata(:queue1);
+ test_check_metadata 
+---------------------
+                   0
+(1 row)
+
+SELECT test_check_metadata(:queue2);
+ test_check_metadata 
+---------------------
+                   0
+(1 row)
+
+SELECT test_count_metadata(:queue1);
+ test_count_metadata 
+---------------------
+                   0
+(1 row)
+
+SELECT test_count_metadata(:queue2);
+ test_count_metadata 
+---------------------
+                   0
+(1 row)
+
+-- Delete two queues
+SELECT test_delete_metadata_queue(:queue1);
+ test_delete_metadata_queue 
+----------------------------
+                          0
+(1 row)
+
+SELECT test_delete_metadata_queue(:queue2);
+ test_delete_metadata_queue 
+----------------------------
+                          0
+(1 row)
+
+commit;
+-- Test error in transaction handling
+begin;
+SELECT test_create_metadata_queue() as queue1
+\gset
+SELECT gp_segment_id, test_send_metadata(42, gp_segment_id, :queue1)
+    FROM gp_dist_random('gp_id');
+WARNING:  Sending custom metadata...
+WARNING:  Custom metadata sent!
+ gp_segment_id | test_send_metadata 
+---------------+--------------------
+             0 |                 42
+             2 |                 42
+             1 |                 42
+(3 rows)
+
+SELECT 1/0; -- Error
+WARNING:  Metadata queue 2 was not deleted in transaction after use
+ERROR:  division by zero
+rollback;
+-- Test sending to non-existent queue
+begin;
+SELECT gp_segment_id, test_send_metadata(42, gp_segment_id, 10000)
+    FROM gp_dist_random('gp_id');
+WARNING:  Could not recieve chunk. No metadata queue with id 10000
+WARNING:  Could not recieve chunk. No metadata queue with id 10000
+WARNING:  Could not recieve chunk. No metadata queue with id 10000
+ gp_segment_id | test_send_metadata 
+---------------+--------------------
+             0 |                 42
+             1 |                 42
+             2 |                 42
+(3 rows)
+
+rollback;

--- a/src/test/modules/test_metadata/sql/test_metadata.sql
+++ b/src/test/modules/test_metadata/sql/test_metadata.sql
@@ -1,0 +1,80 @@
+create extension if not exists test_metadata;
+
+begin;
+-- Create two queues
+SELECT test_create_metadata_queue() as queue1
+\gset
+SELECT test_create_metadata_queue() as queue2
+\gset
+
+-- Test on all segments
+SELECT gp_segment_id, test_send_metadata(150, gp_segment_id, :queue1)
+    FROM gp_dist_random('gp_id');
+
+-- Read metadata collected on coordinator
+SELECT test_check_metadata(:queue1);
+SELECT test_check_metadata(:queue2);
+
+-- Clean metadata on coordinator
+SELECT test_clean_metadata(:queue1);
+
+-- Check that metadata has been cleaned on coordinator
+SELECT test_check_metadata(:queue1);
+
+-- Test longer metadata
+SELECT gp_segment_id, test_send_metadata(150000, gp_segment_id, :queue1)
+    FROM gp_dist_random('gp_id');
+
+SELECT gp_segment_id, test_send_metadata(1500000, gp_segment_id, :queue2)
+    FROM gp_dist_random('gp_id');
+
+SELECT gp_segment_id, test_send_metadata(15000000, gp_segment_id, :queue1)
+    FROM gp_dist_random('gp_id');
+
+SELECT gp_segment_id, test_send_metadata(150000000, gp_segment_id, :queue2)
+    FROM gp_dist_random('gp_id');
+
+SELECT gp_segment_id, test_send_empty_metadata(:queue1)
+    FROM gp_dist_random('gp_id');
+
+-- Read metadata collected on coordinator
+SELECT test_check_metadata(:queue1);
+SELECT test_check_metadata(:queue2);
+
+SELECT test_count_metadata(:queue1);
+SELECT test_count_metadata(:queue2);
+
+SELECT test_clean_metadata(:queue1);
+SELECT test_clean_metadata(:queue2);
+
+SELECT test_check_metadata(:queue1);
+SELECT test_check_metadata(:queue2);
+
+SELECT test_count_metadata(:queue1);
+SELECT test_count_metadata(:queue2);
+
+-- Delete two queues
+SELECT test_delete_metadata_queue(:queue1);
+SELECT test_delete_metadata_queue(:queue2);
+
+commit;
+
+-- Test error in transaction handling
+begin;
+SELECT test_create_metadata_queue() as queue1
+\gset
+
+SELECT gp_segment_id, test_send_metadata(42, gp_segment_id, :queue1)
+    FROM gp_dist_random('gp_id');
+
+SELECT 1/0; -- Error
+
+rollback;
+
+-- Test sending to non-existent queue
+begin;
+
+SELECT gp_segment_id, test_send_metadata(42, gp_segment_id, 10000)
+    FROM gp_dist_random('gp_id');
+
+rollback;

--- a/src/test/modules/test_metadata/test_metadata--1.0.sql
+++ b/src/test/modules/test_metadata/test_metadata--1.0.sql
@@ -1,0 +1,35 @@
+-- test_metadata--1.0.sql
+CREATE FUNCTION test_create_metadata_queue()
+RETURNS integer
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION test_delete_metadata_queue(IN queue_id int4)
+RETURNS integer
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION test_send_metadata(IN len int4, IN gp_id int4, IN queue_id int4)
+RETURNS integer
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION test_send_empty_metadata(IN queue_id int4)
+RETURNS integer
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION test_check_metadata(IN queue_id int4)
+RETURNS integer
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION test_count_metadata(IN queue_id int4)
+RETURNS integer
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION test_clean_metadata(IN queue_id int4)
+RETURNS integer
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;

--- a/src/test/modules/test_metadata/test_metadata.c
+++ b/src/test/modules/test_metadata/test_metadata.c
@@ -1,0 +1,153 @@
+#include "postgres.h"
+#include "fmgr.h"
+#include "libpq/pqcomm.h"
+#include "utils/builtins.h"
+#include "libpq/libpq.h"
+#include "cdb/cdbvars.h"
+#include "cdb/cdbutil.h"
+#include "cdb/cdbconn.h"
+
+PG_MODULE_MAGIC;
+
+PG_FUNCTION_INFO_V1(test_create_metadata_queue);
+PG_FUNCTION_INFO_V1(test_delete_metadata_queue);
+PG_FUNCTION_INFO_V1(test_send_empty_metadata);
+PG_FUNCTION_INFO_V1(test_send_metadata);
+PG_FUNCTION_INFO_V1(test_check_metadata);
+PG_FUNCTION_INFO_V1(test_count_metadata);
+PG_FUNCTION_INFO_V1(test_clean_metadata);
+
+Datum
+test_create_metadata_queue(PG_FUNCTION_ARGS)
+{
+	ggMetadataQueueId queue_id = PQMetadataNextQueueId();
+
+	PQCreateMetadataQueue(queue_id);
+
+	PG_RETURN_INT32(queue_id);
+}
+
+Datum
+test_delete_metadata_queue(PG_FUNCTION_ARGS)
+{
+	ggMetadataQueueId queue_id = PG_GETARG_INT32(0);
+
+	PQDeleteMetadataQueue(queue_id);
+
+	PG_RETURN_INT32(0);
+}
+
+Datum
+test_send_empty_metadata(PG_FUNCTION_ARGS)
+{
+	ggMetadataQueueId queue_id = PG_GETARG_INT32(0);
+
+	elog(WARNING, "Sending empty metadata...");
+	pq_metadatasend("", 0, queue_id);
+	elog(WARNING, "Empty metadata sent!");
+	PG_RETURN_INT32(0);
+}
+
+Datum
+test_send_metadata(PG_FUNCTION_ARGS)
+{
+	uint32		len = PG_GETARG_UINT32(0);
+	uint32		id = PG_GETARG_UINT32(1);
+	ggMetadataQueueId queue_id = PG_GETARG_INT32(2);
+
+	char	   *metadata = palloc(len);
+
+	if (len > sizeof(uint32))
+	{
+		metadata[0] = id % 256;
+
+		for (int i = 1; i < len; i++)
+		{
+			metadata[i] = (len + id - i) % 255;
+		}
+	}
+
+	/*
+	 * Send custom metadata, do not log when wrong queue test performed,
+	 * to not clutter output and deal with output lines ordering.
+	 */
+	if (queue_id != 10000)
+		elog(WARNING, "Sending custom metadata...");
+	pq_metadatasend(metadata, len, queue_id);
+	if (queue_id != 10000)
+		elog(WARNING, "Custom metadata sent!");
+
+	pfree(metadata);
+
+	/* Return a simple result */
+	PG_RETURN_INT32(len);
+}
+
+Datum
+test_check_metadata(PG_FUNCTION_ARGS)
+{
+	Assert(Gp_role == GP_ROLE_DISPATCH);
+	ggMetadataQueueId queue_id = PG_GETARG_INT32(0);
+
+	/*
+	 * Metadata records are unordered for the each query, so to make
+	 * predictable results, make them in few passes
+	 */
+
+	int			numsegments = getgpsegmentCount();
+	int			count = 0;
+
+	for (int seg_id = -1; seg_id < numsegments; seg_id++)
+	{
+		ggMetadataChunkIterator it = PQMetadataWalk(queue_id);
+
+		for (; it; it = PQgetNextMetadata(it))
+		{
+			int32		id = -1;
+			ggMetadataDescriptor metadata;
+
+			PQgetMetadata(it, &metadata);
+
+			if (metadata.metadataLen > 0)
+			{
+				id = ((char *)metadata.data)[0];
+
+				Assert(id == metadata.segindex);
+
+				for (int i = 1; (id == seg_id) && (i < metadata.metadataLen); i++)
+				{
+					char		expected = (metadata.metadataLen + id - i) % 255;
+
+					if (((char *)metadata.data)[i] != expected)
+						elog(ERROR, "Metadata is BAD");
+				}
+			}
+
+			if (seg_id == id)
+			{
+				elog(WARNING, "Custom metadata received, len=%d, id=%d", metadata.metadataLen, id);
+				count++;
+			}
+		}
+
+	}
+	PG_RETURN_INT32(count);
+}
+
+Datum
+test_count_metadata(PG_FUNCTION_ARGS)
+{
+	ggMetadataQueueId queue_id = PG_GETARG_INT32(0);
+	int			count = PQgetMetadataCount(queue_id);
+
+	PG_RETURN_INT32(count);
+}
+
+Datum
+test_clean_metadata(PG_FUNCTION_ARGS)
+{
+	ggMetadataQueueId queue_id = PG_GETARG_INT32(0);
+
+	PQCleanMetadata(queue_id);
+	PG_RETURN_INT32(0);
+}

--- a/src/test/modules/test_metadata/test_metadata.control
+++ b/src/test/modules/test_metadata/test_metadata.control
@@ -1,0 +1,6 @@
+# test_metadata.control
+comment = 'Test extension for custom protocol metadata'
+default_version = '1.0'
+module_pathname = '$libdir/test_metadata'
+relocatable = false
+schema = public


### PR DESCRIPTION
This patch is to add possibility of sending some arbitrary binary data 
(metadata) from backends to the frontend. In out particular case it could
be segment and coordinator.

The data is sent using direct libpq messages with M as a message type. Format 
of the message is pretty simple - just message length and message body.

To send messages there is a new API function pq_metadatasend which can be called 
from an extension.

The messages are processed on the frontend (coordinator in our case) side,
and collected into a linked list ggMetadataList in the cdbconn.c.

The code for message processing is inspired by the notice processing mechanism 
which works in a similar way. To lower the number of allocations,
flexible array is used.

To test the new API there is a test extension and a code for retrieving messages
implemented as well. This code uses methods PQMetadataWalk, PQgetNextMetadata, 
PQgetMetadata and PQCleanMetadata. These methods can be called from an extension 
as well.

New metadata API is available only at the backend (no FRONTEND macro defined).

ADBDEV-9854

(cherry picked from commit 907059a)

Changes from the original commit: resolved few minor conflicts.

GG-627