### PR TITLE
GG-531: Fix array type name collisions that caused restore errors when upgrading from Greengage 6 to 7

### DIFF
--- a/src/backend/utils/adt/pg_upgrade_support.c
+++ b/src/backend/utils/adt/pg_upgrade_support.c
@@ -26,7 +26,6 @@
 #include "miscadmin.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
-
 #include "utils/memutils.h"
 #include "utils/syscache.h"
 

--- a/src/backend/utils/adt/pg_upgrade_support.c
+++ b/src/backend/utils/adt/pg_upgrade_support.c
@@ -66,11 +66,10 @@ InitCreatedArrayNamesHash()
 static void
 RememberCreatedName(char *typname, Oid schema)
 {
-	CreatedName key;
+	/* Zero out padding bytes for HASH_BLOBS */
+	CreatedName key = {0};
 	if (created_names == NULL)
 		InitCreatedArrayNamesHash();
-	/* Zero out padding bytes for HASH_BLOBS */
-	MemSet(&key, 0, sizeof(CreatedName));
 	key.schema_oid = schema;
 	strlcpy(key.name, typname, NAMEDATALEN);
 	hash_search(created_names, &key, HASH_ENTER, NULL);
@@ -99,7 +98,7 @@ makeArrayTypeNameUpgrade(const char *typeName, Oid typeNamespace)
 		pfree(arr);
 		arr = new_arr;
 
-		MemSet(&key, 0, sizeof(CreatedName));
+		key = (CreatedName) {0};
 		key.schema_oid = typeNamespace;
 		strlcpy(key.name, arr, NAMEDATALEN);
 		if (!hash_search(created_names, &key, HASH_FIND, NULL))
@@ -127,7 +126,7 @@ makeArrayTypeNameUpgrade(const char *typeName, Oid typeNamespace)
 Datum
 binary_upgrade_set_next_pg_type_oid(PG_FUNCTION_ARGS)
 {
-	CreatedName   key;
+	CreatedName   key = {0};
 	MemoryContext oldctx;
 	Oid			typoid = PG_GETARG_OID(0);
 	Oid			typnamespaceoid = PG_GETARG_OID(1);
@@ -144,7 +143,6 @@ binary_upgrade_set_next_pg_type_oid(PG_FUNCTION_ARGS)
 	in_catalog = OidIsValid(old_type_oid);
 
 	oldctx = MemoryContextSwitchTo(TopMemoryContext);
-	MemSet(&key, 0, sizeof(CreatedName));
 	key.schema_oid = typnamespaceoid;
 	strlcpy(key.name, typname, NAMEDATALEN);
 	if (in_catalog || (created_names && hash_search(created_names, &key, HASH_FIND, NULL)))

--- a/src/backend/utils/adt/pg_upgrade_support.c
+++ b/src/backend/utils/adt/pg_upgrade_support.c
@@ -86,35 +86,40 @@ static char *
 makeArrayTypeNameUpgrade(const char *typeName, Oid typeNamespace)
 {
 	CreatedName key;
-	char *arr, *modifiedTypeName;
-	int underscores = 0;
+	char *arr, *new_arr;
+	int iteration = 0;
 
-	modifiedTypeName = palloc(NAMEDATALEN);
-	arr = makeArrayTypeName(typeName, typeNamespace);
-	MemSet(&key, 0, sizeof(CreatedName));
-	key.schema_oid = typeNamespace;
-	strlcpy(key.name, arr, NAMEDATALEN);
-	while (created_names && hash_search(created_names, &key, HASH_FIND, NULL))
+	/* Make sure that the initial name is allocated by us */
+	arr = palloc(NAMEDATALEN);
+	strlcpy(arr, typeName, NAMEDATALEN);
+
+	while (true)
 	{
-		underscores++;
-		/* 
-		 * We tried to create new name NAMEDATALEN times,
-		 * effectivly meaning that it is impossible to create one.
-		 */
-		if (underscores >= NAMEDATALEN)
-			ereport(ERROR,
-				   (errcode(ERRCODE_DUPLICATE_OBJECT),
-					errmsg("could not form array type name for type \"%s\"",
-							typeName)));
-		MemSet(modifiedTypeName, '_', underscores);
-		strlcpy(modifiedTypeName + underscores, typeName, NAMEDATALEN - underscores);
+		new_arr = makeArrayTypeName(arr, typeNamespace);
 		pfree(arr);
-		arr = makeArrayTypeName(modifiedTypeName, typeNamespace);
+		arr = new_arr;
+
 		MemSet(&key, 0, sizeof(CreatedName));
 		key.schema_oid = typeNamespace;
 		strlcpy(key.name, arr, NAMEDATALEN);
+		if (!hash_search(created_names, &key, HASH_FIND, NULL))
+			break;
+
+		if (iteration >= NAMEDATALEN)
+		{
+			/*
+			 * If we end up with a name that consists entirely of underscores
+			 * ((NAMEDATALEN - 1) underscores, and one character for a null terminator),
+			 * and it is not present in the catalog, makeArrayTypeName will return
+			 * this name over and over again, leaving us stack in an infinite loop.
+			 *
+			 * In such case, abort when we know that we've seen every possible name.
+			 */
+			break;
+		}
+
+		iteration += 1;
 	}
-	pfree(modifiedTypeName);
 
 	return arr;
 }
@@ -161,10 +166,7 @@ binary_upgrade_set_next_pg_type_oid(PG_FUNCTION_ARGS)
 		 * happed regardless of what we are doing here, so let's
 		 * not complicate the logic.
 		 */
-		char new_typname[NAMEDATALEN];
-		strlcpy(new_typname, typname, NAMEDATALEN);
-
-		moved_array_typname = makeArrayTypeNameUpgrade(new_typname, typnamespaceoid);
+		moved_array_typname = makeArrayTypeNameUpgrade(typname, typnamespaceoid);
 		RememberCreatedName(moved_array_typname, typnamespaceoid);
 	}
 

--- a/src/backend/utils/adt/pg_upgrade_support.c
+++ b/src/backend/utils/adt/pg_upgrade_support.c
@@ -29,6 +29,7 @@
 #include "utils/memutils.h"
 #include "utils/syscache.h"
 
+
 #define GET_STR(textp) DatumGetCString(DirectFunctionCall1(textout, PointerGetDatum(textp)))
 
 #define CHECK_IS_BINARY_UPGRADE									\
@@ -39,69 +40,40 @@ do {															\
 				 (errmsg("function can only be called when server is in binary upgrade mode")))); \
 } while (0)
 
