### PR TITLE
ADBDEV-10515: Add debug info collection for interconnect code

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -5698,6 +5698,8 @@ SendChunkUDPIFC(ChunkTransportState *transportStates,
 		}
 		checkExceptions(transportStates, pEntry, conn, retry++, timeout);
 		doCheckExpiration = false;
+
+		now = getCurrentTime();
 	}
 
 	conn->pBuff = (uint8 *) conn->curBuff->pkt;

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -664,13 +664,13 @@ typedef struct ICTrace
 static ICTrace* ic_trace;
 static uint32 ic_trace_idx = 0;
 
-#define IC_TRACE(o,b,now) do { \
+#define IC_TRACE(o,b,now,r) do { \
 	ICTrace *t = &ic_trace[ic_trace_idx++ % IC_TRACE_MAX_SIZE]; \
 	t->timestamp = (now); \
 	t->operation = (o); \
 	t->buf = (b); \
 	t->numOutStanding = unack_queue_ring.numOutStanding; \
-	t->route = t->buf->conn? t->buf->conn->route : -1; \
+	t->route = (r); \
 	t->seq = t->buf->pkt->seq; \
 } while(0)
 
@@ -739,7 +739,7 @@ static inline ICBuffer *icBufferListDelete(ICBufferList *list, ICBuffer *buf);
 static inline ICBuffer *icBufferListPop(ICBufferList *list);
 static void icBufferListFree(ICBufferList *list);
 static inline ICBuffer *icBufferListAppend(ICBufferList *list, ICBuffer *buf);
-static void icBufferListReturn(ICBufferList *list, bool isUnackQueue, uint64 now);
+static void icBufferListReturn(ICBufferList *list, bool isUnackQueue, uint64 now, uint16 route);
 
 static ChunkTransportState *SetupUDPIFCInterconnect_Internal(SliceTable *sliceTable);
 static inline TupleChunkListItem RecvTupleChunkFromAnyUDPIFC_Internal(ChunkTransportState *transportStates,
@@ -2629,7 +2629,7 @@ icBufferListAppend(ICBufferList *list, ICBuffer *buf)
  *
  */
 static void
-icBufferListReturn(ICBufferList *list, bool isUnackQueue, uint64 now)
+icBufferListReturn(ICBufferList *list, bool isUnackQueue, uint64 now, uint16 route)
 {
 #ifdef USE_ASSERT_CHECKING
 	icBufferListCheck("icBufferListReturn", list);
@@ -2639,7 +2639,7 @@ icBufferListReturn(ICBufferList *list, bool isUnackQueue, uint64 now)
 	while ((buf = icBufferListPop(list)) != NULL)
 	{
 		if (isUnackQueue)
-			IC_TRACE(IC_OP_UNACK_QUEUE_DELETE, buf, now);
+			IC_TRACE(IC_OP_UNACK_QUEUE_DELETE, buf, now, route);
 
 		if (isUnackQueue && Gp_interconnect_fc_method == INTERCONNECT_FC_METHOD_LOSS)
 		{
@@ -2648,11 +2648,11 @@ icBufferListReturn(ICBufferList *list, bool isUnackQueue, uint64 now)
 			unack_queue_ring.numOutStanding--;
 			if (icBufferListLength(list) >= 1)
 				unack_queue_ring.numSharedOutStanding--;
-			IC_TRACE(IC_OP_RING_DELETE, buf, now);
+			IC_TRACE(IC_OP_RING_DELETE, buf, now, route);
 		}
 
 		icBufferListAppend(&snd_buffer_pool.freeList, buf);
-		IC_TRACE(IC_OP_FREELIST_APPEND, buf, now);
+		IC_TRACE(IC_OP_FREELIST_APPEND, buf, now, route);
 	}
 }
 
@@ -2769,7 +2769,7 @@ getSndBuffer(MotionConn *conn, uint64 now)
 	if (icBufferListLength(&snd_buffer_pool.freeList) > 0)
 	{
 		ret = icBufferListPop(&snd_buffer_pool.freeList);
-		IC_TRACE(IC_OP_FREELIST_DELETE, ret, now);
+		IC_TRACE(IC_OP_FREELIST_DELETE, ret, now, conn->route);
 		return ret;
 	}
 	else
@@ -3671,8 +3671,8 @@ TeardownUDPIFCInterconnect_Internal(ChunkTransportState *transportStates,
 					computeNetworkStatistics(conn->rtt, &minRtt, &maxRtt, &avgRtt);
 					computeNetworkStatistics(conn->dev, &minDev, &maxDev, &avgDev);
 
-					icBufferListReturn(&conn->sndQueue, false, now);
-					icBufferListReturn(&conn->unackQueue, true, now);
+					icBufferListReturn(&conn->sndQueue, false, now, conn->route);
+					icBufferListReturn(&conn->unackQueue, true, now, conn->route);
 
 					connDelHash(&ic_control_info.connHtab, conn);
 				}
@@ -4377,7 +4377,7 @@ handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now)
 	bool		bufIsHead = (&buf->primary == icBufferListFirst(&ackConn->unackQueue));
 
 	buf = icBufferListDelete(&ackConn->unackQueue, buf);
