### PR TITLE
[GG-597] Use shared variable for default number of segments

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -27,7 +27,8 @@ ifeq "$(enable_debug_extensions)" "yes"
                gp_subtransaction_overflow \
                gp_check_functions \
                temp_tables_stat \
-               credcheck
+               credcheck \
+               gp_rebalance_numsegments
 else
 	recurse_targets = gp_sparse_vector \
                gp_distribution_policy \
@@ -41,7 +42,8 @@ else
                gp_subtransaction_overflow \
                gp_check_functions \
                temp_tables_stat \
-               credcheck
+               credcheck \
+               gp_rebalance_numsegments
 endif
 
 ifeq "$(with_zstd)" "yes"
@@ -108,4 +110,5 @@ installcheck:
 	$(MAKE) -C gp_check_functions installcheck
 	$(MAKE) -C temp_tables_stat installcheck
 	$(MAKE) -C credcheck installcheck
+	$(MAKE) -C gp_rebalance_numsegments installcheck
 

--- a/gpcontrib/gp_debug_numsegments/gp_debug_numsegments.c
+++ b/gpcontrib/gp_debug_numsegments/gp_debug_numsegments.c
@@ -17,6 +17,8 @@
 #include "cdb/cdbutil.h"
 #include "catalog/gp_policy.h"
 #include "catalog/pg_type.h"
+#include "port/atomics.h"
+#include "utils/gpexpand.h"
 
 
 #ifdef PG_MODULE_MAGIC
@@ -51,8 +53,15 @@ gp_debug_set_create_table_default_numsegments(PG_FUNCTION_ARGS)
 	Oid			argtypeoid = InvalidOid;
 	const char *str = NULL;
 	int			numsegments = -1;
+	uint32		gp_rebalance_numsegs = pg_atomic_read_u32(gp_create_table_rebalance_numsegments);
 
 	Assert(1 == PG_NARGS());
+
+	if (gp_rebalance_numsegs != GP_DEFAULT_NUMSEGMENTS_SHARED_UNSET)
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("ggrebalance in progress, all relations will be created at %u segments",
+						 gp_rebalance_numsegs)));
 
 	argtypeoid = get_fn_expr_argtype(fcinfo->flinfo, 0);
 
