### PR TITLE
ADBDEV-7442: Fix error during WAL compression 

### DIFF
--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -641,6 +641,8 @@ XLogRecordAssemble(RmgrId rmid, uint8 info,
 											cbimg.hole_length,
 											regbuf->compressed_page,
 											&compressed_len);
+				if (!is_compressed)
+					elog(LOG, "WAL compression failed, using uncompressed image");
 			}
 
 			/*
@@ -852,7 +854,10 @@ XLogCompressBackupBlock(char *page, uint16 hole_offset, uint16 hole_length,
 	{
 		cxt = ZSTD_createCCtx();
 		if (!cxt)
-			elog(ERROR, "out of memory");
+		{
+			elog(LOG, "out of memory");
+			return false;
+		}
 	}
 
 	len = ZSTD_compressCCtx(cxt,
@@ -861,8 +866,11 @@ XLogCompressBackupBlock(char *page, uint16 hole_offset, uint16 hole_length,
 							COMPRESS_LEVEL);
 
 	if (ZSTD_isError(len))
-		elog(ERROR, "compression failed: %s uncompressed len %d",
+	{
+		elog(LOG, "compression failed: %s uncompressed len %d",
 			 ZSTD_getErrorName(len), orig_len);
+		len = -1;		/* failure */
+	}
 
 	/*
 	 * We recheck the actual size even if ZSTD reports success and

--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -641,8 +641,6 @@ XLogRecordAssemble(RmgrId rmid, uint8 info,
 											cbimg.hole_length,
 											regbuf->compressed_page,
 											&compressed_len);
-				if (!is_compressed)
-					elog(LOG, "WAL compression failed, using uncompressed image");
 			}
 
 			/*

--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -36,6 +36,7 @@
 #ifdef USE_ZSTD
 /* Zstandard library is provided */
 #include <zstd.h>
+#include <zstd_errors.h>
 /* zstandard compression level to use. */
 #define COMPRESS_LEVEL 3
 #endif