-typedef struct {
-	List *names;
-	Oid  schema;
-} CreatedNamesPerSchema;
-
-static List *createdArrayNames = NIL;
-
-/*
- * isNamePreassigned
- *     Outputs whether type name arg was already assigned during upgrade.
- */
-static bool
-isNamePreassigned(const char *arr, Oid typeNamespace)
+typedef struct
 {
-	CreatedNamesPerSchema *target = NULL;
-	ListCell *lc;
-	char *name;
-	foreach(lc, createdArrayNames)
-	{
-		CreatedNamesPerSchema *names = lfirst(lc);
-		if (names->schema == typeNamespace)
-		{
-			target = names;
-			break;
-		}
-	}
-	if (target)
-	{
-		foreach (lc, target->names)
-		{
-			name = lfirst(lc);
-			if (strcmp(arr, name) == 0)
-				return true;
-		}
-	}
-	return false;
+	Oid		schema_oid;
+	char	name[NAMEDATALEN];
+} CreatedName;
+
+/* Initialized on the first use in RememberCreatedName() */
+static HTAB *created_names = NULL;
+
+static void
+InitCreatedArrayNamesHash()
+{
+	HASHCTL ctl;
+	MemSet(&ctl, 0, sizeof(ctl));
+	ctl.keysize = sizeof(CreatedName);
+	ctl.entrysize = sizeof(CreatedName);
+	ctl.hcxt = TopMemoryContext;
+	created_names = hash_create("Created names during pg_upgrade",
+								128,
+								&ctl,
+								HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 }
 
 static void
 RememberCreatedName(char *typname, Oid schema)
 {
-	CreatedNamesPerSchema *target = NULL;
-	ListCell *lc;
-	char* persistentTypeName = pstrdup(typname);
-
-	foreach(lc, createdArrayNames)
-	{
-		CreatedNamesPerSchema *names = lfirst(lc);
-		if (names->schema == schema)
-		{
-			target = names;
-			break;
-		}
-	}
-	if (!target)
-	{
-		target = palloc0(sizeof(CreatedNamesPerSchema));
-		target->schema = schema;
-		target->names = NIL;
-		createdArrayNames = lappend(createdArrayNames, target);
-	}
-
-	target->names = lappend(target->names, persistentTypeName);
+	CreatedName key;
+	if (created_names == NULL)
+		InitCreatedArrayNamesHash();
+	/* Zero out padding bytes for HASH_BLOBS */
+	MemSet(&key, 0, sizeof(CreatedName));
+	key.schema_oid = schema;
+	strlcpy(key.name, typname, NAMEDATALEN);
+	hash_search(created_names, &key, HASH_ENTER, NULL);
 }
 
 /*
@@ -113,13 +85,17 @@ RememberCreatedName(char *typname, Oid schema)
 static char *
 makeArrayTypeNameUpgrade(const char *typeName, Oid typeNamespace)
 {
+	CreatedName key;
 	char *arr, *modifiedTypeName;
 	int typeNameLen = strlen(typeName);
 	int underscores = 0;
 
 	modifiedTypeName = palloc(NAMEDATALEN);
 	arr = makeArrayTypeName(typeName, typeNamespace);
-	while (isNamePreassigned(arr, typeNamespace))
+	MemSet(&key, 0, sizeof(CreatedName));
+	key.schema_oid = typeNamespace;
+	strlcpy(key.name, arr, NAMEDATALEN);
+	while (created_names && hash_search(created_names, &key, HASH_FIND, NULL))
 	{
 		underscores++;
 		if (typeNameLen + underscores >= NAMEDATALEN)
@@ -127,9 +103,13 @@ makeArrayTypeNameUpgrade(const char *typeName, Oid typeNamespace)
 				   (errcode(ERRCODE_DUPLICATE_OBJECT),
 					errmsg("could not form array type name for type \"%s\"",
 							typeName)));
-		memset(modifiedTypeName, '_', underscores);
+		MemSet(modifiedTypeName, '_', underscores);
 		strcpy(modifiedTypeName + underscores, typeName);
+		pfree(arr);
 		arr = makeArrayTypeName(modifiedTypeName, typeNamespace);
+		MemSet(&key, 0, sizeof(CreatedName));
+		key.schema_oid = typeNamespace;
+		strlcpy(key.name, arr, NAMEDATALEN);
 	}
 	pfree(modifiedTypeName);
 
@@ -167,25 +147,13 @@ binary_upgrade_set_next_array_pg_type_oid(PG_FUNCTION_ARGS)
 	Oid			typnamespaceoid = PG_GETARG_OID(1);
 	char	   *relname = GET_STR(PG_GETARG_TEXT_P(2));
 	char       *typname;
-	ListCell   *lc;
 
 	CHECK_IS_BINARY_UPGRADE;
 
 	old_type_oid = GetSysCacheOid2(TYPENAMENSP, Anum_pg_type_oid,
 								   CStringGetDatum(relname),
 								   ObjectIdGetDatum(typnamespaceoid));
-
 	exists = OidIsValid(old_type_oid);
-
-	foreach(lc, createdArrayNames)
-	{
-		char *name = (char *) lfirst(lc);
-		if (strcmp(relname, name) == 0)
-		{
-			exists = true;
-			break;
-		}
-	}
 
 	oldctx = MemoryContextSwitchTo(TopMemoryContext);
 	typname = makeArrayTypeNameUpgrade(relname, typnamespaceoid);
@@ -209,7 +177,10 @@ binary_upgrade_set_next_array_pg_type_oid(PG_FUNCTION_ARGS)
 		 * happed regardless of what we are doing here, so let's
 		 * not complicate the logic.
 		 */
-		typname = makeArrayTypeNameUpgrade(typname, typnamespaceoid);
+		char new_typname[NAMEDATALEN];
+		strlcpy(new_typname, typname, NAMEDATALEN);
+		pfree(typname);
+		typname = makeArrayTypeNameUpgrade(new_typname, typnamespaceoid);
 		RememberCreatedName(typname, typnamespaceoid);
 	}
 	MemoryContextSwitchTo(oldctx);

--- a/src/backend/utils/adt/pg_upgrade_support.c
+++ b/src/backend/utils/adt/pg_upgrade_support.c
@@ -101,7 +101,7 @@ makeArrayTypeNameUpgrade(const char *typeName, Oid typeNamespace)
 		key = (CreatedName) {0};
 		key.schema_oid = typeNamespace;
 		strlcpy(key.name, arr, NAMEDATALEN);
-		if (!hash_search(created_names, &key, HASH_FIND, NULL))
+		if (!created_names || !hash_search(created_names, &key, HASH_FIND, NULL))
 			break;
 
 		if (iteration >= NAMEDATALEN)

--- a/src/backend/utils/adt/pg_upgrade_support.c
+++ b/src/backend/utils/adt/pg_upgrade_support.c
@@ -27,6 +27,8 @@
 #include "utils/array.h"
 #include "utils/builtins.h"
 
+#include "utils/memutils.h"
+#include "utils/syscache.h"
 
 #define GET_STR(textp) DatumGetCString(DirectFunctionCall1(textout, PointerGetDatum(textp)))
 
@@ -38,14 +40,148 @@ do {															\
 				 (errmsg("function can only be called when server is in binary upgrade mode")))); \
 } while (0)
 