@@ -139,6 +148,13 @@ gp_debug_get_create_table_default_numsegments(PG_FUNCTION_ARGS)
 {
 	char		buf[64];
 	const char *result = NULL;
+	uint32		gp_rebalance_numsegs = pg_atomic_read_u32(gp_create_table_rebalance_numsegments);
+
+	if (gp_rebalance_numsegs != GP_DEFAULT_NUMSEGMENTS_SHARED_UNSET)
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("ggrebalance in progress, all relations will be created at %u segments",
+						 gp_rebalance_numsegs)));
 
 	switch (gp_create_table_default_numsegments)
 	{

--- a/gpcontrib/gp_rebalance_numsegments/.gitignore
+++ b/gpcontrib/gp_rebalance_numsegments/.gitignore
@@ -1,0 +1,3 @@
+results/
+regression.diffs
+regression.out

--- a/gpcontrib/gp_rebalance_numsegments/Makefile
+++ b/gpcontrib/gp_rebalance_numsegments/Makefile
@@ -1,0 +1,20 @@
+MODULE_big = gp_rebalance_numsegments
+
+EXTENSION = gp_rebalance_numsegments
+DATA = gp_rebalance_numsegments--1.0.sql
+
+OBJS       = gp_rebalance_numsegments.o
+PG_CPPFLAGS = -I$(libpq_srcdir)
+
+ifdef USE_PGXS
+PGXS := $(shell pg_config --pgxs)
+include $(PGXS)
+else
+subdir = contrib/gp_rebalance_numsegments
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
+
+installcheck:
+	$(pg_isolation2_regress_installcheck) --dbname=gp_rebalance_numsegments_isolation rebalance_numsegments

--- a/gpcontrib/gp_rebalance_numsegments/expected/rebalance_numsegments.out
+++ b/gpcontrib/gp_rebalance_numsegments/expected/rebalance_numsegments.out
@@ -1,0 +1,106 @@
+-- Test setting numsegments value for table creation during rebalance operation
+create extension if not exists gp_rebalance_numsegments;
+CREATE
+
+-- Test error throwing when catalog is not locked by ggrebalance
+select gp_toolkit.gp_set_rebalance_numsegments(2);
+ERROR:  ggrebalance not in progress, function can be used only under catalog lock
+select gp_toolkit.gp_get_rebalance_numsegments();
+ERROR:  ggrebalance not in progress, function can be used only under catalog lock
+select gp_toolkit.gp_reset_rebalance_numsegments();
+ERROR:  ggrebalance not in progress, function can be used only under catalog lock
+-- gp_rebalance_numsegments_is_set() may be called without the catalog lock
+select gp_toolkit.gp_rebalance_numsegments_is_set();
+ gp_rebalance_numsegments_is_set 
+---------------------------------
+ 0                               
+(1 row)
+-- Test the numsegment value setting mechanics
+1: begin;
+BEGIN
+1: select gp_expand_lock_catalog();
+ gp_expand_lock_catalog 
+------------------------
+                        
+(1 row)
+2: create table t_reb (i int) distributed by (i);
+ERROR:  gpexpand in progress, catalog changes are disallowed.
+1: select gp_toolkit.gp_get_rebalance_numsegments();
+ gp_get_rebalance_numsegments 
+------------------------------
+ 2147483647                   
+(1 row)
+1: select gp_toolkit.gp_set_rebalance_numsegments(2);
+ gp_set_rebalance_numsegments 
+------------------------------
+ 2                            
+(1 row)
+1: select gp_toolkit.gp_get_rebalance_numsegments();
+ gp_get_rebalance_numsegments 
+------------------------------
+ 2                            
+(1 row)
+1: select gp_toolkit.gp_reset_rebalance_numsegments();
+ gp_reset_rebalance_numsegments 
+--------------------------------
+                                
+(1 row)
+1: select gp_toolkit.gp_get_rebalance_numsegments();
+ gp_get_rebalance_numsegments 
+------------------------------
+ 2147483647                   
+(1 row)
+1: select gp_toolkit.gp_set_rebalance_numsegments(2);
+ gp_set_rebalance_numsegments 
+------------------------------
+ 2                            
+(1 row)
+1: commit;
+COMMIT
+-- Test that newly created tables are using updated number of segmetns
+1: create table t_reb (i int) distributed by (i);
+CREATE
+1: select numsegments from gp_distribution_policy where localoid = 't_reb'::regclass;
+ numsegments 
+-------------
+ 2           
+(1 row)
+1: drop table t_reb;
+DROP
+1: select gp_toolkit.gp_rebalance_numsegments_is_set();
+ gp_rebalance_numsegments_is_set 
+---------------------------------
+ 1                               
+(1 row)
+
+1: begin;
+BEGIN
+1: select gp_expand_lock_catalog();
+ gp_expand_lock_catalog 
+------------------------
+                        
+(1 row)
+1: select gp_toolkit.gp_reset_rebalance_numsegments();
+ gp_reset_rebalance_numsegments 
+--------------------------------
+                                
+(1 row)
+1: create table t_reb (i int) distributed by (i);
+CREATE
+1: select  numsegments from gp_distribution_policy where localoid = 't_reb'::regclass;
+ numsegments 
+-------------
+ 3           
+(1 row)
+1: rollback;
+ROLLBACK
+1: select gp_toolkit.gp_rebalance_numsegments_is_set();
+ gp_rebalance_numsegments_is_set 
+---------------------------------
+ 0                               
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+
+drop extension gp_rebalance_numsegments;
+DROP

--- a/gpcontrib/gp_rebalance_numsegments/gp_rebalance_numsegments--1.0.sql
+++ b/gpcontrib/gp_rebalance_numsegments/gp_rebalance_numsegments--1.0.sql
@@ -1,0 +1,34 @@
+/* gpcontrib/gp_rebalance_numsegments/gp_rebalance_numsegments--1.0.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION gp_rebalance_numsegments" to load this file. \quit
+
+-- This function set the numsegments when creating tables during rebalance operation.
+-- This form accepts an integer argument: [1, gp_num_contents_in_cluster].
+CREATE FUNCTION gp_toolkit.gp_set_rebalance_numsegments(integer) RETURNS int
+AS '$libdir/gp_rebalance_numsegments','gp_set_rebalance_numsegments'
+LANGUAGE C STRICT;
+
+REVOKE ALL ON FUNCTION gp_toolkit.gp_set_rebalance_numsegments(integer) FROM public;
+
+-- This function reset the default numsegments.
+-- This function resets numsegments directly to default value INT_MAX
+CREATE FUNCTION gp_toolkit.gp_reset_rebalance_numsegments() RETURNS void
+AS '$libdir/gp_rebalance_numsegments','gp_reset_rebalance_numsegments'
+LANGUAGE C STRICT;
+
+REVOKE ALL ON FUNCTION gp_toolkit.gp_reset_rebalance_numsegments() FROM public;
+
+-- This function get the default numsegments when creating tables.
+CREATE FUNCTION gp_toolkit.gp_get_rebalance_numsegments() RETURNS int
+AS '$libdir/gp_rebalance_numsegments','gp_get_rebalance_numsegments'
+LANGUAGE C STRICT;
+
+REVOKE ALL ON FUNCTION gp_toolkit.gp_get_rebalance_numsegments() FROM public;
+
+-- This function checks if the rebalance numsegments is set.
+CREATE FUNCTION gp_toolkit.gp_rebalance_numsegments_is_set() RETURNS int
+AS '$libdir/gp_rebalance_numsegments','gp_rebalance_numsegments_is_set'
+LANGUAGE C STRICT;
+
+REVOKE ALL ON FUNCTION gp_toolkit.gp_rebalance_numsegments_is_set() FROM public;

--- a/gpcontrib/gp_rebalance_numsegments/gp_rebalance_numsegments.c
+++ b/gpcontrib/gp_rebalance_numsegments/gp_rebalance_numsegments.c
@@ -1,0 +1,105 @@
+#include "postgres.h"
+
+#include "fmgr.h"
+#include "utils/builtins.h"
+#include "cdb/cdbutil.h"
+#include "catalog/gp_policy.h"
+#include "catalog/pg_type.h"
+#include "storage/lock.h"
+#include "utils/gpexpand.h"
+
+#ifdef PG_MODULE_MAGIC
+PG_MODULE_MAGIC;
+#endif
+
+static void
+errorOutOnLock(void)
+{
+	LOCKTAG gp_expand_locktag =
+	{
+		.locktag_field1 = 0xdead,
+		.locktag_field2 = 0xdead,
+		.locktag_field3 = 0xdead,
+		.locktag_field4 = 0xdd,
+		.locktag_type = LOCKTAG_USERLOCK,
+		.locktag_lockmethodid = USER_LOCKMETHOD,
+	};
+	LockAcquireResult acquired = LockAcquire(&gp_expand_locktag, AccessExclusiveLock, false, true);
+
+	if (acquired != LOCKACQUIRE_ALREADY_HELD)
+		ereport(ERROR,
+			(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+			errmsg("ggrebalance not in progress, function can be used only under catalog lock")));
+}
+
+/*
+ * Get the rebalance numsegments when creating a table.
+ */
+PG_FUNCTION_INFO_V1(gp_get_rebalance_numsegments);
+Datum
+gp_get_rebalance_numsegments(PG_FUNCTION_ARGS)
+{
+	uint32 gp_rebalance_numsegs;
+
+	errorOutOnLock();
+
+	gp_rebalance_numsegs = pg_atomic_read_u32(gp_create_table_rebalance_numsegments);
+
+	PG_RETURN_UINT32(gp_rebalance_numsegs);
+}
+
+/*
+ * Set the numsegments when creating tables during ggrebalance run.
+ *
+ * For integer argument the valid range is [1, gp_num_contents_in_cluster].
+ */
+PG_FUNCTION_INFO_V1(gp_set_rebalance_numsegments);
+Datum
+gp_set_rebalance_numsegments(PG_FUNCTION_ARGS)
+{
+	int			numsegments = -1;
+
+	Assert(1 == PG_NARGS());
+
+	errorOutOnLock();
+
+	numsegments = PG_GETARG_INT32(0);
+
+	if (numsegments < 1 || numsegments > getgpsegmentCount())
+		ereport(ERROR,
+				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+				 errmsg("invalid integer value for default numsegments: %d",
+						numsegments),
+				 errhint("Valid range: [1, %d (gp_num_contents_in_cluster)]",
+						 getgpsegmentCount())));
+
+	pg_atomic_write_u32(gp_create_table_rebalance_numsegments, numsegments);
+
+	return gp_get_rebalance_numsegments(fcinfo);
+}
+
+/*
+ * Reset the rebalance numsegments when creating a table.
+ */
+PG_FUNCTION_INFO_V1(gp_reset_rebalance_numsegments);
+Datum
+gp_reset_rebalance_numsegments(PG_FUNCTION_ARGS)
+{
+	errorOutOnLock();
+
+	pg_atomic_write_u32(gp_create_table_rebalance_numsegments, GP_DEFAULT_NUMSEGMENTS_SHARED_UNSET);
+
+	PG_RETURN_VOID();
+}
+
+/*
+ * Check if the rebalance numsegments is set.
+ */
+PG_FUNCTION_INFO_V1(gp_rebalance_numsegments_is_set);
+Datum
+gp_rebalance_numsegments_is_set(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_BOOL(
+			pg_atomic_read_u32(gp_create_table_rebalance_numsegments)
+			!= GP_DEFAULT_NUMSEGMENTS_SHARED_UNSET);
+}