-	IC_TRACE(IC_OP_UNACK_QUEUE_DELETE, buf, now);
+	IC_TRACE(IC_OP_UNACK_QUEUE_DELETE, buf, now, ackConn->route);
 
 	if (Gp_interconnect_fc_method == INTERCONNECT_FC_METHOD_LOSS)
 	{
@@ -4385,7 +4385,7 @@ handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now)
 		unack_queue_ring.numOutStanding--;
 		if (icBufferListLength(&ackConn->unackQueue) >= 1)
 			unack_queue_ring.numSharedOutStanding--;
-		IC_TRACE(IC_OP_RING_DELETE, buf, now);
+		IC_TRACE(IC_OP_RING_DELETE, buf, now, ackConn->route);
 
 		ackTime = now - buf->sentTime;
 
@@ -4437,7 +4437,7 @@ handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now)
 		ackConn->state = mcsStarted;
 
 	icBufferListAppend(&snd_buffer_pool.freeList, buf);
-	IC_TRACE(IC_OP_FREELIST_APPEND, buf, now);
+	IC_TRACE(IC_OP_FREELIST_APPEND, buf, now, ackConn->route);
 
 #ifdef AMS_VERBOSE_LOGGING
 	write_log("REMOVEPKT %d from unack queue for route %d (retry %d) sndbufmaxcount %d sndbufcount %d sndbuffreelistlen %d, sntSeq %d consumedSeq %d recvAckSeq %d capacity %d, sndQ %d, unackQ %d", buf->pkt->seq, ackConn->route, buf->nRetry, snd_buffer_pool.maxCount, snd_buffer_pool.count, icBufferListLength(&snd_buffer_pool.freeList), buf->conn->sentSeq, buf->conn->consumedSeq, buf->conn->receivedAckSeq, buf->conn->capacity, icBufferListLength(&buf->conn->sndQueue), icBufferListLength(&buf->conn->unackQueue));