+typedef struct {
+	List *names;
+	Oid  schema;
+} CreatedNamesPerSchema;
+
+static MemoryContext upgradeCxt = NULL;
+static List *createdArrayNames = NIL;
+
+/*
+ * isNamePreassigned
+ *     Outputs whether type name arg was already assigned during upgrade.
+ */
+static bool
+isNamePreassigned(const char *arr, Oid typeNamespace)
+{
+	CreatedNamesPerSchema *target = NULL;
+	ListCell *lc;
+	char *name;
+	foreach(lc, createdArrayNames)
+	{
+		CreatedNamesPerSchema *names = lfirst(lc);
+		if (names->schema == typeNamespace)
+		{
+			target = names;
+			break;
+		}
+	}
+	if (target)
+	{
+		foreach (lc, target->names)
+		{
+			name = lfirst(lc);
+			if (strcmp(arr, name) == 0)
+				return true;
+		}
+	}
+	return false;
+}
+
+/*
+ * RememberCreatedName
+ *     Stores the typename for future collision detections.
+ */
+static void
+RememberCreatedName(char *typname, Oid schema)
+{
+	Assert(upgradeCxt);
+	CreatedNamesPerSchema *target = NULL;
+	ListCell *lc;
+	char* persistentTypeName = pstrdup(typname);
+
+	foreach(lc, createdArrayNames)
+	{
+		CreatedNamesPerSchema *names = lfirst(lc);
+		if (names->schema == schema)
+		{
+			target = names;
+			break;
+		}
+	}
+	if (!target)
+	{
+		target = palloc0(sizeof(CreatedNamesPerSchema));
+		target->schema = schema;
+		target->names = NIL;
+		createdArrayNames = lappend(createdArrayNames, target);
+	}
+
+	target->names = lappend(target->names, persistentTypeName);
+}
+
+/*
+ * makeArrayTypeNameUpgrade
+ *     A wrapper around makeArrayTypeName, that also checks if the newly
+ *     generated name collides with the ones already assigned
+ *     during upgrade.
+ */
+static char *
+makeArrayTypeNameUpgrade(const char *typeName, Oid typeNamespace)
+{
+	char *arr, *modifiedTypeName;
+	int typeNameLen = strlen(typeName);
+	int underscores = 0;
+
+	modifiedTypeName = palloc(NAMEDATALEN);
+	arr = makeArrayTypeName(typeName, typeNamespace);
+	while (isNamePreassigned(arr, typeNamespace))
+	{
+		underscores++;
+		if (typeNameLen + underscores >= NAMEDATALEN)
+			ereport(ERROR,
+				   (errcode(ERRCODE_DUPLICATE_OBJECT),
+					errmsg("could not form array type name for type \"%s\"", typeName)));
+		memset(modifiedTypeName, '_', underscores);
+		strcpy(modifiedTypeName + underscores, typeName);
+		arr = makeArrayTypeName(modifiedTypeName, typeNamespace);
+	}
+	pfree(modifiedTypeName);
+
+	return arr;
+}
+
+Datum
+binary_upgrade_init(PG_FUNCTION_ARGS)
+{
+	CHECK_IS_BINARY_UPGRADE;
+
+	Assert(!upgradeCxt);
+	if (!upgradeCxt)
+		upgradeCxt = AllocSetContextCreate(TopMemoryContext,
+										   "pg_upgrade temp context",
+										   ALLOCSET_DEFAULT_SIZES);
+
+	PG_RETURN_VOID();
+}
+
+Datum
+binary_upgrade_cleanup(PG_FUNCTION_ARGS)
+{
+	CHECK_IS_BINARY_UPGRADE;
+
+	if (upgradeCxt)
+		MemoryContextDelete(upgradeCxt);
+
+	PG_RETURN_VOID();
+}
+
 Datum
 binary_upgrade_set_next_pg_type_oid(PG_FUNCTION_ARGS)
 {
+	MemoryContext oldctx;
 	Oid			typoid = PG_GETARG_OID(0);
 	Oid			typnamespaceoid = PG_GETARG_OID(1);
 	char	   *typname = GET_STR(PG_GETARG_TEXT_P(2));
 
 	CHECK_IS_BINARY_UPGRADE;
+
+	/* Remember that we've already taken this name */
+	oldctx = MemoryContextSwitchTo(upgradeCxt);
+	RememberCreatedName(typname, typnamespaceoid);
+	MemoryContextSwitchTo(oldctx);
+
 	AddPreassignedOidFromBinaryUpgrade(typoid, TypeRelationId, typname,
 						typnamespaceoid, InvalidOid, InvalidOid);
 
@@ -55,11 +191,60 @@ binary_upgrade_set_next_pg_type_oid(PG_FUNCTION_ARGS)
 Datum
 binary_upgrade_set_next_array_pg_type_oid(PG_FUNCTION_ARGS)
 {
+	MemoryContext oldctx;
 	Oid			typoid = PG_GETARG_OID(0);
+	Oid         old_type_oid;
+	bool        exists;
 	Oid			typnamespaceoid = PG_GETARG_OID(1);
-	char	   *typname = GET_STR(PG_GETARG_TEXT_P(2));
+	char	   *relname = GET_STR(PG_GETARG_TEXT_P(2));
+	char       *typname;
+	ListCell   *lc;
 
 	CHECK_IS_BINARY_UPGRADE;
+
+	old_type_oid = GetSysCacheOid2(TYPENAMENSP, Anum_pg_type_oid,
+								   CStringGetDatum(relname),
+								   ObjectIdGetDatum(typnamespaceoid));
+
+	exists = OidIsValid(old_type_oid);
+
+	foreach(lc, createdArrayNames)
+	{
+		char *name = (char *) lfirst(lc);
+		if (strcmp(relname, name) == 0)
+		{
+			exists = true;
+			break;
+		}
+	}
+
+	oldctx = MemoryContextSwitchTo(upgradeCxt);
+	typname = makeArrayTypeNameUpgrade(relname, typnamespaceoid);
+	RememberCreatedName(typname, typnamespaceoid);
+	if (exists)
+	{
+		/*
+		 * When database wants to create a regular type, and
+		 * there is already an array type with the same name
+		 * in the cluster, exising array type would be renamed,
+		 * getting the next free name via an additional call to
+		 * makeArrayType. Meaning that the next array type name
+		 * needs two makeArrayType calls to get to.
+		 *
+		 * Note, that we assume that the base type for this array type
+		 * is always created.
+		 *
+		 * Also, the whole logic descripted here works only if existing
+		 * type is an array type. If it not, it wouldn't be possible
+		 * to move existing type, and upgrade would fail. But it would
+		 * happed regardless of what we are doing here, so let's
+		 * not complicate the logic.
+		 */
+		typname = makeArrayTypeNameUpgrade(typname, typnamespaceoid);
+		RememberCreatedName(typname, typnamespaceoid);
+	}
+	MemoryContextSwitchTo(oldctx);
+
 	AddPreassignedOidFromBinaryUpgrade(typoid, TypeRelationId, typname,
 						typnamespaceoid, InvalidOid, InvalidOid);
 

--- a/src/backend/utils/adt/pg_upgrade_support.c
+++ b/src/backend/utils/adt/pg_upgrade_support.c
@@ -87,7 +87,6 @@ makeArrayTypeNameUpgrade(const char *typeName, Oid typeNamespace)
 {
 	CreatedName key;
 	char *arr, *modifiedTypeName;
-	int typeNameLen = strlen(typeName);
 	int underscores = 0;
 
 	modifiedTypeName = palloc(NAMEDATALEN);
@@ -98,13 +97,17 @@ makeArrayTypeNameUpgrade(const char *typeName, Oid typeNamespace)
 	while (created_names && hash_search(created_names, &key, HASH_FIND, NULL))
 	{
 		underscores++;
-		if (typeNameLen + underscores >= NAMEDATALEN)
+		/* 
+		 * We tried to create new name NAMEDATALEN times,
+		 * effectivly meaning that it is impossible to create one.
+		 */
+		if (underscores >= NAMEDATALEN)
 			ereport(ERROR,
 				   (errcode(ERRCODE_DUPLICATE_OBJECT),
 					errmsg("could not form array type name for type \"%s\"",
 							typeName)));
 		MemSet(modifiedTypeName, '_', underscores);
-		strcpy(modifiedTypeName + underscores, typeName);
+		strlcpy(modifiedTypeName + underscores, typeName, NAMEDATALEN - underscores);
 		pfree(arr);
 		arr = makeArrayTypeName(modifiedTypeName, typeNamespace);
 		MemSet(&key, 0, sizeof(CreatedName));
@@ -119,46 +122,27 @@ makeArrayTypeNameUpgrade(const char *typeName, Oid typeNamespace)
 Datum
 binary_upgrade_set_next_pg_type_oid(PG_FUNCTION_ARGS)
 {
+	CreatedName   key;
 	MemoryContext oldctx;
 	Oid			typoid = PG_GETARG_OID(0);
 	Oid			typnamespaceoid = PG_GETARG_OID(1);
-	char	   *typname = GET_STR(PG_GETARG_TEXT_P(2));
-
-	CHECK_IS_BINARY_UPGRADE;
-
-	/* Remember that we've already taken this name */
-	oldctx = MemoryContextSwitchTo(TopMemoryContext);
-	RememberCreatedName(typname, typnamespaceoid);
-	MemoryContextSwitchTo(oldctx);
-
-	AddPreassignedOidFromBinaryUpgrade(typoid, TypeRelationId, typname,
-						typnamespaceoid, InvalidOid, InvalidOid);
-
-	PG_RETURN_VOID();
-}
-
-Datum
-binary_upgrade_set_next_array_pg_type_oid(PG_FUNCTION_ARGS)
-{
-	MemoryContext oldctx;
-	Oid			typoid = PG_GETARG_OID(0);
 	Oid         old_type_oid;
-	bool        exists;
-	Oid			typnamespaceoid = PG_GETARG_OID(1);
-	char	   *relname = GET_STR(PG_GETARG_TEXT_P(2));
-	char       *typname;
+	char	   *typname = GET_STR(PG_GETARG_TEXT_P(2));
+	char       *moved_array_typname;
+	bool        in_catalog;
 
 	CHECK_IS_BINARY_UPGRADE;
 
 	old_type_oid = GetSysCacheOid2(TYPENAMENSP, Anum_pg_type_oid,
-								   CStringGetDatum(relname),
+								   CStringGetDatum(typname),
 								   ObjectIdGetDatum(typnamespaceoid));
-	exists = OidIsValid(old_type_oid);
+	in_catalog = OidIsValid(old_type_oid);
 
 	oldctx = MemoryContextSwitchTo(TopMemoryContext);
-	typname = makeArrayTypeNameUpgrade(relname, typnamespaceoid);
-	RememberCreatedName(typname, typnamespaceoid);
-	if (exists)
+	MemSet(&key, 0, sizeof(CreatedName));
+	key.schema_oid = typnamespaceoid;
+	strlcpy(key.name, typname, NAMEDATALEN);
+	if (in_catalog || (created_names && hash_search(created_names, &key, HASH_FIND, NULL)))
 	{
 		/*
 		 * When database wants to create a regular type, and
@@ -179,10 +163,35 @@ binary_upgrade_set_next_array_pg_type_oid(PG_FUNCTION_ARGS)
 		 */
 		char new_typname[NAMEDATALEN];
 		strlcpy(new_typname, typname, NAMEDATALEN);
-		pfree(typname);
-		typname = makeArrayTypeNameUpgrade(new_typname, typnamespaceoid);
-		RememberCreatedName(typname, typnamespaceoid);
+
+		moved_array_typname = makeArrayTypeNameUpgrade(new_typname, typnamespaceoid);
+		RememberCreatedName(moved_array_typname, typnamespaceoid);
 	}
+
+	/* Remember that we've already taken this name */
+	RememberCreatedName(typname, typnamespaceoid);
+	MemoryContextSwitchTo(oldctx);
+
+	AddPreassignedOidFromBinaryUpgrade(typoid, TypeRelationId, typname,
+						typnamespaceoid, InvalidOid, InvalidOid);
+
+	PG_RETURN_VOID();
+}
+
+Datum
+binary_upgrade_set_next_array_pg_type_oid(PG_FUNCTION_ARGS)
+{
+	MemoryContext oldctx;
+	Oid			typoid = PG_GETARG_OID(0);
+	Oid			typnamespaceoid = PG_GETARG_OID(1);
+	char	   *relname = GET_STR(PG_GETARG_TEXT_P(2));
+	char       *typname;
+
+	CHECK_IS_BINARY_UPGRADE;
+
+	oldctx = MemoryContextSwitchTo(TopMemoryContext);
+	typname = makeArrayTypeNameUpgrade(relname, typnamespaceoid);
+	RememberCreatedName(typname, typnamespaceoid);
 	MemoryContextSwitchTo(oldctx);
 
 	AddPreassignedOidFromBinaryUpgrade(typoid, TypeRelationId, typname,

--- a/src/backend/utils/adt/pg_upgrade_support.c
+++ b/src/backend/utils/adt/pg_upgrade_support.c
@@ -27,8 +27,6 @@
 #include "utils/array.h"
 #include "utils/builtins.h"
 
-#include "utils/memutils.h"
-#include "utils/syscache.h"
 
 #define GET_STR(textp) DatumGetCString(DirectFunctionCall1(textout, PointerGetDatum(textp)))
 
@@ -40,148 +38,14 @@ do {															\
 				 (errmsg("function can only be called when server is in binary upgrade mode")))); \
 } while (0)
 
-typedef struct {
-	List *names;
-	Oid  schema;
-} CreatedNamesPerSchema;
-
-static MemoryContext upgradeCxt = NULL;
-static List *createdArrayNames = NIL;
-
-/*
- * isNamePreassigned
- *     Outputs whether type name arg was already assigned during upgrade.
- */
-static bool
-isNamePreassigned(const char *arr, Oid typeNamespace)
-{
-	CreatedNamesPerSchema *target = NULL;
-	ListCell *lc;
-	char *name;
-	foreach(lc, createdArrayNames)
-	{
-		CreatedNamesPerSchema *names = lfirst(lc);
-		if (names->schema == typeNamespace)
-		{
-			target = names;
-			break;
-		}
-	}
-	if (target)
-	{
-		foreach (lc, target->names)
-		{
-			name = lfirst(lc);
-			if (strcmp(arr, name) == 0)
-				return true;
-		}
-	}
-	return false;
-}
-
-/*
- * RememberCreatedName
- *     Stores the typename for future collision detections.
- */
-static void
-RememberCreatedName(char *typname, Oid schema)
-{
-	Assert(upgradeCxt);
-	CreatedNamesPerSchema *target = NULL;
-	ListCell *lc;
-	char* persistentTypeName = pstrdup(typname);
-
-	foreach(lc, createdArrayNames)
-	{
-		CreatedNamesPerSchema *names = lfirst(lc);
-		if (names->schema == schema)
-		{
-			target = names;
-			break;
-		}
-	}
-	if (!target)
-	{
-		target = palloc0(sizeof(CreatedNamesPerSchema));
-		target->schema = schema;
-		target->names = NIL;
-		createdArrayNames = lappend(createdArrayNames, target);
-	}
-
-	target->names = lappend(target->names, persistentTypeName);
-}
-
-/*
- * makeArrayTypeNameUpgrade
- *     A wrapper around makeArrayTypeName, that also checks if the newly
- *     generated name collides with the ones already assigned
- *     during upgrade.
- */
-static char *
-makeArrayTypeNameUpgrade(const char *typeName, Oid typeNamespace)
-{
-	char *arr, *modifiedTypeName;
-	int typeNameLen = strlen(typeName);
-	int underscores = 0;
-
-	modifiedTypeName = palloc(NAMEDATALEN);
-	arr = makeArrayTypeName(typeName, typeNamespace);
-	while (isNamePreassigned(arr, typeNamespace))
-	{
-		underscores++;
-		if (typeNameLen + underscores >= NAMEDATALEN)
-			ereport(ERROR,
-				   (errcode(ERRCODE_DUPLICATE_OBJECT),
-					errmsg("could not form array type name for type \"%s\"", typeName)));
-		memset(modifiedTypeName, '_', underscores);
-		strcpy(modifiedTypeName + underscores, typeName);
-		arr = makeArrayTypeName(modifiedTypeName, typeNamespace);
-	}
-	pfree(modifiedTypeName);
-
-	return arr;
-}
-
-Datum
-binary_upgrade_init(PG_FUNCTION_ARGS)
-{
-	CHECK_IS_BINARY_UPGRADE;
-
-	Assert(!upgradeCxt);
-	if (!upgradeCxt)
-		upgradeCxt = AllocSetContextCreate(TopMemoryContext,
-										   "pg_upgrade temp context",
-										   ALLOCSET_DEFAULT_SIZES);
-
-	PG_RETURN_VOID();
-}
-
-Datum
-binary_upgrade_cleanup(PG_FUNCTION_ARGS)
-{
-	CHECK_IS_BINARY_UPGRADE;
-
-	if (upgradeCxt)
-		MemoryContextDelete(upgradeCxt);
-
-	PG_RETURN_VOID();
-}
-
 Datum
 binary_upgrade_set_next_pg_type_oid(PG_FUNCTION_ARGS)
 {
-	MemoryContext oldctx;
 	Oid			typoid = PG_GETARG_OID(0);
 	Oid			typnamespaceoid = PG_GETARG_OID(1);
 	char	   *typname = GET_STR(PG_GETARG_TEXT_P(2));
 
 	CHECK_IS_BINARY_UPGRADE;
-
-	/* Remember that we've already taken this name */
-	oldctx = MemoryContextSwitchTo(upgradeCxt);
-	RememberCreatedName(typname, typnamespaceoid);
-	MemoryContextSwitchTo(oldctx);
-
 	AddPreassignedOidFromBinaryUpgrade(typoid, TypeRelationId, typname,
 						typnamespaceoid, InvalidOid, InvalidOid);
 
@@ -191,60 +55,11 @@ binary_upgrade_set_next_pg_type_oid(PG_FUNCTION_ARGS)
 Datum
 binary_upgrade_set_next_array_pg_type_oid(PG_FUNCTION_ARGS)
 {
-	MemoryContext oldctx;
 	Oid			typoid = PG_GETARG_OID(0);
-	Oid         old_type_oid;
-	bool        exists;
 	Oid			typnamespaceoid = PG_GETARG_OID(1);
-	char	   *relname = GET_STR(PG_GETARG_TEXT_P(2));
-	char       *typname;
-	ListCell   *lc;
+	char	   *typname = GET_STR(PG_GETARG_TEXT_P(2));
 
 	CHECK_IS_BINARY_UPGRADE;
-
-	old_type_oid = GetSysCacheOid2(TYPENAMENSP, Anum_pg_type_oid,
-								   CStringGetDatum(relname),
-								   ObjectIdGetDatum(typnamespaceoid));
-
-	exists = OidIsValid(old_type_oid);
-
-	foreach(lc, createdArrayNames)
-	{
-		char *name = (char *) lfirst(lc);
-		if (strcmp(relname, name) == 0)
-		{
-			exists = true;
-			break;
-		}
-	}
-
-	oldctx = MemoryContextSwitchTo(upgradeCxt);
-	typname = makeArrayTypeNameUpgrade(relname, typnamespaceoid);
-	RememberCreatedName(typname, typnamespaceoid);
-	if (exists)
-	{
-		/*
-		 * When database wants to create a regular type, and
-		 * there is already an array type with the same name
-		 * in the cluster, exising array type would be renamed,
-		 * getting the next free name via an additional call to
-		 * makeArrayType. Meaning that the next array type name
-		 * needs two makeArrayType calls to get to.
-		 *
-		 * Note, that we assume that the base type for this array type
-		 * is always created.
-		 *
-		 * Also, the whole logic descripted here works only if existing
-		 * type is an array type. If it not, it wouldn't be possible
-		 * to move existing type, and upgrade would fail. But it would
-		 * happed regardless of what we are doing here, so let's
-		 * not complicate the logic.
-		 */
-		typname = makeArrayTypeNameUpgrade(typname, typnamespaceoid);
-		RememberCreatedName(typname, typnamespaceoid);
-	}
-	MemoryContextSwitchTo(oldctx);
-
 	AddPreassignedOidFromBinaryUpgrade(typoid, TypeRelationId, typname,
 						typnamespaceoid, InvalidOid, InvalidOid);
 

--- a/src/backend/utils/adt/pg_upgrade_support.c
+++ b/src/backend/utils/adt/pg_upgrade_support.c
@@ -27,6 +27,8 @@
 #include "utils/array.h"
 #include "utils/builtins.h"
 
+#include "utils/memutils.h"
+#include "utils/syscache.h"
 
 #define GET_STR(textp) DatumGetCString(DirectFunctionCall1(textout, PointerGetDatum(textp)))
 
@@ -38,14 +40,118 @@ do {															\
 				 (errmsg("function can only be called when server is in binary upgrade mode")))); \
 } while (0)
 
+typedef struct {
+	List *names;
+	Oid  schema;
+} CreatedNamesPerSchema;
+
+static List *createdArrayNames = NIL;
+
+/*
+ * isNamePreassigned
+ *     Outputs whether type name arg was already assigned during upgrade.
+ */
+static bool
+isNamePreassigned(const char *arr, Oid typeNamespace)
+{
+	CreatedNamesPerSchema *target = NULL;
+	ListCell *lc;
+	char *name;
+	foreach(lc, createdArrayNames)
+	{
+		CreatedNamesPerSchema *names = lfirst(lc);
+		if (names->schema == typeNamespace)
+		{
+			target = names;
+			break;
+		}
+	}
+	if (target)
+	{
+		foreach (lc, target->names)
+		{
+			name = lfirst(lc);
+			if (strcmp(arr, name) == 0)
+				return true;
+		}
+	}
+	return false;
+}
+
+static void
+RememberCreatedName(char *typname, Oid schema)
+{
+	CreatedNamesPerSchema *target = NULL;
+	ListCell *lc;
+	char* persistentTypeName = pstrdup(typname);
+
+	foreach(lc, createdArrayNames)
+	{
+		CreatedNamesPerSchema *names = lfirst(lc);
+		if (names->schema == schema)
+		{
+			target = names;
+			break;
+		}
+	}
+	if (!target)
+	{
+		target = palloc0(sizeof(CreatedNamesPerSchema));
+		target->schema = schema;
+		target->names = NIL;
+		createdArrayNames = lappend(createdArrayNames, target);
+	}
+
+	target->names = lappend(target->names, persistentTypeName);
+}
+
+/*
+ * makeArrayTypeNameUpgrade
+ *     A wrapper around makeArrayTypeName, that also checks if the newly
+ *     generated name collides with the ones already assigned
+ *     during upgrade.
+ */
+static char *
+makeArrayTypeNameUpgrade(const char *typeName, Oid typeNamespace)
+{
+	char *arr, *modifiedTypeName;
+	int typeNameLen = strlen(typeName);
+	int underscores = 0;
+
+	modifiedTypeName = palloc(NAMEDATALEN);
+	arr = makeArrayTypeName(typeName, typeNamespace);
+	while (isNamePreassigned(arr, typeNamespace))
+	{
+		underscores++;
+		if (typeNameLen + underscores >= NAMEDATALEN)
+			ereport(ERROR,
+				   (errcode(ERRCODE_DUPLICATE_OBJECT),
+					errmsg("could not form array type name for type \"%s\"",
+							typeName)));
+		memset(modifiedTypeName, '_', underscores);
+		strcpy(modifiedTypeName + underscores, typeName);
+		arr = makeArrayTypeName(modifiedTypeName, typeNamespace);
+	}
+	pfree(modifiedTypeName);
+
+	return arr;
+}
+
 Datum
 binary_upgrade_set_next_pg_type_oid(PG_FUNCTION_ARGS)
 {
+	MemoryContext oldctx;
 	Oid			typoid = PG_GETARG_OID(0);
 	Oid			typnamespaceoid = PG_GETARG_OID(1);
 	char	   *typname = GET_STR(PG_GETARG_TEXT_P(2));
 
 	CHECK_IS_BINARY_UPGRADE;
+
+	/* Remember that we've already taken this name */
+	oldctx = MemoryContextSwitchTo(TopMemoryContext);
+	RememberCreatedName(typname, typnamespaceoid);
+	MemoryContextSwitchTo(oldctx);
+
 	AddPreassignedOidFromBinaryUpgrade(typoid, TypeRelationId, typname,
 						typnamespaceoid, InvalidOid, InvalidOid);
 
@@ -55,11 +161,60 @@ binary_upgrade_set_next_pg_type_oid(PG_FUNCTION_ARGS)
 Datum
 binary_upgrade_set_next_array_pg_type_oid(PG_FUNCTION_ARGS)
 {
+	MemoryContext oldctx;
 	Oid			typoid = PG_GETARG_OID(0);
+	Oid         old_type_oid;
+	bool        exists;
 	Oid			typnamespaceoid = PG_GETARG_OID(1);
-	char	   *typname = GET_STR(PG_GETARG_TEXT_P(2));
+	char	   *relname = GET_STR(PG_GETARG_TEXT_P(2));
+	char       *typname;
+	ListCell   *lc;
 
 	CHECK_IS_BINARY_UPGRADE;
+
+	old_type_oid = GetSysCacheOid2(TYPENAMENSP, Anum_pg_type_oid,
+								   CStringGetDatum(relname),
+								   ObjectIdGetDatum(typnamespaceoid));
+
+	exists = OidIsValid(old_type_oid);
+
+	foreach(lc, createdArrayNames)
+	{
+		char *name = (char *) lfirst(lc);
+		if (strcmp(relname, name) == 0)
+		{
+			exists = true;
+			break;
+		}
+	}
+
+	oldctx = MemoryContextSwitchTo(TopMemoryContext);
+	typname = makeArrayTypeNameUpgrade(relname, typnamespaceoid);
+	RememberCreatedName(typname, typnamespaceoid);
+	if (exists)
+	{
+		/*
+		 * When database wants to create a regular type, and
+		 * there is already an array type with the same name
+		 * in the cluster, exising array type would be renamed,
+		 * getting the next free name via an additional call to
+		 * makeArrayType. Meaning that the next array type name
+		 * needs two makeArrayType calls to get to.
+		 *
+		 * Note, that we assume that the base type for this array type
+		 * is always created.
+		 *
+		 * Also, the whole logic descripted here works only if existing
+		 * type is an array type. If it not, it wouldn't be possible
+		 * to move existing type, and upgrade would fail. But it would
+		 * happed regardless of what we are doing here, so let's
+		 * not complicate the logic.
+		 */
+		typname = makeArrayTypeNameUpgrade(typname, typnamespaceoid);
+		RememberCreatedName(typname, typnamespaceoid);
+	}
+	MemoryContextSwitchTo(oldctx);
+
 	AddPreassignedOidFromBinaryUpgrade(typoid, TypeRelationId, typname,
 						typnamespaceoid, InvalidOid, InvalidOid);
 

--- a/src/backend/utils/adt/pg_upgrade_support.c
+++ b/src/backend/utils/adt/pg_upgrade_support.c
@@ -154,11 +154,7 @@ binary_upgrade_set_next_pg_type_oid(PG_FUNCTION_ARGS)
 		 * there is already an array type with the same name
 		 * in the cluster, exising array type would be renamed,
 		 * getting the next free name via an additional call to
-		 * makeArrayType. Meaning that the next array type name
-		 * needs two makeArrayType calls to get to.
-		 *
-		 * Note, that we assume that the base type for this array type
-		 * is always created.
+		 * makeArrayType. So remember it as created too.
 		 *
 		 * Also, the whole logic descripted here works only if existing
 		 * type is an array type. If it not, it wouldn't be possible

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -17128,14 +17128,26 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 				PQExpBuffer 	partquery = createPQExpBuffer();
 				PGresult	   *partres;
 
-				appendPQExpBuffer(partquery, "SELECT DISTINCT(child.oid) "
-											 "FROM pg_catalog.pg_partition part, "
-											 "     pg_catalog.pg_partition_rule rule, "
-											 "     pg_catalog.pg_class child "
-											 "WHERE part.parrelid = '%u'::pg_catalog.oid "
-											 "  AND rule.paroid = part.oid "
-											 "  AND child.oid = rule.parchildrelid",
-											 tbinfo->dobj.catId.oid);
+				appendPQExpBuffer(partquery,
+								 "WITH RECURSIVE parts AS ("
+								 "    SELECT rule.parchildrelid AS childoid,"
+								 "            rule.oid AS ruleoid,"
+								 "            part.parlevel,"
+								 "            ARRAY[rule.parisdefault::int * 100000 + rule.parruleord] AS path"
+								 "     FROM pg_catalog.pg_partition part"
+								 "     JOIN pg_catalog.pg_partition_rule rule ON rule.paroid = part.oid"
+								 "     WHERE part.parrelid = '%u'::pg_catalog.oid"
+								 "       AND part.parlevel = 0"
+								 "   UNION ALL"
+								 "     SELECT rule.parchildrelid, rule.oid, part.parlevel,"
+								 "            p.path || (rule.parisdefault::int * 100000 + rule.parruleord)"
+								 "     FROM parts p"
+								 "     JOIN pg_catalog.pg_partition_rule rule ON rule.parparentrule = p.ruleoid"
+								 "     JOIN pg_catalog.pg_partition part ON part.oid = rule.paroid"
+								 "                                      AND NOT part.paristemplate)"
+								 " SELECT childoid FROM parts"
+								 " ORDER BY parlevel, path",
+					tbinfo->dobj.catId.oid);
 				partres = ExecuteSqlQuery(fout, partquery->data, PGRES_TUPLES_OK);
 
 				/* It really should..  */

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -313,6 +313,8 @@ static void binary_upgrade_set_namespace_oid(Archive *fout,
 								PQExpBuffer upgrade_buffer,
 								Oid pg_namespace_oid);
 static void dumpSearchPath(Archive *AH);
+static void binaryInitUpgradeCxt(Archive *fout);
+static void binaryCleanupUpgradeCxt(Archive *fout);
 static void binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 													 PQExpBuffer upgrade_buffer,
 													 const TypeInfo *tyinfo,
@@ -1089,6 +1091,13 @@ main(int argc, char **argv)
 	if (dopt.outputCreateDB)
 		dumpDatabase(fout);
 
+	/*
+	 * In case of binary upgrade, we might need to have a memory context on backend
+	 * for temp stuff (e.g. assigned type names) during upgrade.
+	 */
+	if (dopt.binary_upgrade)
+		binaryInitUpgradeCxt(fout);
+
 	int binfo_index = -1;
 	/* Now the rearrangeable objects. */
 	for (i = 0; i < numObjs; i++)
@@ -1168,6 +1177,9 @@ main(int argc, char **argv)
 	 */
 	if (plainText)
 		RestoreArchive(fout);
+
+	if (dopt.binary_upgrade)
+		binaryCleanupUpgradeCxt(fout);
 
 	CloseArchive(fout);
 
@@ -4780,6 +4792,44 @@ dumpSubscription(Archive *fout, const SubscriptionInfo *subinfo)
 }
 
 /*
+ * binaryInitUpgradeCxt
+ *    Set up a temp memory context on backend.
+ *    Used for binary upgrade purposes only.
+ */
+static void
+binaryInitUpgradeCxt(Archive *fout)
+{
+	PQExpBuffer query = createPQExpBuffer();
+	appendPQExpBufferStr(query, "\n-- Allocate binary upgrade memory context\n"
+								"SELECT binary_upgrade_init();\n\n");
+	ArchiveEntry(fout, nilCatalogId, createDumpId(),
+				 ARCHIVE_OPTS(.tag = "BINARY UPGRADE INIT",
+							  .description = "BINARY UPGRADE INIT",
+							  .section = SECTION_PRE_DATA,
+							  .createStmt = query->data));
+	destroyPQExpBuffer(query);
+}
+
+/*
+ * binaryCleanupUpgradeCxt
+ *    Cleanup a previosly allocated temp memory context on backend.
+ *    Used for binary upgrade purposes only.
+ */
+static void
+binaryCleanupUpgradeCxt(Archive *fout)
+{
+	PQExpBuffer query = createPQExpBuffer();
+	appendPQExpBufferStr(query, "\n-- Free binary upgrade memory context \n"
+								"SELECT binary_upgrade_cleanup();\n\n");
+	ArchiveEntry(fout, nilCatalogId, createDumpId(),
+				 ARCHIVE_OPTS(.tag = "BINARY UPGRADE CLEANUP",
+							  .description = "BINARY UPGRADE CLEANUP",
+							  .section = SECTION_POST_DATA,
+							  .createStmt = query->data));
+	destroyPQExpBuffer(query);
+}
+
+/*
  * Given a "create query", append as many ALTER ... DEPENDS ON EXTENSION as
  * the object needs.
  */
@@ -4879,7 +4929,6 @@ binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 	PGresult   *res;
 	Oid			pg_type_array_oid = tyinfo->typarrayoid;
 	Oid			pg_type_array_ns_oid = tyinfo->typarrayns;
-	char	*pg_type_array_name = tyinfo->typarrayname;
 
 
 	simple_oid_list_append(&preassigned_oids, tyinfo->dobj.catId.oid);
@@ -4917,7 +4966,6 @@ binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 
 		pg_type_array_oid = next_possible_free_oid;
 		pg_type_array_ns_oid = tyinfo->dobj.namespace->dobj.catId.oid;
-		pg_type_array_name = psprintf("_%s", tyinfo->dobj.name);
 	}
 
 	if (OidIsValid(pg_type_array_oid))
@@ -4929,7 +4977,7 @@ binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 						  "SELECT pg_catalog.binary_upgrade_set_next_array_pg_type_oid('%u'::pg_catalog.oid, "
 						  "'%u'::pg_catalog.oid, $_GPDB_$%s$_GPDB_$::text);\n\n",
 						  pg_type_array_oid, pg_type_array_ns_oid,
-						  pg_type_array_name);
+						  tyinfo->dobj.name /* leave the target cluster decide the name of this type */);
 	}
 
 	destroyPQExpBuffer(upgrade_query);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -313,8 +313,6 @@ static void binary_upgrade_set_namespace_oid(Archive *fout,
 								PQExpBuffer upgrade_buffer,
 								Oid pg_namespace_oid);
 static void dumpSearchPath(Archive *AH);
-static void binaryInitUpgradeCxt(Archive *fout);
-static void binaryCleanupUpgradeCxt(Archive *fout);
 static void binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 													 PQExpBuffer upgrade_buffer,
 													 const TypeInfo *tyinfo,
@@ -1091,13 +1089,6 @@ main(int argc, char **argv)
 	if (dopt.outputCreateDB)
 		dumpDatabase(fout);
 
-	/*
-	 * In case of binary upgrade, we might need to have a memory context on backend
-	 * for temp stuff (e.g. assigned type names) during upgrade.
-	 */
-	if (dopt.binary_upgrade)
-		binaryInitUpgradeCxt(fout);
-
 	int binfo_index = -1;
 	/* Now the rearrangeable objects. */
 	for (i = 0; i < numObjs; i++)
@@ -1177,9 +1168,6 @@ main(int argc, char **argv)
 	 */
 	if (plainText)
 		RestoreArchive(fout);
-
-	if (dopt.binary_upgrade)
-		binaryCleanupUpgradeCxt(fout);
 
 	CloseArchive(fout);
 
@@ -4792,44 +4780,6 @@ dumpSubscription(Archive *fout, const SubscriptionInfo *subinfo)
 }
 
 /*
- * binaryInitUpgradeCxt
- *    Set up a temp memory context on backend.
- *    Used for binary upgrade purposes only.
- */
-static void
-binaryInitUpgradeCxt(Archive *fout)
-{
-	PQExpBuffer query = createPQExpBuffer();
-	appendPQExpBufferStr(query, "\n-- Allocate binary upgrade memory context\n"
-								"SELECT binary_upgrade_init();\n\n");
-	ArchiveEntry(fout, nilCatalogId, createDumpId(),
-				 ARCHIVE_OPTS(.tag = "BINARY UPGRADE INIT",
-							  .description = "BINARY UPGRADE INIT",
-							  .section = SECTION_PRE_DATA,
-							  .createStmt = query->data));
-	destroyPQExpBuffer(query);
-}
-
-/*
- * binaryCleanupUpgradeCxt
- *    Cleanup a previosly allocated temp memory context on backend.
- *    Used for binary upgrade purposes only.
- */
-static void
-binaryCleanupUpgradeCxt(Archive *fout)
-{
-	PQExpBuffer query = createPQExpBuffer();
-	appendPQExpBufferStr(query, "\n-- Free binary upgrade memory context \n"
-								"SELECT binary_upgrade_cleanup();\n\n");
-	ArchiveEntry(fout, nilCatalogId, createDumpId(),
-				 ARCHIVE_OPTS(.tag = "BINARY UPGRADE CLEANUP",
-							  .description = "BINARY UPGRADE CLEANUP",
-							  .section = SECTION_POST_DATA,
-							  .createStmt = query->data));
-	destroyPQExpBuffer(query);
-}
-
-/*
  * Given a "create query", append as many ALTER ... DEPENDS ON EXTENSION as
  * the object needs.
  */