--- a/gpcontrib/gp_rebalance_numsegments/gp_rebalance_numsegments.control
+++ b/gpcontrib/gp_rebalance_numsegments/gp_rebalance_numsegments.control
@@ -1,0 +1,5 @@
+# gp_rebalance_numsegments extension
+comment = 'functions to manage the default numsegments during ggrebalance'
+default_version = '1.0'
+schema = gp_toolkit
+relocatable = false

--- a/gpcontrib/gp_rebalance_numsegments/sql/rebalance_numsegments.sql
+++ b/gpcontrib/gp_rebalance_numsegments/sql/rebalance_numsegments.sql
@@ -1,0 +1,37 @@
+-- Test setting numsegments value for table creation during rebalance operation
+create extension if not exists gp_rebalance_numsegments;
+
+-- Test error throwing when catalog is not locked by ggrebalance
+select gp_toolkit.gp_set_rebalance_numsegments(2);
+select gp_toolkit.gp_get_rebalance_numsegments();
+select gp_toolkit.gp_reset_rebalance_numsegments();
+-- gp_rebalance_numsegments_is_set() may be called without the catalog lock
+select gp_toolkit.gp_rebalance_numsegments_is_set();
+-- Test the numsegment value setting mechanics
+1: begin;
+1: select gp_expand_lock_catalog();
+2: create table t_reb (i int) distributed by (i);
+1: select gp_toolkit.gp_get_rebalance_numsegments();
+1: select gp_toolkit.gp_set_rebalance_numsegments(2);
+1: select gp_toolkit.gp_get_rebalance_numsegments();
+1: select gp_toolkit.gp_reset_rebalance_numsegments();
+1: select gp_toolkit.gp_get_rebalance_numsegments();
+1: select gp_toolkit.gp_set_rebalance_numsegments(2);
+1: commit;
+-- Test that newly created tables are using updated number of segmetns
+1: create table t_reb (i int) distributed by (i);
+1: select numsegments from gp_distribution_policy where localoid = 't_reb'::regclass;
+1: drop table t_reb;
+1: select gp_toolkit.gp_rebalance_numsegments_is_set();
+
+1: begin;
+1: select gp_expand_lock_catalog();
+1: select gp_toolkit.gp_reset_rebalance_numsegments();
+1: create table t_reb (i int) distributed by (i);
+1: select  numsegments from gp_distribution_policy where localoid = 't_reb'::regclass;
+1: rollback;
+1: select gp_toolkit.gp_rebalance_numsegments_is_set();
+1q:
+2q:
+
+drop extension gp_rebalance_numsegments;

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -211,6 +211,9 @@ CreateSharedMemoryAndSemaphores(int port)
 		/* size of expand version */
 		size = add_size(size, GpExpandVersionShmemSize());
 
