### PR TITLE
Implement API for sparse deforming of TupleTableSlot

### DIFF
--- a/.abi-check/7.4.1/postgres.symbols.ignore
+++ b/.abi-check/7.4.1/postgres.symbols.ignore
@@ -1,1 +1,5 @@
 ConfigureNamesBool_gp
+TTSOpsBufferHeapTuple
+TTSOpsHeapTuple
+TTSOpsMinimalTuple
+TTSOpsVirtual

--- a/src/backend/executor/execExpr.c
+++ b/src/backend/executor/execExpr.c
@@ -60,6 +60,8 @@ typedef struct ExprSetupInfo
 	AttrNumber	last_inner;
 	AttrNumber	last_outer;
 	AttrNumber	last_scan;
+	/* All attribute numbers fetched from scan tuple slots: */
+	Bitmapset  *all_scan_attrs;
 	/* MULTIEXPR SubPlan nodes appearing in the expression: */
 	List	   *multiexpr_subplans;
 } ExprSetupInfo;
@@ -2366,7 +2368,7 @@ ExecInitFunc(ExprEvalStep *scratch, Expr *node, List *args, Oid funcid,
 static void
 ExecCreateExprSetupSteps(ExprState *state, Node *node)
 {
-	ExprSetupInfo info = {0, 0, 0, NIL};
+	ExprSetupInfo info = {0, 0, 0, NULL, NIL};
 
 	/* Prescan to find out what we need. */
 	expr_setup_walker(node, &info);
@@ -2396,6 +2398,7 @@ ExecPushExprSetupSteps(ExprState *state, ExprSetupInfo *info)
 	{
 		scratch.opcode = EEOP_INNER_FETCHSOME;
 		scratch.d.fetch.last_var = info->last_inner;
+		scratch.d.fetch.all_vars = NULL;
 		scratch.d.fetch.fixed = false;
 		scratch.d.fetch.kind = NULL;
 		scratch.d.fetch.known_desc = NULL;
@@ -2406,6 +2409,7 @@ ExecPushExprSetupSteps(ExprState *state, ExprSetupInfo *info)
 	{
 		scratch.opcode = EEOP_OUTER_FETCHSOME;
 		scratch.d.fetch.last_var = info->last_outer;
+		scratch.d.fetch.all_vars = NULL;
 		scratch.d.fetch.fixed = false;
 		scratch.d.fetch.kind = NULL;
 		scratch.d.fetch.known_desc = NULL;
@@ -2416,6 +2420,7 @@ ExecPushExprSetupSteps(ExprState *state, ExprSetupInfo *info)
 	{
 		scratch.opcode = EEOP_SCAN_FETCHSOME;
 		scratch.d.fetch.last_var = info->last_scan;
+		scratch.d.fetch.all_vars = info->all_scan_attrs;
 		scratch.d.fetch.fixed = false;
 		scratch.d.fetch.kind = NULL;
 		scratch.d.fetch.known_desc = NULL;
@@ -2486,6 +2491,10 @@ expr_setup_walker(Node *node, ExprSetupInfo *info)
 
 			default:
 				info->last_scan = Max(info->last_scan, attnum);
+				if (attnum > 0)
+				{
+					info->all_scan_attrs = bms_add_member(info->all_scan_attrs, attnum - 1);
+				}
 				break;
 		}
 		return false;
@@ -3297,7 +3306,7 @@ ExecBuildAggTrans(AggState *aggstate, AggStatePerPhase phase,
 	ExprEvalStep scratch = {0};
 	int			transno = 0;
 	int			setoff = 0;
-	ExprSetupInfo deform = {0, 0, 0, NIL};
+	ExprSetupInfo deform = {0, 0, 0, NULL, NIL};
 
 	state->expr = (Expr *) aggstate;
 	state->parent = parent;

--- a/src/backend/executor/execExpr.c
+++ b/src/backend/executor/execExpr.c
@@ -2492,9 +2492,7 @@ expr_setup_walker(Node *node, ExprSetupInfo *info)
 			default:
 				info->last_scan = Max(info->last_scan, attnum);
 				if (attnum > 0)
-				{
 					info->all_scan_attrs = bms_add_member(info->all_scan_attrs, attnum - 1);
-				}
 				break;
 		}
 		return false;

--- a/src/backend/executor/execExprInterp.c
+++ b/src/backend/executor/execExprInterp.c
@@ -456,7 +456,8 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 		{
 			CheckOpSlotCompatibility(op, scanslot);
 
-			slot_getsomeattrs(scanslot, op->d.fetch.last_var);
+			if (!slot_gettargetattr(scanslot, op->d.fetch.all_vars))
+				slot_getsomeattrs(scanslot, op->d.fetch.last_var);
 
 			EEO_NEXT();
 		}
@@ -497,7 +498,7 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 
 			/* See EEOP_INNER_VAR comments */
 
-			Assert(attnum >= 0 && attnum < scanslot->tts_nvalid);
+			Assert(attnum >= 0 && slot_is_attr_valid(scanslot, attnum));
 			*op->resvalue = scanslot->tts_values[attnum];
 			*op->resnull = scanslot->tts_isnull[attnum];
 
@@ -573,7 +574,7 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 			 * We do not need CheckVarSlotCompatibility here; that was taken
 			 * care of at compilation time.  But see EEOP_INNER_VAR comments.
 			 */
-			Assert(attnum >= 0 && attnum < scanslot->tts_nvalid);
+			Assert(attnum >= 0 && slot_is_attr_valid(scanslot, attnum));
 			Assert(resultnum >= 0 && resultnum < resultslot->tts_tupleDescriptor->natts);
 			resultslot->tts_values[resultnum] = scanslot->tts_values[attnum];
 			resultslot->tts_isnull[resultnum] = scanslot->tts_isnull[attnum];

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -1052,7 +1052,10 @@ const TupleTableSlotOps TTSOpsVirtual = {
 	.get_heap_tuple = NULL,
 	.get_minimal_tuple = NULL,
 	.copy_heap_tuple = tts_virtual_copy_heap_tuple,
-	.copy_minimal_tuple = tts_virtual_copy_minimal_tuple
+	.copy_minimal_tuple = tts_virtual_copy_minimal_tuple,
+
+	.gettargetattr = NULL,
+	.is_attr_valid = NULL
 };
 
 const TupleTableSlotOps TTSOpsHeapTuple = {
@@ -1069,7 +1072,10 @@ const TupleTableSlotOps TTSOpsHeapTuple = {
 	/* A heap tuple table slot can not "own" a minimal tuple. */
 	.get_minimal_tuple = NULL,
 	.copy_heap_tuple = tts_heap_copy_heap_tuple,
-	.copy_minimal_tuple = tts_heap_copy_minimal_tuple
+	.copy_minimal_tuple = tts_heap_copy_minimal_tuple,
+
+	.gettargetattr = NULL,
+	.is_attr_valid = NULL
 };
 
 const TupleTableSlotOps TTSOpsMinimalTuple = {
@@ -1086,7 +1092,10 @@ const TupleTableSlotOps TTSOpsMinimalTuple = {
 	.get_heap_tuple = NULL,
 	.get_minimal_tuple = tts_minimal_get_minimal_tuple,
 	.copy_heap_tuple = tts_minimal_copy_heap_tuple,
-	.copy_minimal_tuple = tts_minimal_copy_minimal_tuple
+	.copy_minimal_tuple = tts_minimal_copy_minimal_tuple,
+
+	.gettargetattr = NULL,
+	.is_attr_valid = NULL
 };
 
 const TupleTableSlotOps TTSOpsBufferHeapTuple = {
@@ -1103,7 +1112,10 @@ const TupleTableSlotOps TTSOpsBufferHeapTuple = {
 	/* A buffer heap tuple table slot can not "own" a minimal tuple. */
 	.get_minimal_tuple = NULL,
 	.copy_heap_tuple = tts_buffer_heap_copy_heap_tuple,
-	.copy_minimal_tuple = tts_buffer_heap_copy_minimal_tuple
+	.copy_minimal_tuple = tts_buffer_heap_copy_minimal_tuple,
+
+	.gettargetattr = NULL,
+	.is_attr_valid = NULL
 };
 
 
@@ -1933,6 +1945,22 @@ slot_getsomeattrs_int(TupleTableSlot *slot, int attnum)
 		slot_getmissingattrs(slot, slot->tts_nvalid, attnum);
 		slot->tts_nvalid = attnum;
 	}
+}
+
+/*
+ * slot_gettargetattr - fetch exactly the given (possibly sparse) set of
+ * attributes, for slot types that support it (see TupleTableSlotOps).
+ *
+ * Returns false, doing nothing, if the slot type has no gettargetattr
+ * callback, so the caller can fall back to slot_getsomeattrs().
+ */
+bool
+slot_gettargetattr(TupleTableSlot *slot, Bitmapset *attrs)
+{
+	if (NULL == slot->tts_ops->gettargetattr)
+		return false;
+
+	return slot->tts_ops->gettargetattr(slot, attrs);
 }
 
 /* ----------------------------------------------------------------

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -1957,7 +1957,7 @@ slot_getsomeattrs_int(TupleTableSlot *slot, int attnum)
 bool
 slot_gettargetattr(TupleTableSlot *slot, Bitmapset *attrs)
 {
-	if (NULL == slot->tts_ops->gettargetattr)
+	if (slot->tts_ops->gettargetattr == NULL)
 		return false;
 
 	return slot->tts_ops->gettargetattr(slot, attrs);

--- a/src/backend/jit/llvm/llvmjit.c
+++ b/src/backend/jit/llvm/llvmjit.c
@@ -98,6 +98,7 @@ LLVMTypeRef StructAggState;
 LLVMTypeRef StructAggStatePerGroupData;
 LLVMTypeRef StructAggStatePerTransData;
 LLVMTypeRef StructPlanState;
+LLVMTypeRef StructBitmapset;
 
 LLVMValueRef AttributeTemplate;
 LLVMValueRef ExecEvalSubroutineTemplate;
@@ -1179,6 +1180,7 @@ llvm_create_types(void)
 	StructAggStatePerTransData = llvm_pg_var_type("StructAggStatePerTransData");
 	StructPlanState = llvm_pg_var_type("StructPlanState");
 	StructMinimalTupleData = llvm_pg_var_type("StructMinimalTupleData");
+	StructBitmapset = llvm_pg_var_type("StructBitmapset");
 
 	AttributeTemplate = LLVMGetNamedFunction(llvm_types_module, "AttributeTemplate");
 	ExecEvalSubroutineTemplate = LLVMGetNamedFunction(llvm_types_module, "ExecEvalSubroutineTemplate");

--- a/src/backend/jit/llvm/llvmjit_expr.c
+++ b/src/backend/jit/llvm/llvmjit_expr.c
@@ -343,7 +343,7 @@ llvm_compile_expr(ExprState *state)
 
 						v_params[0] = v_slot;
 						v_params[1] = l_ptr_const(op->d.fetch.all_vars,
-												   l_ptr(StructBitmapset));
+												  l_ptr(StructBitmapset));
 
 						v_ret = l_call(b,
 									   llvm_pg_var_func_type("slot_gettargetattr"),

--- a/src/backend/jit/llvm/llvmjit_expr.c
+++ b/src/backend/jit/llvm/llvmjit_expr.c
@@ -322,6 +322,43 @@ llvm_compile_expr(ExprState *state)
 						v_slot = v_scanslot;
 
 					/*
+					 * For scan slots where the exact (possibly sparse) set
+					 * of required attnos is known, try slot_gettargetattr()
+					 * first: slot types that support it fetch just those
+					 * attributes and can skip the nvalid-prefix based deform
+					 * below entirely.
+					 * If the slot type doesn't support it,
+					 * slot_gettargetattr() returns false and we fall
+					 * through to the regular check, exactly mirroring the
+					 * EEOP_SCAN_FETCHSOME handling in ExecInterpExpr().
+					 */
+					if (opcode == EEOP_SCAN_FETCHSOME && op->d.fetch.all_vars)
+					{
+						LLVMBasicBlockRef b_nvalid_check;
+						LLVMValueRef v_params[2];
+						LLVMValueRef v_ret;
+
+						b_nvalid_check = l_bb_before_v(b_fetch,
+													   "op.%d.nvalid_check", i);
+
+						v_params[0] = v_slot;
+						v_params[1] = l_ptr_const(op->d.fetch.all_vars,
+												   l_ptr(StructBitmapset));
+
+						v_ret = l_call(b,
+									   llvm_pg_var_func_type("slot_gettargetattr"),
+									   llvm_pg_func(mod, "slot_gettargetattr"),
+									   v_params, lengthof(v_params), "");
+
+						LLVMBuildCondBr(b,
+										LLVMBuildICmp(b, LLVMIntNE, v_ret,
+													  LLVMConstNull(LLVMTypeOf(v_ret)), ""),
+										opblocks[i + 1], b_nvalid_check);
+
+						LLVMPositionBuilderAtEnd(b, b_nvalid_check);
+					}
+
+					/*
 					 * Check if all required attributes are available, or
 					 * whether deforming is required.
 					 *

--- a/src/backend/jit/llvm/llvmjit_types.c
+++ b/src/backend/jit/llvm/llvmjit_types.c
@@ -68,6 +68,7 @@ MinimalTupleTableSlot StructMinimalTupleTableSlot;
 TupleDescData StructTupleDescData;
 PlanState	StructPlanState;
 MinimalTupleData StructMinimalTupleData;
+Bitmapset	StructBitmapset;
 
 
 /*
@@ -125,6 +126,7 @@ void	   *referenced_functions[] =
 	strlen,
 	varsize_any,
 	slot_getsomeattrs_int,
+	slot_gettargetattr,
 	slot_getmissingattrs,
 	MakeExpandedObjectReadOnlyInternal,
 	ExecEvalSubscriptingRef,

--- a/src/include/executor/execExpr.h
+++ b/src/include/executor/execExpr.h
@@ -289,6 +289,8 @@ typedef struct ExprEvalStep
 			TupleDesc	known_desc;
 			/* type of slot, can only be relied upon if fixed is set */
 			const TupleTableSlotOps *kind;
+			/* all att numbers to fetch (if NULL, use `last_var`) */
+			Bitmapset  *all_vars;
 		}			fetch;
 
 		/* for EEOP_INNER/OUTER/SCAN_[SYS]VAR[_FIRST] */

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -118,7 +118,13 @@ typedef struct TupleTableSlot
 #define FIELDNO_TUPLETABLESLOT_FLAGS 1
 	uint16		tts_flags;		/* Boolean states */
 #define FIELDNO_TUPLETABLESLOT_NVALID 2
-	AttrNumber	tts_nvalid;		/* # of valid values in tts_values */
+	/*
+	 * # of valid values in tts_values. Entry in tts_values with index
+	 * below tts_nvalid is guaranteed to be valid. But other entries in
+	 * tts_values *may* be valid (if fetched via slot_gettargetattr()) and
+	 * their validity can be checked via slot_is_attr_valid().
+	 */
+	AttrNumber	tts_nvalid;
 	const TupleTableSlotOps *const tts_ops; /* implementation of slot */
 #define FIELDNO_TUPLETABLESLOT_TUPLEDESCRIPTOR 4
 	TupleDesc	tts_tupleDescriptor;	/* slot's tuple descriptor */
@@ -214,6 +220,17 @@ struct TupleTableSlotOps
 	 * consumed by the slot.
 	 */
 	MinimalTuple (*copy_minimal_tuple) (TupleTableSlot *slot);
+
+	/*
+	 * Fill up target entries of tts_values and tts_isnull arrays with
+	 * values from the tuple contained in the slot.
+	 */
+	bool		(*gettargetattr) (TupleTableSlot *slot, Bitmapset *attrs);
+
+	/*
+	 * Check if value for attnum in tts_values and tts_isnull arrays is valid.
+	 */
+	bool		(*is_attr_valid) (TupleTableSlot *slot, int attnum);
 };
 
 /*
@@ -328,6 +345,7 @@ extern Datum ExecFetchSlotHeapTupleDatum(TupleTableSlot *slot);
 extern void slot_getmissingattrs(TupleTableSlot *slot, int startAttNum,
 								 int lastAttNum);
 extern void slot_getsomeattrs_int(TupleTableSlot *slot, int attnum);
+extern bool slot_gettargetattr(TupleTableSlot *slot, Bitmapset *attrs);
 
 extern MemTuple appendonly_form_memtuple(TupleTableSlot *slot, MemTupleBinding *mt_bind);
 extern void appendonly_free_memtuple(MemTuple tuple);
@@ -358,6 +376,20 @@ slot_getallattrs(TupleTableSlot *slot)
 	slot_getsomeattrs(slot, slot->tts_tupleDescriptor->natts);
 }
 
+/*
+ * This function checks if Datum/isnull array value for attnum is valid.
+ */
+static inline bool
+slot_is_attr_valid(TupleTableSlot *slot, int attnum)
+{
+	if (slot->tts_nvalid > attnum)
+		return true;
+
+	if (slot->tts_ops->is_attr_valid)
+		return slot->tts_ops->is_attr_valid(slot, attnum);
+
+	return false;
+}
 
 /*
  * slot_attisnull

--- a/src/include/jit/llvmjit.h
+++ b/src/include/jit/llvmjit.h
@@ -94,6 +94,7 @@ extern LLVMTypeRef StructExprState;
 extern LLVMTypeRef StructAggState;
 extern LLVMTypeRef StructAggStatePerTransData;
 extern LLVMTypeRef StructAggStatePerGroupData;
+extern LLVMTypeRef StructBitmapset;
 
 extern LLVMValueRef AttributeTemplate;
 extern LLVMValueRef ExecEvalSubroutineTemplate;


### PR DESCRIPTION
Implement API for sparse deforming of TupleTableSlot

This patch introduces a generic, optional extension point on
`TupleTableSlotOps` that lets a slot type fetch a sparse, caller-specified
set of attributes instead of the built-in "deform everything up to the
highest referenced attribute" (`tts_nvalid`-prefix) convention, and wires
that capability through both the plain expression interpreter and the LLVM
JIT expression compiler. This capability is required to avoid unnecessary
deforming for column-oriented storage engines.

Behavior for existing 'TTSOpsVirtual', 'TTSOpsHeapTuple', 'TTSOpsMinimalTuple',
and 'TTSOpsBufferHeapTuple' is unchanged.

This infrastructural change will later be utilized by Greengage-specific code
for AOCS tables.