### PR TITLE
GG-615: Fix handling custom cgroup v2 path for resource groups

### DIFF
--- a/gpMgmt/bin/gpcheckresgroupv2impl
+++ b/gpMgmt/bin/gpcheckresgroupv2impl
@@ -86,7 +86,7 @@ class CgroupValidationVersionTwo(CgroupValidation):
 
 
 if __name__ == '__main__':
-    # We should always be given exactly one arg
+    assert len(sys.argv) == 2, "Internal error: this script should be given exactly one argument."
     cgroup_parent = sys.argv[1]
 
     try:

--- a/gpMgmt/bin/gpcheckresgroupv2impl
+++ b/gpMgmt/bin/gpcheckresgroupv2impl
@@ -2,6 +2,7 @@
 # Copyright (c) 2017, VMware, Inc. or its affiliates.
 
 import os
+import sys
 from functools import reduce
 
 
@@ -30,7 +31,7 @@ class CgroupValidationVersionTwo(CgroupValidation):
         self.mount_point = self.detect_cgroup_mount_point()
         self.tab = {"r": os.R_OK, "w": os.W_OK, "x": os.X_OK, "f": os.F_OK}
 
-    def validate_all(self):
+    def validate_all(self, cgroup_parent):
         """
         Check the permissions of the toplevel gpdb cgroup dirs.
 
@@ -43,23 +44,23 @@ class CgroupValidationVersionTwo(CgroupValidation):
 
         self.validate_permission("cgroup.procs", "rw")
 
-        self.validate_permission("gpdb/", "rwx")
-        self.validate_permission("gpdb/cgroup.procs", "rw")
+        self.validate_permission(os.path.join(cgroup_parent, ""), "rwx")
+        self.validate_permission(os.path.join(cgroup_parent, "cgroup.procs"), "rw")
 
-        self.validate_permission("gpdb/cpu.max", "rw")
-        self.validate_permission("gpdb/cpu.weight", "rw")
-        self.validate_permission("gpdb/cpu.weight.nice", "rw")
-        self.validate_permission("gpdb/cpu.stat", "r")
+        self.validate_permission(os.path.join(cgroup_parent, "cpu.max"), "rw")
+        self.validate_permission(os.path.join(cgroup_parent, "cpu.weight"), "rw")
+        self.validate_permission(os.path.join(cgroup_parent, "cpu.weight.nice"), "rw")
+        self.validate_permission(os.path.join(cgroup_parent, "cpu.stat"), "r")
 
-        self.validate_permission("gpdb/cpuset.cpus", "rw")
-        self.validate_permission("gpdb/cpuset.cpus.partition", "rw")
-        self.validate_permission("gpdb/cpuset.mems", "rw")
-        self.validate_permission("gpdb/cpuset.cpus.effective", "r")
-        self.validate_permission("gpdb/cpuset.mems.effective", "r")
+        self.validate_permission(os.path.join(cgroup_parent, "cpuset.cpus"), "rw")
+        self.validate_permission(os.path.join(cgroup_parent, "cpuset.cpus.partition"), "rw")
+        self.validate_permission(os.path.join(cgroup_parent, "cpuset.mems"), "rw")
+        self.validate_permission(os.path.join(cgroup_parent, "cpuset.cpus.effective"), "r")
+        self.validate_permission(os.path.join(cgroup_parent, "cpuset.mems.effective"), "r")
 
-        self.validate_permission("gpdb/memory.current", "r")
+        self.validate_permission(os.path.join(cgroup_parent, "memory.current"), "r")
 
-        self.validate_permission("gpdb/io.max", "rw")
+        self.validate_permission(os.path.join(cgroup_parent, "io.max"), "rw")
 
     def die(self, msg):
         raise ValidationException("cgroup is not properly configured: {}".format(msg))
@@ -85,7 +86,10 @@ class CgroupValidationVersionTwo(CgroupValidation):
 
 
 if __name__ == '__main__':
+    # We should always be given exactly one arg
+    cgroup_parent = sys.argv[1]
+
     try:
-        CgroupValidationVersionTwo().validate_all()
+        CgroupValidationVersionTwo().validate_all(cgroup_parent)
     except ValidationException as e:
         exit(e.message)

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -167,7 +167,11 @@ class Guc:
                 if msg is not None:
                     return msg
             elif newval == "'group-v2'":
-                msg = GpResGroup().validate_v2()
+                dburl = dbconn.DbURL()
+                conn = dbconn.connect(dburl, True)
+                cgroup_parent = Guc(dbconn.queryRow(conn, GucQuery("gp_resource_group_cgroup_parent").query))
+                msg = GpResGroup().validate_v2(cgroup_parent.setting)
+
                 if msg is not None:
                     return msg
             elif newval != "'queue'" and newval != "'none'":

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -167,13 +167,18 @@ class Guc:
                 if msg is not None:
                     return msg
             elif newval == "'group-v2'":
-                dburl = dbconn.DbURL()
-                conn = dbconn.connect(dburl, True)
-                cgroup_parent = Guc(dbconn.queryRow(conn, GucQuery("gp_resource_group_cgroup_parent").query))
-                msg = GpResGroup().validate_v2(cgroup_parent.setting)
+                try:
+                    dburl = dbconn.DbURL()
+                    conn = dbconn.connect(dburl, True)
+                    cgroup_parent = Guc(dbconn.queryRow(conn, GucQuery("gp_resource_group_cgroup_parent").query))
+                    conn.close()
+                    msg = GpResGroup().validate_v2(cgroup_parent.setting)
+                    if msg is not None:
+                        return msg
 
-                if msg is not None:
-                    return msg
+                except DatabaseError as _:
+                    LOGGER.error('Failed to connect to database, this script can only be run when the database is up.')
+
             elif newval != "'queue'" and newval != "'none'":
                 return "the value of gp_resource_manager must be 'none', 'queue', 'group', or 'group-v2'"
         elif self.name == "gp_resource_group_cgroup_parent":

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -148,7 +148,7 @@ class Guc:
         self.min_val = row[6]
         self.max_val = row[7]
 
-    def validate(self, newval, newcoordinatorval, options):
+    def validate(self, newval, newcoordinatorval, options, conn):
         # todo add code here...
         # be careful 128KB in postgresql.conf is translated into 32KB units
 
@@ -167,18 +167,10 @@ class Guc:
                 if msg is not None:
                     return msg
             elif newval == "'group-v2'":
-                try:
-                    dburl = dbconn.DbURL()
-                    conn = dbconn.connect(dburl, True)
-                    cgroup_parent = Guc(dbconn.queryRow(conn, GucQuery("gp_resource_group_cgroup_parent").query))
-                    conn.close()
-                    msg = GpResGroup().validate_v2(cgroup_parent.setting)
-                    if msg is not None:
-                        return msg
-
-                except DatabaseError as _:
-                    LOGGER.error('Failed to connect to database, this script can only be run when the database is up.')
-
+                cgroup_parent = Guc(dbconn.queryRow(conn, GucQuery("gp_resource_group_cgroup_parent").query))
+                msg = GpResGroup().validate_v2(cgroup_parent.setting)
+                if msg is not None:
+                    return msg
             elif newval != "'queue'" and newval != "'none'":
                 return "the value of gp_resource_manager must be 'none', 'queue', 'group', or 'group-v2'"
         elif self.name == "gp_resource_group_cgroup_parent":
@@ -463,7 +455,7 @@ def validate_change_options(options, conn, guc):
         raise Exception(msg)
 
     if options.value:
-        msg = guc.validate(options.value, options.coordinatorvalue, options)
+        msg = guc.validate(options.value, options.coordinatorvalue, options, conn)
         if msg != "ok":
             msg = "new GUC value failed validation: " + msg
             LOGGER.fatal(msg)

--- a/gpMgmt/bin/gppylib/gpresgroup.py
+++ b/gpMgmt/bin/gppylib/gpresgroup.py
@@ -39,14 +39,16 @@ class GpResGroup(object):
         return msg
 
     @staticmethod
-    def validate_v2():
+    def validate_v2(cgroup_parent):
         pool = base.WorkerPool()
         gp_array = GpArray.initFromCatalog(dbconn.DbURL(), utility=True)
         host_list = list(set(gp_array.get_hostlist(True)))
         msg = None
 
         for h in host_list:
-            cmd = Command(h, "gpcheckresgroupv2impl", REMOTE, h)
+            # Assuming that the given path doesn't need escaping
+            command_str = "gpcheckresgroupv2impl {}".format(cgroup_parent)
+            cmd = Command(h, command_str, REMOTE, h)
             pool.addCommand(cmd)
         pool.join()
 

--- a/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
@@ -21,7 +21,7 @@ CREATE LANGUAGE plpython3u;
 -- enable resource group and restart cluster.
 -- start_ignore
 ! gpconfig -c gp_resource_group_cgroup_parent -v "gpdb";
-! gpstop -rai;
+! gpstop -rai; -- changing gp_resource_group_cgroup_parent requires restarting Postmaster
 ! gpconfig -c gp_resource_manager -v group-v2;
 ! gpconfig -c max_connections -v 250 -m 25;
 ! gpconfig -c runaway_detector_activation_percent -v 100;

--- a/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
@@ -20,8 +20,9 @@ CREATE LANGUAGE plpython3u;
 
 -- enable resource group and restart cluster.
 -- start_ignore
+! gpconfig -c gp_resource_group_cgroup_parent -v "gpdb";
+! gpstop -rai;
 ! gpconfig -c gp_resource_manager -v group-v2;
-! gpconfig -c gp_resource_group_cgroup_parent -v "gpdb"
 ! gpconfig -c max_connections -v 250 -m 25;
 ! gpconfig -c runaway_detector_activation_percent -v 100;
 ! gpstop -rai;


### PR DESCRIPTION
When changing a guc via gp_config, it may perform its own 
validations, in addition to the ones in the cluster. 

Such check for gp_resource_manager guc
wasn't properly updated to reflect changes made in
ffee673bd734cd4811e060fcf83595642fcf8e7b
making it verify hardcoded /sys/fs/cgroup/gpdb path,
instead of the actual one, specified via 
gp_resource_group_cgroup_parent guc.

Update the check to use gp_resource_group_cgroup_parent.