@@ -4929,6 +4879,7 @@ binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 	PGresult   *res;
 	Oid			pg_type_array_oid = tyinfo->typarrayoid;
 	Oid			pg_type_array_ns_oid = tyinfo->typarrayns;
+	char	*pg_type_array_name = tyinfo->typarrayname;
 
 
 	simple_oid_list_append(&preassigned_oids, tyinfo->dobj.catId.oid);
@@ -4966,6 +4917,7 @@ binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 
 		pg_type_array_oid = next_possible_free_oid;
 		pg_type_array_ns_oid = tyinfo->dobj.namespace->dobj.catId.oid;
+		pg_type_array_name = psprintf("_%s", tyinfo->dobj.name);
 	}
 
 	if (OidIsValid(pg_type_array_oid))
@@ -4977,7 +4929,7 @@ binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 						  "SELECT pg_catalog.binary_upgrade_set_next_array_pg_type_oid('%u'::pg_catalog.oid, "
 						  "'%u'::pg_catalog.oid, $_GPDB_$%s$_GPDB_$::text);\n\n",
 						  pg_type_array_oid, pg_type_array_ns_oid,
-						  tyinfo->dobj.name /* leave the target cluster decide the name of this type */);
+						  pg_type_array_name);
 	}
 
 	destroyPQExpBuffer(upgrade_query);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -4879,7 +4879,6 @@ binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 	PGresult   *res;
 	Oid			pg_type_array_oid = tyinfo->typarrayoid;
 	Oid			pg_type_array_ns_oid = tyinfo->typarrayns;