@@ -824,6 +825,7 @@ XLogCompressBackupBlock(char *page, uint16 hole_offset, uint16 hole_length,
 {
 #ifdef USE_ZSTD
 	static ZSTD_CCtx  *cxt = NULL;      /* ZSTD compression context */
+	static bool	compression_failure_logged = false;
 	int32		orig_len = BLCKSZ - hole_length;
 	int32		len;
 	int32		extra_bytes = 0;
@@ -853,9 +855,14 @@ XLogCompressBackupBlock(char *page, uint16 hole_offset, uint16 hole_length,
 		cxt = ZSTD_createCCtx();
 		if (!cxt)
 		{
-			elog(LOG, "out of memory");
+			if (!compression_failure_logged)
+			{
+				elog(LOG, "out of memory while allocating ZSTD compression context");
+				compression_failure_logged = true;
+			}
 			return false;
 		}
+		compression_failure_logged = false;
 	}
 
 	len = ZSTD_compressCCtx(cxt,
@@ -865,10 +872,17 @@ XLogCompressBackupBlock(char *page, uint16 hole_offset, uint16 hole_length,
 
 	if (ZSTD_isError(len))
 	{
-		elog(LOG, "compression failed: %s uncompressed len %d",
-			 ZSTD_getErrorName(len), orig_len);
-		len = -1;		/* failure */
+		if (ZSTD_getErrorCode(len) != ZSTD_error_dstSize_tooSmall && !compression_failure_logged)
+		{
+			elog(LOG, "compression failed: %s uncompressed len %d",
+				ZSTD_getErrorName(len), orig_len);
+
+			compression_failure_logged = true;
+		}
+		return false;
 	}
+
+	compression_failure_logged = false;
 
 	/*
 	 * We recheck the actual size even if ZSTD reports success and

--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -30,6 +30,7 @@
 #include "replication/origin.h"
 #include "storage/bufmgr.h"
 #include "storage/proc.h"
+#include "utils/faultinjector.h"
 #include "utils/memutils.h"
 #include "pg_trace.h"
 
@@ -853,6 +854,15 @@ XLogCompressBackupBlock(char *page, uint16 hole_offset, uint16 hole_length,
 	if (!cxt)
 	{
 		cxt = ZSTD_createCCtx();
+
+#ifdef FAULT_INJECTOR
+		/*
+		 * Forget the context to imitate context creation failure, producing 
+		 * an out of memory log record.
+		 */
+		if (SIMPLE_FAULT_INJECTOR("xlog_compress_backup_block") == FaultInjectorTypeSkip)
+			cxt = NULL;
+#endif
 		if (!cxt)
 		{
 			if (!compression_failure_logged)
@@ -865,8 +875,20 @@ XLogCompressBackupBlock(char *page, uint16 hole_offset, uint16 hole_length,
 		compression_failure_logged = false;
 	}
 
+	size_t dest_capacity = BLCKSZ;
+
+#ifdef FAULT_INJECTOR
+	/*
+	 * Shrink the output buffer so ZSTD_compressCCtx() genuinely returns
+	 * ZSTD_error_dstSize_tooSmall below, regardless of how compressible
+	 * the input actually is.
+	 */
+	if (SIMPLE_FAULT_INJECTOR("xlog_compress_backup_block_dstsize_too_small") == FaultInjectorTypeSkip)
+		dest_capacity = 1;
+#endif
+
 	len = ZSTD_compressCCtx(cxt,
-							dest, BLCKSZ,
+							dest, dest_capacity,
 							source, orig_len,
 							COMPRESS_LEVEL);
 

--- a/src/test/isolation2/expected/xlog_compress_backup_block_dstsize_too_small.out
+++ b/src/test/isolation2/expected/xlog_compress_backup_block_dstsize_too_small.out
@@ -1,0 +1,42 @@
+-- ZSTD_compressCCtx() reporting ZSTD_error_dstSize_tooSmall is a routine
+-- outcome (the page just didn't compress small enough to fit), not a real
+-- failure -- it is expected to happen regularly on ordinary data, not only
+-- on pathological input. Verify XLogCompressBackupBlock() still handles it
+-- gracefully: no crash, and the page falls back to being stored
+-- uncompressed.
+SET wal_compression = on;
+SET
+
+-- Force ZSTD_compressCCtx() to genuinely report dstSize_tooSmall on every
+-- call, on every segment, by shrinking its output buffer.
+SELECT gp_inject_fault_infinite('xlog_compress_backup_block_dstsize_too_small', 'skip', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+ Success:                 
+ Success:                 
+(3 rows)
+
+CREATE TABLE xlog_compress_backup_block_dstsize_too_small(a int, b text) DISTRIBUTED BY (a);
+CREATE TABLE
+
+INSERT INTO xlog_compress_backup_block_dstsize_too_small SELECT i, repeat('x', 200) FROM generate_series(1, 3000) i;
+INSERT 0 3000
+
+SELECT gp_inject_fault('xlog_compress_backup_block_dstsize_too_small', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+-- Segments must still be up, and every row must have made it in.
+SELECT count(*) FROM xlog_compress_backup_block_dstsize_too_small;
+ count 
+-------
+ 3000  
+(1 row)
+
+DROP TABLE xlog_compress_backup_block_dstsize_too_small;
+DROP TABLE

--- a/src/test/isolation2/expected/xlog_compress_backup_block_fail.out
+++ b/src/test/isolation2/expected/xlog_compress_backup_block_fail.out
@@ -1,0 +1,40 @@
+-- XLogCompressBackupBlock() used to elog(ERROR) when ZSTD compression of a
+-- full-page image failed. That ERROR happens inside a critical section
+-- during WAL record assembly, so it gets promoted to PANIC and crashes the
+-- segment. Verify that a compression failure is now handled gracefully:
+-- the segment stays up and falls back to storing the page uncompressed.
+SET wal_compression = on;
+SET
+
+-- Force every call to XLogCompressBackupBlock() to fail, on every segment.
+SELECT gp_inject_fault_infinite('xlog_compress_backup_block', 'skip', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+ Success:                 
+ Success:                 
+(3 rows)
+
+CREATE TABLE xlog_compress_backup_block_fail(a int, b text) DISTRIBUTED BY (a);
+CREATE TABLE
+
+INSERT INTO xlog_compress_backup_block_fail SELECT i, repeat('x', 200) FROM generate_series(1, 3000) i;
+INSERT 0 3000
+
+SELECT gp_inject_fault('xlog_compress_backup_block', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+-- Segments must still be up, and every row must have made it in.
+SELECT count(*) FROM xlog_compress_backup_block_fail;
+ count 
+-------
+ 3000  
+(1 row)
+
+DROP TABLE xlog_compress_backup_block_fail;
+DROP TABLE

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -109,6 +109,10 @@ test: pqsignal
 
 test: fsync_ao
 
+# Tests on xlog compression errors
+test: xlog_compress_backup_block_fail
+test: xlog_compress_backup_block_dstsize_too_small
+
 # Disable auto-vacuum for below tests
 test: disable_autovacuum
 

--- a/src/test/isolation2/sql/xlog_compress_backup_block_dstsize_too_small.sql
+++ b/src/test/isolation2/sql/xlog_compress_backup_block_dstsize_too_small.sql
@@ -1,0 +1,25 @@
+-- ZSTD_compressCCtx() reporting ZSTD_error_dstSize_tooSmall is a routine
+-- outcome (the page just didn't compress small enough to fit), not a real
+-- failure -- it is expected to happen regularly on ordinary data, not only
+-- on pathological input. Verify XLogCompressBackupBlock() still handles it
+-- gracefully: no crash, and the page falls back to being stored
+-- uncompressed.
+SET wal_compression = on;
+
+-- Force ZSTD_compressCCtx() to genuinely report dstSize_tooSmall on every
+-- call, on every segment, by shrinking its output buffer.
+SELECT gp_inject_fault_infinite('xlog_compress_backup_block_dstsize_too_small', 'skip', dbid)
+    FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+CREATE TABLE xlog_compress_backup_block_dstsize_too_small(a int, b text) DISTRIBUTED BY (a);
+
+INSERT INTO xlog_compress_backup_block_dstsize_too_small
+    SELECT i, repeat('x', 200) FROM generate_series(1, 3000) i;
+
+SELECT gp_inject_fault('xlog_compress_backup_block_dstsize_too_small', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- Segments must still be up, and every row must have made it in.
+SELECT count(*) FROM xlog_compress_backup_block_dstsize_too_small;
+
+DROP TABLE xlog_compress_backup_block_dstsize_too_small;

--- a/src/test/isolation2/sql/xlog_compress_backup_block_fail.sql
+++ b/src/test/isolation2/sql/xlog_compress_backup_block_fail.sql
@@ -1,0 +1,23 @@
+-- XLogCompressBackupBlock() used to elog(ERROR) when ZSTD compression of a
+-- full-page image failed. That ERROR happens inside a critical section
+-- during WAL record assembly, so it gets promoted to PANIC and crashes the
+-- segment. Verify that a compression failure is now handled gracefully:
+-- the segment stays up and falls back to storing the page uncompressed.
+SET wal_compression = on;
+
+-- Force every call to XLogCompressBackupBlock() to fail, on every segment.
+SELECT gp_inject_fault_infinite('xlog_compress_backup_block', 'skip', dbid)
+    FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+CREATE TABLE xlog_compress_backup_block_fail(a int, b text) DISTRIBUTED BY (a);
+
+INSERT INTO xlog_compress_backup_block_fail
+    SELECT i, repeat('x', 200) FROM generate_series(1, 3000) i;
+
+SELECT gp_inject_fault('xlog_compress_backup_block', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- Segments must still be up, and every row must have made it in.
+SELECT count(*) FROM xlog_compress_backup_block_fail;
+
+DROP TABLE xlog_compress_backup_block_fail;


### PR DESCRIPTION
Sometimes when WAL compression happend, it could produce an error indicating
that destination buffer is too small.
Error occurs because compression produces image, larger than uncompressed one
and larger than destination buffer.
Better way to handle this is to fall back to using uncompressed image.

Return false when it fails to compress WAL, falling back to uncompressed image.
Replace elog(ERROR) with elog(LOG).

No tests because of unpredictable WAL writing and good zstd compression, 
compressing pretty much everything.

Chose cloudberry's patch because it contains more elog messages and is more error-tolerant.

Ticket: ADBDEV-7442

(cherry-picked from commits
apache/cloudberry@55d2cacddbcfa1363a948e82fea3ded8fe247a86,
apache/cloudberry@ec75156498c01d2ef2e228d1782b9b8b6d2c0851)

Patch should be merged with rebase.