@@ -4879,8 +4879,8 @@ handleStopMsgs(ChunkTransportState *transportStates, ChunkTransportStateEntry *p
 			icBufferListAppend(&conn->sndQueue, conn->curBuff);
 
 			/* return all buffers */
-			icBufferListReturn(&conn->sndQueue, false, now);
-			icBufferListReturn(&conn->unackQueue, true, now);
+			icBufferListReturn(&conn->sndQueue, false, now, conn->route);
+			icBufferListReturn(&conn->unackQueue, true, now, conn->route);
 
 			conn->tupleCount = 0;
 			conn->msgSize = sizeof(conn->conn_info);
@@ -4955,7 +4955,7 @@ sendBuffers(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEnt
 		conn->capacity--;
 
 		icBufferListAppend(&conn->unackQueue, buf);
-		IC_TRACE(IC_OP_UNACK_QUEUE_APPEND, buf, now);
+		IC_TRACE(IC_OP_UNACK_QUEUE_APPEND, buf, now, conn->route);
 
 		if (Gp_interconnect_fc_method == INTERCONNECT_FC_METHOD_LOSS)
 		{
@@ -5140,7 +5140,7 @@ handleAckForDisorderPkt(ChunkTransportState *transportStates,
 			if (Gp_interconnect_fc_method == INTERCONNECT_FC_METHOD_LOSS)
 			{
 				buf = icBufferListDelete(&unack_queue_ring.slots[buf->unackQueueRingSlot], buf);
-				IC_TRACE(IC_OP_RING_DELETE, buf, now);
+				IC_TRACE(IC_OP_RING_DELETE, buf, now, conn->route);
 				putIntoUnackQueueRing(&unack_queue_ring, buf,
 									  computeExpirationPeriod(buf->conn, buf->nRetry), now);
 			}
@@ -5339,7 +5339,7 @@ checkExpiration(ChunkTransportState *transportStates,
 
 		while ((curBuf = icBufferListPop(&unack_queue_ring.slots[unack_queue_ring.idx])) != NULL)
 		{
-			IC_TRACE(IC_OP_RING_DELETE, curBuf, now);
+			IC_TRACE(IC_OP_RING_DELETE, curBuf, now, curBuf->conn->route);
 			curBuf->nRetry++;
 			putIntoUnackQueueRing(
 								  &unack_queue_ring,
@@ -6097,7 +6097,7 @@ putIntoUnackQueueRing(UnackQueueRing *uqr, ICBuffer *buf, uint64 expTime, uint64
 
 	buf->unackQueueRingSlot = idx;
 	icBufferListAppend(&unack_queue_ring.slots[idx], buf);
-	IC_TRACE(IC_OP_RING_INSERT, buf, now);
+	IC_TRACE(IC_OP_RING_INSERT, buf, now, buf->conn->route);
 }
 
 /*

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -739,7 +739,7 @@ static inline ICBuffer *icBufferListDelete(ICBufferList *list, ICBuffer *buf);
 static inline ICBuffer *icBufferListPop(ICBufferList *list);
 static void icBufferListFree(ICBufferList *list);
 static inline ICBuffer *icBufferListAppend(ICBufferList *list, ICBuffer *buf);
-static void icBufferListReturn(ICBufferList *list, bool isUnackQueue);
+static void icBufferListReturn(ICBufferList *list, bool isUnackQueue, uint64 now);
 
 static ChunkTransportState *SetupUDPIFCInterconnect_Internal(SliceTable *sliceTable);
 static inline TupleChunkListItem RecvTupleChunkFromAnyUDPIFC_Internal(ChunkTransportState *transportStates,
@@ -792,7 +792,7 @@ static void sendBuffers(ChunkTransportState *transportStates, ChunkTransportStat
 static void sendOnce(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEntry, ICBuffer *buf, MotionConn *conn);
 static inline uint64 computeExpirationPeriod(MotionConn *conn, uint32 retry);
 
-static ICBuffer *getSndBuffer(MotionConn *conn);
+static ICBuffer *getSndBuffer(MotionConn *conn, uint64 now);
 static void initSndBufferPool();
 
 static void putIntoUnackQueueRing(UnackQueueRing *uqr, ICBuffer *buf, uint64 expTime, uint64 now);
@@ -2629,13 +2629,12 @@ icBufferListAppend(ICBufferList *list, ICBuffer *buf)
  *
  */
 static void
-icBufferListReturn(ICBufferList *list, bool isUnackQueue)
+icBufferListReturn(ICBufferList *list, bool isUnackQueue, uint64 now)
 {
 #ifdef USE_ASSERT_CHECKING
 	icBufferListCheck("icBufferListReturn", list);
 #endif
 	ICBuffer   *buf = NULL;
-	uint64		now = getCurrentTime();
 
 	while ((buf = icBufferListPop(list)) != NULL)
 	{
@@ -2752,7 +2751,7 @@ cleanSndBufferPool(SendBufferPool *p)
  * 	Return NULL when no free buffer available.
  */
 static ICBuffer *
-getSndBuffer(MotionConn *conn)
+getSndBuffer(MotionConn *conn, uint64 now)
 {
 	ICBuffer   *ret = NULL;
 
@@ -2770,7 +2769,7 @@ getSndBuffer(MotionConn *conn)
 	if (icBufferListLength(&snd_buffer_pool.freeList) > 0)
 	{
 		ret = icBufferListPop(&snd_buffer_pool.freeList);
-		IC_TRACE(IC_OP_FREELIST_DELETE, ret, getCurrentTime());
+		IC_TRACE(IC_OP_FREELIST_DELETE, ret, now);
 		return ret;
 	}
 	else
@@ -2826,6 +2825,7 @@ startOutgoingUDPConnections(ChunkTransportState *transportStates,
 	Slice	   *recvSlice;
 	CdbProcess *cdbProc;
 	int			i;
+	uint64		now = getCurrentTime();
 
 	*pOutgoingCount = 0;
 
@@ -2863,7 +2863,7 @@ startOutgoingUDPConnections(ChunkTransportState *transportStates,
 			/* send buffer pool must be initialized before this. */
 			snd_buffer_pool.maxCount += Gp_interconnect_snd_queue_depth;
 			snd_control_info.cwnd += 1;
-			conn->curBuff = getSndBuffer(conn);
+			conn->curBuff = getSndBuffer(conn, now);
 
 			/* should have at least one buffer for each connection */
 			Assert(conn->curBuff != NULL);
@@ -3660,6 +3660,7 @@ TeardownUDPIFCInterconnect_Internal(ChunkTransportState *transportStates,
 			/* connection array allocation may fail in interconnect setup. */
 			if (pEntry->conns)
 			{
+				uint64		now = getCurrentTime();
 				for (i = 0; i < pEntry->numConns; i++)
 				{
 					conn = pEntry->conns + i;
@@ -3670,8 +3671,8 @@ TeardownUDPIFCInterconnect_Internal(ChunkTransportState *transportStates,
 					computeNetworkStatistics(conn->rtt, &minRtt, &maxRtt, &avgRtt);
 					computeNetworkStatistics(conn->dev, &minDev, &maxDev, &avgDev);
 
-					icBufferListReturn(&conn->sndQueue, false);
-					icBufferListReturn(&conn->unackQueue, true);
+					icBufferListReturn(&conn->sndQueue, false, now);
+					icBufferListReturn(&conn->unackQueue, true, now);
 
 					connDelHash(&ic_control_info.connHtab, conn);
 				}
@@ -4830,6 +4831,7 @@ static void
 handleStopMsgs(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEntry, int16 motionId)
 {
 	int			i = 0;
+	uint64		now = getCurrentTime();
 
 #ifdef AMS_VERBOSE_LOGGING
 	elog(DEBUG3, "handleStopMsgs: node %d", motionId);
@@ -4877,8 +4879,8 @@ handleStopMsgs(ChunkTransportState *transportStates, ChunkTransportStateEntry *p
 			icBufferListAppend(&conn->sndQueue, conn->curBuff);
 
 			/* return all buffers */
-			icBufferListReturn(&conn->sndQueue, false);
-			icBufferListReturn(&conn->unackQueue, true);
+			icBufferListReturn(&conn->sndQueue, false, now);
+			icBufferListReturn(&conn->unackQueue, true, now);
 
 			conn->tupleCount = 0;
 			conn->msgSize = sizeof(conn->conn_info);
@@ -5677,7 +5679,7 @@ SendChunkUDPIFC(ChunkTransportState *transportStates,
 	ic_control_info.lastPacketSendTime = 0;
 	conn->deadlockCheckBeginTime = now;
 
-	while (doCheckExpiration || (conn->curBuff = getSndBuffer(conn)) == NULL)
+	while (doCheckExpiration || (conn->curBuff = getSndBuffer(conn, now)) == NULL)
 	{
 		int			timeout = (doCheckExpiration ? 0 : computeTimeout(conn, retry));
 

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1695,6 +1695,7 @@ CleanupMotionUDPIFC(void)
 
 	/* free the debug trace buffer*/
 	pfree(ic_trace);
+	ic_trace = NULL;
 
 	MemoryContextDelete(ic_control_info.memContext);
 

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -664,9 +664,9 @@ typedef struct ICTrace
 static ICTrace* ic_trace;
 static uint32 ic_trace_idx = 0;
 
-#define IC_TRACE(o,b) do { \
+#define IC_TRACE(o,b,now) do { \
 	ICTrace *t = &ic_trace[ic_trace_idx++ % IC_TRACE_MAX_SIZE]; \
-	t->timestamp = getCurrentTime(); \
+	t->timestamp = (now); \
 	t->operation = (o); \
 	t->buf = (b); \
 	t->numOutStanding = unack_queue_ring.numOutStanding; \
@@ -2635,11 +2635,12 @@ icBufferListReturn(ICBufferList *list, bool isUnackQueue)
 	icBufferListCheck("icBufferListReturn", list);
 #endif
 	ICBuffer   *buf = NULL;
+	uint64		now = getCurrentTime();
 
 	while ((buf = icBufferListPop(list)) != NULL)
 	{
 		if (isUnackQueue)
-			IC_TRACE(IC_OP_UNACK_QUEUE_DELETE, buf);
+			IC_TRACE(IC_OP_UNACK_QUEUE_DELETE, buf, now);
 
 		if (isUnackQueue && Gp_interconnect_fc_method == INTERCONNECT_FC_METHOD_LOSS)
 		{
@@ -2648,11 +2649,11 @@ icBufferListReturn(ICBufferList *list, bool isUnackQueue)
 			unack_queue_ring.numOutStanding--;
 			if (icBufferListLength(list) >= 1)
 				unack_queue_ring.numSharedOutStanding--;
-			IC_TRACE(IC_OP_RING_DELETE, buf);
+			IC_TRACE(IC_OP_RING_DELETE, buf, now);
 		}
 
 		icBufferListAppend(&snd_buffer_pool.freeList, buf);
-		IC_TRACE(IC_OP_FREELIST_APPEND, buf);
+		IC_TRACE(IC_OP_FREELIST_APPEND, buf, now);
 	}
 }
 
@@ -2769,7 +2770,7 @@ getSndBuffer(MotionConn *conn)
 	if (icBufferListLength(&snd_buffer_pool.freeList) > 0)
 	{
 		ret = icBufferListPop(&snd_buffer_pool.freeList);
-		IC_TRACE(IC_OP_FREELIST_DELETE, ret);
+		IC_TRACE(IC_OP_FREELIST_DELETE, ret, getCurrentTime());
 		return ret;
 	}
 	else
@@ -4375,7 +4376,7 @@ handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now)
 	bool		bufIsHead = (&buf->primary == icBufferListFirst(&ackConn->unackQueue));
 
 	buf = icBufferListDelete(&ackConn->unackQueue, buf);
-	IC_TRACE(IC_OP_UNACK_QUEUE_DELETE, buf);
+	IC_TRACE(IC_OP_UNACK_QUEUE_DELETE, buf, now);
 
 	if (Gp_interconnect_fc_method == INTERCONNECT_FC_METHOD_LOSS)
 	{
@@ -4383,7 +4384,7 @@ handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now)
 		unack_queue_ring.numOutStanding--;
 		if (icBufferListLength(&ackConn->unackQueue) >= 1)
 			unack_queue_ring.numSharedOutStanding--;
-		IC_TRACE(IC_OP_RING_DELETE, buf);
+		IC_TRACE(IC_OP_RING_DELETE, buf, now);
 
 		ackTime = now - buf->sentTime;
 
@@ -4435,7 +4436,7 @@ handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now)
 		ackConn->state = mcsStarted;
 
 	icBufferListAppend(&snd_buffer_pool.freeList, buf);
-	IC_TRACE(IC_OP_FREELIST_APPEND, buf);
+	IC_TRACE(IC_OP_FREELIST_APPEND, buf, now);
 
 #ifdef AMS_VERBOSE_LOGGING
 	write_log("REMOVEPKT %d from unack queue for route %d (retry %d) sndbufmaxcount %d sndbufcount %d sndbuffreelistlen %d, sntSeq %d consumedSeq %d recvAckSeq %d capacity %d, sndQ %d, unackQ %d", buf->pkt->seq, ackConn->route, buf->nRetry, snd_buffer_pool.maxCount, snd_buffer_pool.count, icBufferListLength(&snd_buffer_pool.freeList), buf->conn->sentSeq, buf->conn->consumedSeq, buf->conn->receivedAckSeq, buf->conn->capacity, icBufferListLength(&buf->conn->sndQueue), icBufferListLength(&buf->conn->unackQueue));
@@ -4952,7 +4953,7 @@ sendBuffers(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEnt
 		conn->capacity--;
 
 		icBufferListAppend(&conn->unackQueue, buf);
-		IC_TRACE(IC_OP_UNACK_QUEUE_APPEND, buf);
+		IC_TRACE(IC_OP_UNACK_QUEUE_APPEND, buf, now);
 
 		if (Gp_interconnect_fc_method == INTERCONNECT_FC_METHOD_LOSS)
 		{
@@ -5137,7 +5138,7 @@ handleAckForDisorderPkt(ChunkTransportState *transportStates,
 			if (Gp_interconnect_fc_method == INTERCONNECT_FC_METHOD_LOSS)
 			{
 				buf = icBufferListDelete(&unack_queue_ring.slots[buf->unackQueueRingSlot], buf);
-				IC_TRACE(IC_OP_RING_DELETE, buf);
+				IC_TRACE(IC_OP_RING_DELETE, buf, now);
 				putIntoUnackQueueRing(&unack_queue_ring, buf,
 									  computeExpirationPeriod(buf->conn, buf->nRetry), now);
 			}
@@ -5336,7 +5337,7 @@ checkExpiration(ChunkTransportState *transportStates,
 
 		while ((curBuf = icBufferListPop(&unack_queue_ring.slots[unack_queue_ring.idx])) != NULL)
 		{
-			IC_TRACE(IC_OP_RING_DELETE, curBuf);
+			IC_TRACE(IC_OP_RING_DELETE, curBuf, now);
 			curBuf->nRetry++;
 			putIntoUnackQueueRing(
 								  &unack_queue_ring,
@@ -6094,7 +6095,7 @@ putIntoUnackQueueRing(UnackQueueRing *uqr, ICBuffer *buf, uint64 expTime, uint64
 
 	buf->unackQueueRingSlot = idx;
 	icBufferListAppend(&unack_queue_ring.slots[idx], buf);
-	IC_TRACE(IC_OP_RING_INSERT, buf);
+	IC_TRACE(IC_OP_RING_INSERT, buf, now);
 }
 
 /*

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -637,6 +637,44 @@ static ICStatistics ic_statistics;
 /* Cached sockaddr of the listening udp socket */
 static struct sockaddr_storage udp_dummy_packet_sockaddr;
 
+/*
+ * Debug tracing for interconnect buffers. This is a useful thing to have
+ * inside a core dump to reconstruct the sequence of events that happened
+ * just prior to it.
+ */
+typedef enum ICTraceOperation {
+	IC_OP_SEND,
+	IC_OP_FREELIST_APPEND,
+	IC_OP_FREELIST_DELETE,
+	IC_OP_UNACK_QUEUE_APPEND,
+	IC_OP_UNACK_QUEUE_DELETE,
+	IC_OP_RING_INSERT,
+	IC_OP_RING_DELETE,
+} ICTraceOperation;
+typedef struct ICTrace
+{
+	uint64 timestamp;
+	ICBuffer *buf;
+	ICTraceOperation operation;
+	int16 numOutStanding;
+	int16 route;
+	uint32 seq;
+} ICTrace;
+
+#define IC_TRACE_MAX_SIZE 1024
+static ICTrace* ic_trace;
+static uint32 ic_trace_idx = 0;
+
+#define IC_TRACE(o,b) do { \
+	ICTrace *t = &ic_trace[ic_trace_idx++ % IC_TRACE_MAX_SIZE]; \
+	t->timestamp = getCurrentTime(); \
+	t->operation = (o); \
+	t->buf = (b); \
+	t->numOutStanding = unack_queue_ring.numOutStanding; \
+	t->route = t->buf->conn->route; \
+	t->seq = t->buf->pkt->seq; \
+} while(0)
+
 /*=========================================================================
  * STATIC FUNCTIONS declarations
  */
@@ -702,7 +740,7 @@ static inline ICBuffer *icBufferListDelete(ICBufferList *list, ICBuffer *buf);
 static inline ICBuffer *icBufferListPop(ICBufferList *list);
 static void icBufferListFree(ICBufferList *list);
 static inline ICBuffer *icBufferListAppend(ICBufferList *list, ICBuffer *buf);
-static void icBufferListReturn(ICBufferList *list, bool inExpirationQueue);
+static void icBufferListReturn(ICBufferList *list, bool isUnackQueue);
 
 static ChunkTransportState *SetupUDPIFCInterconnect_Internal(SliceTable *sliceTable);
 static inline TupleChunkListItem RecvTupleChunkFromAnyUDPIFC_Internal(ChunkTransportState *transportStates,
@@ -1579,6 +1617,10 @@ InitMotionUDPIFC(int *listenerSocketFd, uint16 *listenerPort)
 	snd_control_info.minCwnd = 0;
 	snd_control_info.ackBuffer = palloc0(MIN_PACKET_SIZE);
 
+	/* Allocate debug tracing circular buffer */
+	ic_trace = palloc0(sizeof(ICTrace) * IC_TRACE_MAX_SIZE);
+	ic_trace_idx = 0;
+
 	MemoryContextSwitchTo(old);
 
 #ifdef TRANSFER_PROTOCOL_STATS
@@ -1651,6 +1693,9 @@ CleanupMotionUDPIFC(void)
 	/* free the buffer for acks */
 	pfree(snd_control_info.ackBuffer);
 	snd_control_info.ackBuffer = NULL;
+
+	/* free the debug trace buffer*/
+	pfree(ic_trace);
 
 	MemoryContextDelete(ic_control_info.memContext);
 
@@ -2584,7 +2629,7 @@ icBufferListAppend(ICBufferList *list, ICBuffer *buf)
  *
  */
 static void
-icBufferListReturn(ICBufferList *list, bool inExpirationQueue)
+icBufferListReturn(ICBufferList *list, bool isUnackQueue)
 {
 #ifdef USE_ASSERT_CHECKING
 	icBufferListCheck("icBufferListReturn", list);
@@ -2593,15 +2638,21 @@ icBufferListReturn(ICBufferList *list, bool inExpirationQueue)
 
 	while ((buf = icBufferListPop(list)) != NULL)
 	{
-		if (inExpirationQueue)	/* the buf is in also in the expiration queue */
+		if (isUnackQueue)
+			IC_TRACE(IC_OP_UNACK_QUEUE_DELETE, buf);
+
+		if (isUnackQueue && Gp_interconnect_fc_method == INTERCONNECT_FC_METHOD_LOSS)
 		{
+			/* the buf is in also in the expiration queue */
 			icBufferListDelete(&unack_queue_ring.slots[buf->unackQueueRingSlot], buf);
 			unack_queue_ring.numOutStanding--;
 			if (icBufferListLength(list) >= 1)
 				unack_queue_ring.numSharedOutStanding--;
+			IC_TRACE(IC_OP_RING_DELETE, buf);
 		}
 
 		icBufferListAppend(&snd_buffer_pool.freeList, buf);
+		IC_TRACE(IC_OP_FREELIST_APPEND, buf);
 	}
 }
 
@@ -2717,7 +2768,12 @@ getSndBuffer(MotionConn *conn)
 
 	if (icBufferListLength(&snd_buffer_pool.freeList) > 0)
 	{
-		return icBufferListPop(&snd_buffer_pool.freeList);
+		ret = icBufferListPop(&snd_buffer_pool.freeList);
+		IC_TRACE(IC_OP_FREELIST_DELETE, ret);
+		if (conn != ret->conn)
+			elog(PANIC, "ack/buf mismatch: conn route=%d ret->conn route=%d seq=%d",
+				 conn->route, ret->conn->route, ret->pkt->seq);
+		return ret;
 	}
 	else
 	{
@@ -3617,7 +3673,7 @@ TeardownUDPIFCInterconnect_Internal(ChunkTransportState *transportStates,
 					computeNetworkStatistics(conn->dev, &minDev, &maxDev, &avgDev);
 
 					icBufferListReturn(&conn->sndQueue, false);
-					icBufferListReturn(&conn->unackQueue, Gp_interconnect_fc_method == INTERCONNECT_FC_METHOD_CAPACITY ? false : true);
+					icBufferListReturn(&conn->unackQueue, true);
 
 					connDelHash(&ic_control_info.connHtab, conn);
 				}
@@ -4313,11 +4369,16 @@ logPkt(char *prefix, icpkthdr *pkt)
 static void
 handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now)
 {
+	if (ackConn != buf->conn)
+		elog(PANIC, "ack/buf mismatch: ackConn route=%d buf->conn route=%d seq=%d",
+			 ackConn->route, buf->conn->route, buf->pkt->seq);
+
 	uint64		ackTime = 0;
 
 	bool		bufIsHead = (&buf->primary == icBufferListFirst(&ackConn->unackQueue));
 
 	buf = icBufferListDelete(&ackConn->unackQueue, buf);
+	IC_TRACE(IC_OP_UNACK_QUEUE_DELETE, buf);
 
 	if (Gp_interconnect_fc_method == INTERCONNECT_FC_METHOD_LOSS)
 	{
@@ -4325,6 +4386,7 @@ handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now)
 		unack_queue_ring.numOutStanding--;
 		if (icBufferListLength(&ackConn->unackQueue) >= 1)
 			unack_queue_ring.numSharedOutStanding--;
+		IC_TRACE(IC_OP_RING_DELETE, buf);
 
 		ackTime = now - buf->sentTime;
 
@@ -4376,6 +4438,7 @@ handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now)
 		ackConn->state = mcsStarted;
 
 	icBufferListAppend(&snd_buffer_pool.freeList, buf);
+	IC_TRACE(IC_OP_FREELIST_APPEND, buf);
 
 #ifdef AMS_VERBOSE_LOGGING
 	write_log("REMOVEPKT %d from unack queue for route %d (retry %d) sndbufmaxcount %d sndbufcount %d sndbuffreelistlen %d, sntSeq %d consumedSeq %d recvAckSeq %d capacity %d, sndQ %d, unackQ %d", buf->pkt->seq, ackConn->route, buf->nRetry, snd_buffer_pool.maxCount, snd_buffer_pool.count, icBufferListLength(&snd_buffer_pool.freeList), buf->conn->sentSeq, buf->conn->consumedSeq, buf->conn->receivedAckSeq, buf->conn->capacity, icBufferListLength(&buf->conn->sndQueue), icBufferListLength(&buf->conn->unackQueue));
@@ -4817,7 +4880,7 @@ handleStopMsgs(ChunkTransportState *transportStates, ChunkTransportStateEntry *p
 
 			/* return all buffers */
 			icBufferListReturn(&conn->sndQueue, false);
-			icBufferListReturn(&conn->unackQueue, Gp_interconnect_fc_method == INTERCONNECT_FC_METHOD_CAPACITY ? false : true);
+			icBufferListReturn(&conn->unackQueue, true);
 
 			conn->tupleCount = 0;
 			conn->msgSize = sizeof(conn->conn_info);
@@ -4882,6 +4945,7 @@ sendBuffers(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEnt
 			break;
 
 		buf = icBufferListPop(&conn->sndQueue);
+		IC_TRACE(IC_OP_SEND, buf);
 
 		uint64		now = getCurrentTime();
 
@@ -4892,6 +4956,7 @@ sendBuffers(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEnt
 		conn->capacity--;
 
 		icBufferListAppend(&conn->unackQueue, buf);
+		IC_TRACE(IC_OP_UNACK_QUEUE_APPEND, buf);
 
 		if (Gp_interconnect_fc_method == INTERCONNECT_FC_METHOD_LOSS)
 		{
@@ -5057,6 +5122,10 @@ handleAckForDisorderPkt(ChunkTransportState *transportStates,
 				  buf->pkt->seq, *curLostPktSeq, lostPktCnt, buf, pkt->seq);
 #endif
 
+		if (conn != buf->conn)
+			elog(PANIC, "ack/buf mismatch: conn route=%d buf->conn route=%d seq=%d",
+				 conn->route, buf->conn->route, buf->pkt->seq);
+
 		if (buf->pkt->seq == pkt->seq)
 		{
 			handleAckedPacket(conn, buf, now);
@@ -5072,6 +5141,7 @@ handleAckForDisorderPkt(ChunkTransportState *transportStates,
 			if (Gp_interconnect_fc_method == INTERCONNECT_FC_METHOD_LOSS)
 			{
 				buf = icBufferListDelete(&unack_queue_ring.slots[buf->unackQueueRingSlot], buf);
+				IC_TRACE(IC_OP_RING_DELETE, buf);
 				putIntoUnackQueueRing(&unack_queue_ring, buf,
 									  computeExpirationPeriod(buf->conn, buf->nRetry), now);
 			}
@@ -5270,6 +5340,7 @@ checkExpiration(ChunkTransportState *transportStates,
 
 		while ((curBuf = icBufferListPop(&unack_queue_ring.slots[unack_queue_ring.idx])) != NULL)
 		{
+			IC_TRACE(IC_OP_RING_DELETE, curBuf);
 			curBuf->nRetry++;
 			putIntoUnackQueueRing(
 								  &unack_queue_ring,
@@ -6027,6 +6098,7 @@ putIntoUnackQueueRing(UnackQueueRing *uqr, ICBuffer *buf, uint64 expTime, uint64
 
 	buf->unackQueueRingSlot = idx;
 	icBufferListAppend(&unack_queue_ring.slots[idx], buf);
+	IC_TRACE(IC_OP_RING_INSERT, buf);
 }
 
 /*

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -643,7 +643,6 @@ static struct sockaddr_storage udp_dummy_packet_sockaddr;
  * just prior to it.
  */
 typedef enum ICTraceOperation {
-	IC_OP_SEND,
 	IC_OP_FREELIST_APPEND,
 	IC_OP_FREELIST_DELETE,
 	IC_OP_UNACK_QUEUE_APPEND,
@@ -671,7 +670,7 @@ static uint32 ic_trace_idx = 0;
 	t->operation = (o); \
 	t->buf = (b); \
 	t->numOutStanding = unack_queue_ring.numOutStanding; \
-	t->route = t->buf->conn->route; \
+	t->route = t->buf->conn? t->buf->conn->route : -1; \
 	t->seq = t->buf->pkt->seq; \
 } while(0)
 
@@ -2770,9 +2769,6 @@ getSndBuffer(MotionConn *conn)
 	{
 		ret = icBufferListPop(&snd_buffer_pool.freeList);
 		IC_TRACE(IC_OP_FREELIST_DELETE, ret);
-		if (conn != ret->conn)
-			elog(PANIC, "ack/buf mismatch: conn route=%d ret->conn route=%d seq=%d",
-				 conn->route, ret->conn->route, ret->pkt->seq);
 		return ret;
 	}
 	else
@@ -4945,7 +4941,6 @@ sendBuffers(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEnt
 			break;
 
 		buf = icBufferListPop(&conn->sndQueue);
-		IC_TRACE(IC_OP_SEND, buf);
 
 		uint64		now = getCurrentTime();
 


### PR DESCRIPTION
Add debug info collection for interconnect code

To assist with further investigation of a segfault, more info should be
collected in interconnect. Specifically, add elog(PANIC) to collect a core
dump if a connection/buffer mismatch is ever detected. Also, add buffer list
event tracing using a fixed-size circular buffer. Previous events such as
adding/removing ICBuffers to/from interconnect lists will be recorded in the
buffer, and so the trace of past events will be present in the core dump if a
segfault happens. This would allow to verify if the sequence of ICBuffer
operations leading up to the segfault was valid.

No test is added because this doesn't fix any specific bug.