-	char	*pg_type_array_name = tyinfo->typarrayname;
 
 
 	simple_oid_list_append(&preassigned_oids, tyinfo->dobj.catId.oid);
@@ -4917,7 +4916,6 @@ binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 
 		pg_type_array_oid = next_possible_free_oid;
 		pg_type_array_ns_oid = tyinfo->dobj.namespace->dobj.catId.oid;
-		pg_type_array_name = psprintf("_%s", tyinfo->dobj.name);
 	}
 
 	if (OidIsValid(pg_type_array_oid))
@@ -4929,7 +4927,7 @@ binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 						  "SELECT pg_catalog.binary_upgrade_set_next_array_pg_type_oid('%u'::pg_catalog.oid, "
 						  "'%u'::pg_catalog.oid, $_GPDB_$%s$_GPDB_$::text);\n\n",
 						  pg_type_array_oid, pg_type_array_ns_oid,
-						  pg_type_array_name);
+						  tyinfo->dobj.name /* leave the target cluster decide the name of this type */);
 	}
 
 	destroyPQExpBuffer(upgrade_query);

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -10133,14 +10133,6 @@
   prosrc => 'hypothetical_dense_rank_final' },
 
 # pg_upgrade support
-{ oid => '7780', descr => 'for use by pg_upgrade',
-  proname => 'binary_upgrade_init', provolatile => 'v',
-  proparallel => 'r', prorettype => 'void', proargtypes => '',
-  prosrc => 'binary_upgrade_init' },
-{ oid => '7781', descr => 'for use by pg_upgrade',
-  proname => 'binary_upgrade_cleanup', provolatile => 'v',
-  proparallel => 'r', prorettype => 'void', proargtypes => '',
-  prosrc => 'binary_upgrade_cleanup' },
 { oid => '3582', descr => 'for use by pg_upgrade',
   proname => 'binary_upgrade_set_next_pg_type_oid', provolatile => 'v',
   proparallel => 'r', prorettype => 'void', proargtypes => 'oid oid text',

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -10133,6 +10133,14 @@
   prosrc => 'hypothetical_dense_rank_final' },
 
 # pg_upgrade support