+		/* size of rebalance numsegments variable */
+		size = add_size(size, GgRebalanceNumsegmentsShmemSize());
+
 		/* size of token and endpoint shared memory */
 		size = add_size(size, EndpointShmemSize());
 
@@ -366,6 +369,8 @@ CreateSharedMemoryAndSemaphores(int port)
 		InstrShmemInit();
 
 	GpExpandVersionShmemInit();
+
+	GgRebalanceNumsegmentsShmemInit();
 
 	FtsProbeShmemInit();
 

--- a/src/backend/utils/misc/gpexpand.c
+++ b/src/backend/utils/misc/gpexpand.c
@@ -32,8 +32,12 @@
 #include "utils/rel.h"
 #include "utils/relcache.h"
 #include "utils/gpexpand.h"
+#include "port/atomics.h"
+#include "catalog/gp_policy.h"
 
 static volatile int *gp_expand_version;
+
+volatile pg_atomic_uint32 *gp_create_table_rebalance_numsegments;
 
 /*
  * Catalog lock.
@@ -162,4 +166,27 @@ gp_expand_protect_catalog_changes(Relation relation)
 				 errmsg("cluster is expaneded from version %d to %d, "
 						"catalog changes are disallowed",
 						oldVersion, newVersion)));
+}
+
+int
+GgRebalanceNumsegmentsShmemSize(void)
+{
+	return sizeof(*gp_create_table_rebalance_numsegments);
+}
+
+void
+GgRebalanceNumsegmentsShmemInit(void)
+{
+	if (IsUnderPostmaster)
+		return;
+
+	/* only postmaster initialize it */
+	gp_create_table_rebalance_numsegments = (volatile pg_atomic_uint32 *)ShmemAlloc(GgRebalanceNumsegmentsShmemSize());
+	pg_atomic_init_u32(gp_create_table_rebalance_numsegments, GP_DEFAULT_NUMSEGMENTS_SHARED_UNSET);
+}
+
+uint32
+getRebalanceNumsegments(void)
+{
+	return pg_atomic_read_u32(gp_create_table_rebalance_numsegments);
 }

