### PR TITLE
Avoid 2PC when only locks are present in WAL

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -148,6 +148,20 @@ int32 gp_subtrans_warn_limit = 16777216; /* 16 million */
 bool		seqXlogWrite;
 
 /*
+ * Set when the current transaction emits a WAL record that modifies a
+ * permanent relation, i.e. a record carrying registered block references.
+ * Temporary and unlogged relations never WAL-log their data pages
+ * (RelationNeedsWAL is false for them), so such records always pertain to a
+ * permanent relation and mean the transaction did durable work that requires a
+ * distributed two-phase commit.  A transaction that only emits
+ * lock/invalidation/commit records -- e.g. one that touches only temporary
+ * tables through the in-memory catalog -- leaves this false and may commit with
+ * a cheaper one-phase commit.  It is reset at top-level transaction start and
+ * is otherwise sticky (only ever set), which is the safe direction.
+ */
+static bool xactWroteWalForPermanentRel = false;
+
+/*
  * Miscellaneous flag bits to record events which occur on the top level
  * transaction. These flags are only persisted in MyXactFlags and are intended
  * so we remember to do certain things later on in the transaction. This is
@@ -464,6 +478,28 @@ TransactionDidWriteXLog(void)
 {
 	TransactionState s = CurrentTransactionState;
 	return s->didLogXid;
+}
+
+/*
+ * Record that the current transaction emitted a WAL record modifying a
+ * permanent relation.  Called from the WAL insertion path when a record
+ * carries block references.  See xactWroteWalForPermanentRel.
+ */
+void
+MarkWalWriteForPermanentRel(void)
+{
+	xactWroteWalForPermanentRel = true;
+}
+
+/*
+ * Whether the current transaction has made a durable change to a permanent
+ * relation.  Used to decide whether a distributed two-phase commit is needed:
+ * a transaction that only touched temporary objects never sets this.
+ */
+bool
+TransactionWroteWalForPermanentRel(void)
+{
+	return xactWroteWalForPermanentRel;
 }
 
 bool
@@ -2419,6 +2455,7 @@ StartTransaction(void)
 	nUnreportedXids = 0;
 	s->didLogXid = false;
 	TopXactexecutorDidWriteXLog = false;
+	xactWroteWalForPermanentRel = false;
 
 	/*
 	 * must initialize resource-management stuff first

--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -476,6 +476,17 @@ XLogInsert_Internal(RmgrId rmid, uint8 info, TransactionId headerXid)
 		EndPos = XLogInsertRecord(rdt, fpw_lsn, curinsert_flags, num_fpw);
 	} while (EndPos == InvalidXLogRecPtr);
 
+	/*
+	 * A record carrying block references modifies one or more relation pages.
+	 * Temporary and unlogged relations never emit such records (their data is
+	 * not WAL-logged), so this implies a durable change to a permanent
+	 * relation.  Remember it so the dispatcher can tell a transaction that did
+	 * real work (which needs a two-phase commit) apart from one that only
+	 * touched temporary objects (which can use a one-phase commit).
+	 */
+	if (max_registered_block_id > 0)
+		MarkWalWriteForPermanentRel();
+
 	XLogResetInsertion();
 
 	return EndPos;

--- a/src/backend/tcop/dest.c
+++ b/src/backend/tcop/dest.c
@@ -266,8 +266,18 @@ ReadyForQuery(CommandDest dest)
 					pq_sendint64(&buf, VmemTracker_GetMaxReservedVmemBytes());
 					pq_endmessage(&buf);
 
+					/*
+					 * Tell the dispatcher whether this QE did durable work that
+					 * requires a two-phase commit.  We report whether the
+					 * transaction wrote WAL for a permanent relation rather than
+					 * whether it wrote any WAL at all: a transaction that only
+					 * touched temporary objects (e.g. temp tables via the in-memory
+					 * catalog) still emits lock/invalidation WAL, but that does not
+					 * need a two-phase commit, so the dispatcher can use a cheaper
+					 * one-phase commit.
+					 */
 					pq_beginmessage(&buf, 'x'); /* wrote_xlog */
-					pq_sendbyte(&buf, TransactionDidWriteXLog());
+					pq_sendbyte(&buf, TransactionWroteWalForPermanentRel());
 					pq_endmessage(&buf);
 				}
 

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -417,6 +417,8 @@ extern bool IsTransactionState(void);
 extern bool IsAbortInProgress(void);
 extern bool IsAbortedTransactionBlockState(void);
 extern bool TransactionDidWriteXLog(void);
+extern void MarkWalWriteForPermanentRel(void);
+extern bool TransactionWroteWalForPermanentRel(void);
 extern bool TopXactExecutorDidWriteXLog(void);
 extern void GetAllTransactionXids(
 	DistributedTransactionId	*distribXid,


### PR DESCRIPTION
Initially introduced in: https://github.com/GreengageDB/greengage/pull/451
And tempcat will hugely benefit from this optimization

## Rationale

`CREATE TEMP TABLE + INSERT` transaction with tempcat on emits exactly four records: three XLOG_STANDBY_LOCK (table, toast table, toast index) and the commit record. Zero with block references.

Those standby-lock records are the ones that were flipping didLogXid and forcing 2PC, and they can't be suppressed cheaply:

- LockAcquireExtended() decides to log from the locktag alone (lock.c:955) - just (dbid, reloid). It has no way to know the relation is temporary.
- On CREATE, there is no relation yet at all: heap_create_with_catalog() locks a freshly allocated OID at heap.c:1578, before any catalog tuple or relcache entry exists - and under tempcat a shared-catalog row never appears.
- Everywhere else, persistence lives behind the lock; looking it up first inverts PG's lock-then-lookup ordering in the hottest lock-manager path.

Plus the commit record is unavoidable regardless (temp tuples need a real XID), so it is not possible to write no WAL.

But "wrote any WAL" was being used as a proxy for "did durable work needing a distributed prepare (2PC)", and tempcat decoupled the two. Hence fixing the predicate (max_registered_block_id > 0) rather than trying to write zero WAL.