+{ oid => '7780', descr => 'for use by pg_upgrade',
+  proname => 'binary_upgrade_init', provolatile => 'v',
+  proparallel => 'r', prorettype => 'void', proargtypes => '',
+  prosrc => 'binary_upgrade_init' },
+{ oid => '7781', descr => 'for use by pg_upgrade',
+  proname => 'binary_upgrade_cleanup', provolatile => 'v',
+  proparallel => 'r', prorettype => 'void', proargtypes => '',
+  prosrc => 'binary_upgrade_cleanup' },
 { oid => '3582', descr => 'for use by pg_upgrade',
   proname => 'binary_upgrade_set_next_pg_type_oid', provolatile => 'v',
   proparallel => 'r', prorettype => 'void', proargtypes => 'oid oid text',


### PR DESCRIPTION
What happened?
Dumping 6.x with forceful array type creation option leads to type names
collision and otherwise impossible type names in 7.x. When trying to restore
from dump, they lead to errors.

Why it happens?
Array type name creation logic inside pg_dump.c is much simpler and not
consistent with the one in pg_type.c.

How do we fix this?
Let's  generate missing type names not during dump, but during restore. This
allows to get exact type names as on the source cluster. For this purpose, use
makeArrayTypeName() from pg_type.c, also keep assigned type names to prevent
collisions. Keep assigned names inside HTAB.
Also, change the query that is used to get partitioned tables inside 
dumpTableSchema function. With the current approach, when creating a 
partitioned table, it is necessary for binary_upgrade_set_next_pg_type_oid and 
binary_upgrade_set_next_array_pg_type_oid function calls to appear in the same 
order as the partitions in the subsequent CREATE TABLE ... PARTITION BY 
command.
The order of partitions is determined by the get_parts function,
so imitate its logic with RECURSIVE query.

Freeing up shenanigans?
HTAB is allocated inside TopMemoryContext, and not freed intentionally. As
restore creates a backend process with its libpq connection, all its memory
(including HTAB) will be cleared when work is done. The reason for this is that
the moment clear up is needed is not obvious - we can't tell if we don't need
generated names anymore.

Tests?
No auto tests as this is the one of many to fix them. Testing could be done by
manually dumping and looking and resulting type names.

Ticket: GG-531