### PR TITLE
CI-6025 Add RHEL9 and RedOS8.0 support

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -132,6 +132,7 @@ astra1.8_x86_64_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapreduce 
 rhel7_x86_64_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml --with-pythonsrc-ext --with-uuid=e2fs
 rhel7_ppc64le_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml --with-pythonsrc-ext --with-uuid=e2fs
 rhel8_x86_64_CONFIGFLAGS=--disable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml --with-pythonsrc-ext --with-uuid=e2fs
+rhel9_x86_64_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml --with-pythonsrc-ext --with-uuid=e2fs
 rocky8_x86_64_CONFIGFLAGS=--with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --enable-gpcloud --with-libxml --with-openssl --with-pam --with-ldap --with-pythonsrc-ext --with-uuid=e2fs
 rocky9_x86_64_CONFIGFLAGS=--disable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml --with-pythonsrc-ext --with-uuid=e2fs
 linux_x86_64_CONFIGFLAGS=${ORCA_CONFIG} --with-libxml --with-pythonsrc-ext --with-uuid=e2fs
@@ -141,6 +142,7 @@ ubuntu22.04_x86_64_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapredu
 ubuntu24.04_x86_64_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml --with-pythonsrc-ext --with-uuid=e2fs
 sles12_x86_64_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml --with-pythonsrc-ext --with-uuid=e2fs
 redos7.3_x86_64_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml --with-pythonsrc-ext --with-uuid=e2fs
+redos8.0_x86_64_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml --with-pythonsrc-ext --with-uuid=e2fs
 BLD_CONFIGFLAGS=$($(BLD_ARCH)_CONFIGFLAGS)
 
 CONFIGFLAGS=$(strip $(BLD_CONFIGFLAGS) --with-pgport=$(DEFPORT) $(BLD_DEPLOYMENT_SETTING))

--- a/gpAux/Makefile.global
+++ b/gpAux/Makefile.global
@@ -46,6 +46,7 @@ export NO_M64=1
 rhel6_x86_64_BLD_CFLAGS=-m64 -gdwarf-2 -gstrict-dwarf
 rhel7_x86_64_BLD_CFLAGS=-m64
 rhel8_x86_64_BLD_CFLAGS=-m64
+rhel9_x86_64_BLD_CFLAGS=-m64
 rhel7_ppc64le_BLD_CFLAGS=-m64 -fasynchronous-unwind-tables -fsigned-char
 rocky8_x86_64_BLD_CFLAGS=-m64
 rocky9_x86_64_BLD_CFLAGS=-m64
@@ -56,6 +57,7 @@ astra1.8_x86_64_BLD_CFLAGS=-m64
 ubuntu22.04_x86_64_BLD_CFLAGS=-m64
 ubuntu24.04_x86_64_BLD_CFLAGS=-m64
 redos7.3_x86_64_BLD_CFLAGS=-m64
+redos8.0_x86_64_BLD_CFLAGS=-m64
 BLD_CFLAGS=$($(BLD_ARCH)_BLD_CFLAGS)
 
 BLD_LDFLAGS=$($(BLD_ARCH)_BLD_LDFLAGS)


### PR DESCRIPTION
Add support for several distros

- RedHat 9 support
- RedOS 8.0 support

Ticket: CI-6025