--- a/src/include/catalog/gp_policy.h
+++ b/src/include/catalog/gp_policy.h
@@ -73,6 +73,10 @@ typedef FormData_gp_policy *Form_gp_policy;
  * gp_create_table_default_numsegments.
  */
 #define GP_POLICY_DEFAULT_NUMSEGMENTS()		\
+( (getRebalanceNumsegments() != GP_DEFAULT_NUMSEGMENTS_SHARED_UNSET) ? \
+   getRebalanceNumsegments() : GP_POLICY_ORIGINAL_BEHAVIOR() )
+
+#define GP_POLICY_ORIGINAL_BEHAVIOR()		\
 ( gp_create_table_default_numsegments == GP_DEFAULT_NUMSEGMENTS_FULL    ? getgpsegmentCount() \
 : gp_create_table_default_numsegments == GP_DEFAULT_NUMSEGMENTS_RANDOM  ? (1 + random() % getgpsegmentCount()) \
 : gp_create_table_default_numsegments == GP_DEFAULT_NUMSEGMENTS_MINIMAL ? 1 \
@@ -81,12 +85,14 @@ typedef FormData_gp_policy *Form_gp_policy;
 /*
  * The the default numsegments policies when creating a table.
  *
+ * - UNSET: shared value used during rebalance is not set, default variable is used
  * - FULL: all the segments;
  * - RANDOM: pick a random set of segments each time;
  * - MINIMAL: the minimal set of segments;
  */
 enum
 {
+	GP_DEFAULT_NUMSEGMENTS_SHARED_UNSET = 0x7fffffff,
 	GP_DEFAULT_NUMSEGMENTS_FULL    = -1,
 	GP_DEFAULT_NUMSEGMENTS_RANDOM  = -2,
 	GP_DEFAULT_NUMSEGMENTS_MINIMAL = -3,
@@ -180,5 +186,7 @@ extern GpPolicy *createRandomPartitionedPolicy(int numsegments);
 extern GpPolicy *createHashPartitionedPolicy(List *keys, List *opclasses, int numsegments);
 
 extern bool IsReplicatedTable(Oid relid);
+
+extern uint32 getRebalanceNumsegments(void);
 
 #endif /*_GP_POLICY_H_*/

--- a/src/include/utils/gpexpand.h
+++ b/src/include/utils/gpexpand.h
@@ -14,6 +14,10 @@
 #ifndef GPEXPAND_H
 #define GPEXPAND_H
 
+#include "fmgr.h"
+#include "port/atomics.h"
+#include "utils/relcache.h"
+
 extern int GpExpandVersionShmemSize(void);
 extern void GpExpandVersionShmemInit(void);
 extern int GetGpExpandVersion(void);
@@ -24,6 +28,10 @@ extern void gp_expand_protect_catalog_changes(Relation relation);
 
 extern Datum gp_expand_bump_version(PG_FUNCTION_ARGS);
 
+extern volatile pg_atomic_uint32	*gp_create_table_rebalance_numsegments;
+
+extern void GgRebalanceNumsegmentsShmemInit(void);
+extern int GgRebalanceNumsegmentsShmemSize(void);
 
 #endif   /* GPEXPAND_H */
 


### PR DESCRIPTION
This is the port of commit 3114ed9 from the 7.x ggrebalance code.
Changes from the ported commit:
- gp_toolkit is not an extension in 6.x (it is a plain schema created at
  initdb from gp_toolkit.sql), so the SQL functions are delivered via a
  new dedicated gpcontrib extension 'gp_rebalance_numsegments' instead of
  a gp_toolkit upgrade script. Its control file sets schema = gp_toolkit
  and relocatable = false, so the functions keep the same qualified names
  (gp_toolkit.gp_set/get/reset_rebalance_numsegments) that the
  ggrebalance tool calls. The extension is installable at runtime with
  CREATE EXTENSION and requires no catalog changes.
- gp_rebalance_numsegments_is_set() from the follow-up commit 7037bb7
  is included, as the ggrebalance tool depends on it for restart
  recovery.
- The policy header is catalog/gp_policy.h in 6.x (7.x has
  catalog/gp_distribution_policy.h).
- The rebalance_numsegments isolation2 test lives inside the extension
  directory and is run by the extension's installcheck target via
  pg_isolation2_regress (same pattern as temp_tables_stat). In 7.x it
  could live in src/test/isolation2 because gp_toolkit is installed by
  default; in 6.x the extension is optional, so its test ships with it.

Original commit message:

Commit arenadata/gpdb@5b3f506 introduced new command ALTER
TABLE REBALANCE with shrink support. The target number of segments (if not
specified in ALTER command) is taken from GP_POLICY_DEFAULT_NUMSEGMENTS() macro.
Therefore, we need somehow to set and maintain the creation number across all
backends.

This patch introduces a mechanism for managing the default number of segments
used for table creation during a rebalance operation in GPDB. A new shared
variable gp_create_table_rebalance_numsegments is introduced in gpexpand.h to
track the number of segments to use during table creation while a rebalancing
operation is in progress. The shared variable is initialized in shared memory
with appropriate size and get functionality.

Corresponding SQL functions are created in gp_toolkit schema.
The system now checks if a rebalancing operation is active by verifying locks
before allowing modifications to the number of segments. If a lock is not
already acquired in current transaction (indicating that no rebalancing is
underway), an appropriate error message is returned.

gp_debug_numsegments extension preserves its behaviour. But we disallow to
modify local numsegments value when gp_create_table_rebalance_numsegments
is set.

(cherry picked from commit 3114ed9)