RedOS 8.0 pg_config output:
```
BINDIR = /usr/lib/gpdb/bin
DOCDIR = /usr/lib/gpdb/share/doc/postgresql
HTMLDIR = /usr/lib/gpdb/share/doc/postgresql
INCLUDEDIR = /usr/lib/gpdb/include
PKGINCLUDEDIR = /usr/lib/gpdb/include/postgresql
INCLUDEDIR-SERVER = /usr/lib/gpdb/include/postgresql/server
LIBDIR = /usr/lib/gpdb/lib
PKGLIBDIR = /usr/lib/gpdb/lib/postgresql
LOCALEDIR = /usr/lib/gpdb/share/locale
MANDIR = /usr/lib/gpdb/man
SHAREDIR = /usr/lib/gpdb/share/postgresql
SYSCONFDIR = /usr/lib/gpdb/etc/postgresql
PGXS = /usr/lib/gpdb/lib/postgresql/pgxs/src/makefiles/pgxs.mk
CONFIGURE = '--enable-gpperfmon' '--with-gssapi' '--enable-mapreduce' '--enable-orafce' '--enable-ic-proxy' '--enable-orca' '--with-libxml' '--with-pythonsrc-ext' '--with-uuid=e2fs' '--with-pgport=5432' '--with-perl' '--with-python' '--with-libxslt' '--with-openssl' '--with-pam' '--with-ldap' '--with-includes=/opt/zstd/usr/include/' '--with-libraries=/opt/zstd/usr/lib/' '--disable-rpath' 'LDFLAGS=-Wl,--enable-new-dtags -Wl,-rpath,$ORIGIN/../lib' '--prefix=/usr/lib/gpdb' '--mandir=/usr/lib/gpdb/man' 'CC=gcc -m64' 'CFLAGS=-m64 -O3 -fargument-noalias-global -fno-omit-frame-pointer -g'
CC = gcc -m64
CPPFLAGS = -D_GNU_SOURCE -I/usr/include/libxml2 -I/opt/zstd/usr/include/ -I/usr/lib/gpdb/include
CFLAGS = -Wall -Wmissing-prototypes -Wpointer-arith -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -fno-aggressive-loop-optimizations -Wno-unused-but-set-variable -Wno-address -Werror=implicit-fallthrough=3 -Wno-format-truncation -Wno-stringop-truncation -m64 -O3 -fargument-noalias-global -fno-omit-frame-pointer -g -std=gnu99 -Werror=uninitialized -Werror=implicit-function-declaration -I/usr/lib/gpdb/include
CFLAGS_SL = -fPIC
LDFLAGS = -Wl,--enable-new-dtags -Wl,-rpath,$ORIGIN/../lib -L/opt/zstd/usr/lib/ -Wl,--as-needed -L/usr/lib/gpdb/lib
LDFLAGS_EX = 
LDFLAGS_SL = 
LIBS = -lpgcommon -lpgport -lxerces-c -lxslt -lxml2 -lpam -lrt -lyaml -lgssapi_krb5 -luv -l:libzstd.a -lcrypt -lm -L/usr/lib/gpdb/lib
VERSION = PostgreSQL 9.4.26
GP_VERSION = Greengage 6.31.0_arenadata71 build 4914.gitaa53193487d.red80
```

RHEL9 pg_config output:
```
BINDIR = /usr/lib/gpdb/bin
DOCDIR = /usr/lib/gpdb/share/doc/postgresql
HTMLDIR = /usr/lib/gpdb/share/doc/postgresql
INCLUDEDIR = /usr/lib/gpdb/include
PKGINCLUDEDIR = /usr/lib/gpdb/include/postgresql
INCLUDEDIR-SERVER = /usr/lib/gpdb/include/postgresql/server
LIBDIR = /usr/lib/gpdb/lib
PKGLIBDIR = /usr/lib/gpdb/lib/postgresql
LOCALEDIR = /usr/lib/gpdb/share/locale
MANDIR = /usr/lib/gpdb/man
SHAREDIR = /usr/lib/gpdb/share/postgresql
SYSCONFDIR = /usr/lib/gpdb/etc/postgresql
PGXS = /usr/lib/gpdb/lib/postgresql/pgxs/src/makefiles/pgxs.mk
CONFIGURE = '--enable-gpperfmon' '--with-gssapi' '--enable-mapreduce' '--enable-orafce' '--enable-ic-proxy' '--enable-orca' '--with-libxml' '--with-pythonsrc-ext' '--with-uuid=e2fs' '--with-pgport=5432' '--with-perl' '--with-python' '--with-libxslt' '--with-openssl' '--with-pam' '--with-ldap' '--with-includes=/opt/zstd/usr/include/' '--with-libraries=/opt/zstd/usr/lib/' '--disable-rpath' 'LDFLAGS=-Wl,--enable-new-dtags -Wl,-rpath,$ORIGIN/../lib' '--prefix=/usr/lib/gpdb' '--mandir=/usr/lib/gpdb/man' 'CC=gcc -m64' 'CFLAGS=-m64 -O3 -fargument-noalias-global -fno-omit-frame-pointer -g'
CC = gcc -m64
CPPFLAGS = -D_GNU_SOURCE -I/usr/include/libxml2 -I/opt/zstd/usr/include/ -I/usr/lib/gpdb/include
CFLAGS = -Wall -Wmissing-prototypes -Wpointer-arith -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -fno-aggressive-loop-optimizations -Wno-unused-but-set-variable -Wno-address -Werror=implicit-fallthrough=3 -Wno-format-truncation -Wno-stringop-truncation -m64 -O3 -fargument-noalias-global -fno-omit-frame-pointer -g -std=gnu99 -Werror=uninitialized -Werror=implicit-function-declaration -I/usr/lib/gpdb/include
CFLAGS_SL = -fPIC
LDFLAGS = -Wl,--enable-new-dtags -Wl,-rpath,$ORIGIN/../lib -L/opt/zstd/usr/lib/ -Wl,--as-needed -L/usr/lib/gpdb/lib
LDFLAGS_EX = 
LDFLAGS_SL = 
LIBS = -lpgcommon -lpgport -lxerces-c -lxslt -lxml2 -lpam -lrt -lyaml -lgssapi_krb5 -luv -l:libzstd.a -lcrypt -lm -L/usr/lib/gpdb/lib
VERSION = PostgreSQL 9.4.26
GP_VERSION = Greengage 6.31.0_arenadata71 build 4914.gitaa53193487d.el9
```