### PR TITLE
GG-452: Correct exception handling for gpactivatestandby

### DIFF
--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -379,11 +379,12 @@ setup_tool_logging(EXECNAME, unix.getLocalHostname(), unix.getUserName())
 
 # parse args and options
 (options_, args_) = parseargs()
-read_standby_port_from_postgresqlconf(options_)
 
 # if we got a new log dir, we can now set it up.
 if options_.logfile:
     setup_tool_logging(EXECNAME, unix.getLocalHostname(), unix.getUserName(), logdir=options_.logfile)
+
+read_standby_port_from_postgresqlconf(options_)
 
 try:
     print_summary(options_)

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -17,6 +17,7 @@ from builtins import range
 import os
 import sys
 import signal
+import socket
 import glob
 import time
 import shutil
@@ -374,11 +375,13 @@ def check_standby_activation(options, err):
     master_data_dir = os.path.normpath(array.master.getSegmentDataDirectory())
     master_port = array.master.getSegmentPort()
 
-    standby_hostname = unix.getLocalHostname()
+    standby_hostname = socket.gethostname()
+    standby_fqdn = socket.getfqdn()
     standby_data_dir = os.path.normpath(options.master_data_dir)
     standby_port = options.standby_port
 
-    if not (master_hostname == standby_hostname and
+    if not ((master_hostname == standby_hostname or
+            master_hostname == standby_fqdn) and
             master_data_dir == standby_data_dir and
             master_port == standby_port):
         logger.fatal('Error activating standby master: %s' % str(err))

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -245,7 +245,7 @@ def read_standby_port_from_postgresqlconf(options):
         options.standby_port = pgconf_dict.int('port')
 
 #-------------------------------------------------------------------------
-def get_config(port=0):
+def get_config(port):
     """Retrieves configuration information from the catalog."""
     
     logger.info('Reading current configuration...')
@@ -342,9 +342,12 @@ def promote_standby(master_data_dir, port):
     for i in range(600):
         try:
             dburl = dbconn.DbURL(port=port)
-            conn = dbconn.connect(dburl, utility=True, logConn=False)
-            dbconn.execSQL(conn, 'CHECKPOINT')
-            conn.close()
+            with dbconn.connect(dburl, utility=True, logConn=False) as conn:
+                # When the new master is available for connections, we should
+                # run a CHECKPOINT to force the new TimeLineID to be written to
+                # the pg_control file.
+                dbconn.execSQL(conn, 'CHECKPOINT')
+            logger.info('Standby master is promoted')
             return True
         except pygresql.InternalError as e:
             pass

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -249,19 +249,10 @@ def get_config(port):
     """Retrieves configuration information from the catalog."""
     
     logger.info('Reading current configuration...')
-    array = None
-    last_error = None
-    for i in range(600):
-        try:
-            dburl = dbconn.DbURL(port=port)
-            array = gparray.GpArray.initFromCatalog(dburl, utility=True)
-            return array
-        except (psycopg2.InternalError, psycopg2.OperationalError) as e:
-            last_error = e
-            pass
-        time.sleep(1)
-    # Shouldn't be able to get here in normal execution.
-    raise last_error
+    dburl = dbconn.DbURL(port=port)
+    array = gparray.GpArray.initFromCatalog(dburl, utility=True)
+    
+    return array
 
 #-------------------------------------------------------------------------
 def check_standby_running(options):

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -253,7 +253,7 @@ def get_config(port):
     """Retrieves configuration information from the catalog."""
     
     logger.info('Reading current configuration...')
-    dburl = dbconn.DbURL(port=port)
+    dburl = dbconn.DbURL(port=port, hostname='localhost')
     array = gparray.GpArray.initFromCatalog(dburl, utility=True)
     
     return array

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -337,22 +337,24 @@ def promote_standby(master_data_dir):
 
 
 #-------------------------------------------------------------------------
-def check_standby_activation(options_, array_=None):
+def check_standby_activation(options_):
     """
-    Check if coordinator postmaster is running.
+    Check if standby was promoted and running.
     """
 
-    # If array is empty, it means that we failed even before/in process of
-    # execution of get_config() and something nasty happened.
-    if not array_:
-        return False
-
-    # Here we check that gpstop accidentally hasn't stopped our promoted standby
+    # Here we check that gpstop or something else accidentally hasn't stopped
+    # our standby we're activating.
     pid = gp.get_postmaster_pid_locally(options_.coordinator_data_dir)
     if pid > 0:
-        return True
-    else:
-        return False
+        # We should wrap this in try/catch because we could get here after
+        # unsuccessful promotion and standby may not be able to accept queries
+        try:
+            array = get_config()
+        except Exception as e:
+            return False
+        if array.coordinator.isSegmentCoordinator(current_role=True):
+            return True
+    return False
 
 #-------------------------------------------------------------------------
 # Main
@@ -411,18 +413,17 @@ try:
     
     print_results(array_, unix.getLocalHostname(), options_)
 
-except ExecutionError as e:
-    errStr = str(e)
+except (ExecutionError, GpActivateStandbyException) as e:
 
-    # Even with ExecutionError we still can have promoted standby.
-    # User need to be notified about this with separate return code.  
-    if (errStr.startswith("ExecutionError: 'non-zero rc: 2'")):
-        if (check_standby_activation(options_, array_)):
-            logger.warning('Standby activated with exception', exc_info=e)
-            sys.exit(1)
-        else:
-            logger.fatal('Error activating standby coordinator: %s' % str(e))
-            sys.exit(2)
+    # Even with raised exceptions we still could have promoted standby.
+    # User need to be notified about this with separate return code.
+    if (check_standby_activation(options_)):
+        logger.warning('Encountered exception: ', exc_info=e)
+        logger.warning('The specified standby coordinator at directory %s acts as primary.' % options_.coordinator_data_dir)
+        sys.exit(1)
+    else:
+        logger.fatal('Error activating standby coordinator: %s' % str(e))
+        sys.exit(2)
 except Exception as e:
     logger.fatal('Error activating standby coordinator: %s' % str(e))
     sys.exit(2)

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -142,12 +142,17 @@ def parseargs():
 
 
 #-------------------------------------------------------------------------
-def print_results(array, hostname, options):
+def print_results(array, hostname, options, successfully=False):
     """Prints out the summary of the operation."""
     
     logger.info('-----------------------------------------------------')
-    logger.info('The activation of the standby master has completed successfully.')
-    logger.info('%s is now the new primary master.' % hostname)
+    if successfully:
+        logger.info('The activation of the standby coordinator has completed successfully.')
+    else:
+        logger.info('The activation of the standby coordinator has completed.')
+        logger.warning('Some non-critical exceptions were encountered during activation process.')
+        logger.warning('Cluster state needs to be analyzed before proceeding with further instructions.')
+    logger.info('%s is now the new primary coordinator.' % hostname)
     logger.info('You will need to update your user access mechanism to reflect')
     logger.info('the change of master hostname.')
     logger.info('Do not re-start the failed master while the fail-over master is')
@@ -337,7 +342,7 @@ def promote_standby(master_data_dir):
 
 
 #-------------------------------------------------------------------------
-def check_standby_activation(options_):
+def check_standby_activation(options_, err):
     """
     Check if standby was promoted and running.
     """
@@ -353,6 +358,8 @@ def check_standby_activation(options_):
         except Exception as e:
             return False
         if array.coordinator.isSegmentCoordinator(current_role=True):
+            logger.warning('Encountered exception: %s.' %str(err))
+            print_results(array, unix.getLocalHostname(), options_, False)
             return True
     return False
 
@@ -411,15 +418,13 @@ try:
     # keyboard interrupt.
     signal.signal(signal.SIGINT, signal.default_int_handler)
     
-    print_results(array_, unix.getLocalHostname(), options_)
+    print_results(array_, unix.getLocalHostname(), options_, True)
 
 except (ExecutionError, GpActivateStandbyException) as e:
 
     # Even with raised exceptions we still could have promoted standby.
     # User need to be notified about this with separate return code.
-    if (check_standby_activation(options_)):
-        logger.warning('Encountered exception: ', exc_info=e)
-        logger.warning('The specified standby coordinator at directory %s acts as primary.' % options_.coordinator_data_dir)
+    if (check_standby_activation(options_, e)):
         sys.exit(1)
     else:
         logger.fatal('Error activating standby coordinator: %s' % str(e))

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -439,7 +439,7 @@ except (ExecutionError, GpActivateStandbyException) as e:
         sys.exit(3)
     else:
         logger.fatal('Error activating standby master: %s' % str(e))
-        sys.exit(2)
+        sys.exit(1)
 except Exception as e:
     logger.fatal('Error activating standby master: %s' % str(e))
     sys.exit(2)

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -363,7 +363,7 @@ def check_standby_activation(options, err):
         try:
             array = get_config(options.standby_port)
         except Exception as e:
-            logger.warning("Couldn't get cluster configuration.")
+            logger.warning("Couldn't get cluster configuration: %s." % str(e))
             return False
         if array.master.isSegmentMaster(current_role=True):
             logger.warning('Encountered exception: %s.' %str(err))
@@ -378,8 +378,9 @@ def check_standby_activation(options, err):
 """
 Return codes:
   0 - Standby activated successfully
-  1 - Standby activated successfully but exceptions were encountered
+  1 - Command encountered an unexpected internal failure that couldn't be handled by the normal error-handling path
   2 - Standby activation failed
+  3 - Standby activated successfully but exceptions were encountered
 """
 
 # setup logging
@@ -433,9 +434,9 @@ try:
 except (ExecutionError, GpActivateStandbyException) as e:
 
     # Even with raised exceptions we still could have promoted standby.
-    # User need to be notified about this with separate return code.
+    # User needs to be notified about this with separate return code.
     if (check_standby_activation(options_, e)):
-        sys.exit(1)
+        sys.exit(3)
     else:
         logger.fatal('Error activating standby master: %s' % str(e))
         sys.exit(2)

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -133,7 +133,7 @@ def parseargs():
 
     # There shouldn't be any args
     if len(args) > 0:
-        logger.error('Unknown arguments: ')
+        logger.error('Unknown arguments:')
         for arg in args:
             logger.error('  %s' % arg)
         parser.exit(2, None)
@@ -356,6 +356,7 @@ def check_standby_activation(options_, err):
         try:
             array = get_config()
         except Exception as e:
+            logger.warning("Couldn't get cluster configuration.")
             return False
         if array.coordinator.isSegmentCoordinator(current_role=True):
             logger.warning('Encountered exception: %s.' %str(err))

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -244,10 +244,19 @@ def get_config(port=0):
     """Retrieves configuration information from the catalog."""
     
     logger.info('Reading current configuration...')
-    dburl = dbconn.DbURL(port=port)
-    array = gparray.GpArray.initFromCatalog(dburl, utility=True)
-    
-    return array
+    array = None
+    last_error = None
+    for i in range(600):
+        try:
+            dburl = dbconn.DbURL(port=port)
+            array = gparray.GpArray.initFromCatalog(dburl, utility=True)
+            return array
+        except (psycopg2.InternalError, psycopg2.OperationalError) as e:
+            last_error = e
+            pass
+        time.sleep(1)
+    # Shouldn't be able to get here in normal execution.
+    raise last_error
 
 #-------------------------------------------------------------------------
 def check_standby_running(options):

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -27,6 +27,7 @@ from datetime import datetime, timedelta
 try:
     from pygresql import pg as pygresql
     from gppylib.commands import unix, gp, pg
+    from gppylib.commands.base import ExecutionError
     from gppylib.db import dbconn
     from gppylib.gpparseopts import OptParser, OptChecker, OptionGroup, SUPPRESS_HELP
     from gppylib.gplog import get_default_logger, setup_tool_logging, enable_verbose_logging, get_logger_if_verbose
@@ -132,7 +133,7 @@ def parseargs():
 
     # There shouldn't be any args
     if len(args) > 0:
-        logger.error('Unknown arguments:')
+        logger.error('Unknown arguments: ')
         for arg in args:
             logger.error('  %s' % arg)
         parser.exit(2, None)
@@ -173,7 +174,6 @@ def print_summary(options):
     """Print summary of the action and asks user if they want to
     continue with the activation."""
 
-    warnings_generated = False
     require_force = False
     
     # check the standby master
@@ -196,14 +196,11 @@ def print_summary(options):
     if require_force and not options.force:
         logger.warning('If you wish to continue you must use the -f option to force')
         logger.warning('the activation process.')
-        warnings_generated = True
         raise GpActivateStandbyException('Force activation required')
     if options.confirm:
         yn = ask_yesno(None, 'Do you want to continue with standby master activation?', 'N')
         if not yn:
             raise GpActivateStandbyException('User canceled') 
-
-    return warnings_generated
 
 #-------------------------------------------------------------------------
 def check_original_master_status(options):
@@ -340,8 +337,33 @@ def promote_standby(master_data_dir):
 
 
 #-------------------------------------------------------------------------
+def check_standby_activation(options_, array_=None):
+    """
+    Check if coordinator postmaster is running.
+    """
+
+    # If array is empty, it means that we failed even before/in process of
+    # execution of get_config() and something nasty happened.
+    if not array_:
+        return False
+
+    # Here we check that gpstop accidentally hasn't stopped our promoted standby
+    pid = gp.get_postmaster_pid_locally(options_.coordinator_data_dir)
+    if pid > 0:
+        return True
+    else:
+        return False
+
+#-------------------------------------------------------------------------
 # Main
 #-------------------------------------------------------------------------
+
+"""
+Return codes:
+  0 - Standby activated successfully
+  1 - Standby activated successfully but exceptions were encountered
+  2 - Standby activation failed
+"""
 
 # setup logging
 logger = get_default_logger()
@@ -355,7 +377,7 @@ if options_.logfile:
     setup_tool_logging(EXECNAME, unix.getLocalHostname(), unix.getUserName(), logdir=options_.logfile)
 
 try:
-    warnings_generated_ = print_summary(options_)
+    print_summary(options_)
 
 
     # disable keyboard interrupt to prevent users from canceling
@@ -388,14 +410,21 @@ try:
     signal.signal(signal.SIGINT, signal.default_int_handler)
     
     print_results(array_, unix.getLocalHostname(), options_)
-    
-    if warnings_generated_:
-        sys.exit(1)
-    else:
-        sys.exit(0)
-    
-except Exception as e_:
-    logger.fatal('Error activating standby master: %s' % str(e_))
+
+except ExecutionError as e:
+    errStr = str(e)
+
+    # Even with ExecutionError we still can have promoted standby.
+    # User need to be notified about this with separate return code.  
+    if (errStr.startswith("ExecutionError: 'non-zero rc: 2'")):
+        if (check_standby_activation(options_, array_)):
+            logger.warning('Standby activated with exception', exc_info=e)
+            sys.exit(1)
+        else:
+            logger.fatal('Error activating standby coordinator: %s' % str(e))
+            sys.exit(2)
+except Exception as e:
+    logger.fatal('Error activating standby coordinator: %s' % str(e))
     sys.exit(2)
 
 sys.exit(0)

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -45,6 +45,11 @@ LOG_TIME_THRESHOLD_MINS = 120
 
 GP_RECOVERY_CONF_FILE = "recovery.conf"
 
+GPACTIVATESTANDBY_SUCCESS = 0
+GPACTIVATESTANDBY_INTERNAL_FAILURE = 1
+GPACTIVATESTANDBY_FAILED = 2
+GPACTIVATESTANDBY_SUCCESS_WITH_EXCEPTIONS = 3
+
 _description = sys.modules[__name__].__doc__
 _usage = "\n"
 
@@ -357,19 +362,29 @@ def check_standby_activation(options, err):
     # Here we check that gpstop or something else accidentally hasn't stopped
     # our standby we're activating.
     pid = gp.get_postmaster_pid_locally(options.master_data_dir)
-    if pid > 0:
-        # We should wrap this in try/catch because we could get here after
-        # unsuccessful promotion and standby may not be able to accept queries
-        try:
-            array = get_config(options.standby_port)
-        except Exception as e:
-            logger.warning("Couldn't get cluster configuration: %s." % str(e))
-            return False
-        if array.master.isSegmentMaster(current_role=True):
-            logger.warning('Encountered exception: %s.' %str(err))
-            print_results(array, unix.getLocalHostname(), options, False)
-            return True
-    return False
+
+    if pid <= 0:
+        logger.fatal('Internal error activating standby master: %s' % str(err))
+        return GPACTIVATESTANDBY_INTERNAL_FAILURE
+    
+    # We should wrap this in try/catch because we could get here after
+    # unsuccessful promotion and standby may not be able to accept queries
+    try:
+        array = get_config(options.standby_port)
+    except Exception as e:
+        logger.warning("Couldn't get cluster configuration: %s." % str(e))
+        logger.fatal('Internal error activating standby master: %s' % str(err))
+        return GPACTIVATESTANDBY_INTERNAL_FAILURE
+    
+    if not array.master.isSegmentMaster(current_role=True):
+        logger.fatal('Error activating standby master: %s' % str(err))
+        return GPACTIVATESTANDBY_FAILED
+
+    logger.warning('Encountered exception: %s.' %str(err))
+    print_results(array, unix.getLocalHostname(), options, False)
+
+    return GPACTIVATESTANDBY_SUCCESS_WITH_EXCEPTIONS
+    
 
 #-------------------------------------------------------------------------
 # Main
@@ -431,17 +446,24 @@ try:
     
     print_results(array_, unix.getLocalHostname(), options_, True)
 
-except (ExecutionError, GpActivateStandbyException) as e:
+# Even with raised exceptions we still could have promoted standby.
+# User needs to be notified about this with separate return code.
+except ExecutionError as e:
+    return_code = check_standby_activation(options_, e)
+    sys.exit(return_code)
 
-    # Even with raised exceptions we still could have promoted standby.
-    # User needs to be notified about this with separate return code.
-    if (check_standby_activation(options_, e)):
-        sys.exit(3)
-    else:
-        logger.fatal('Error activating standby master: %s' % str(e))
-        sys.exit(1)
+except GpActivateStandbyException as e:
+    # We still can possibly get GPACTIVATESTANDBY_INTERNAL_FAILURE
+    if "the postmaster could not come up" in str(e):
+        return_code = check_standby_activation(options_, e)
+        sys.exit(return_code)
+
+    logger.fatal('Error activating standby master: %s' % str(e))
+    sys.exit(GPACTIVATESTANDBY_FAILED)
+
+
 except Exception as e:
     logger.fatal('Error activating standby master: %s' % str(e))
-    sys.exit(2)
+    sys.exit(GPACTIVATESTANDBY_FAILED)
 
-sys.exit(0)
+sys.exit(GPACTIVATESTANDBY_SUCCESS)

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -118,12 +118,6 @@ def parseargs():
     # We have to normalize this path for a later comparison
     options.master_data_dir = os.path.abspath(options.master_data_dir)
 
-    # check if PGPORT environment variable is set.
-    env_pgport = os.getenv('PGPORT', None)
-    if not env_pgport:
-        logger.fatal('PGPORT environment variable not set.')
-        parser.exit(2, None)
-
     if options.logfile and not os.path.exists(options.logfile):
         logger.fatal('Log directory %s does not exist.' % options.logfile)
         parser.exit(2, None)

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -336,7 +336,7 @@ def promote_standby(master_data_dir, port):
     logger.debug('Waiting for connection...')
     for i in range(600):
         try:
-            dburl = dbconn.DbURL(port=port)
+            dburl = dbconn.DbURL(port=port, hostname='localhost')
             with dbconn.connect(dburl, utility=True, logConn=False) as conn:
                 # When the new master is available for connections, we should
                 # run a CHECKPOINT to force the new TimeLineID to be written to

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -370,7 +370,17 @@ def check_standby_activation(options, err):
         logger.fatal('Internal error activating standby master: %s' % str(err))
         return GPACTIVATESTANDBY_INTERNAL_FAILURE
     
-    if not array.master.isSegmentMaster(current_role=True):
+    master_hostname = array.master.getSegmentHostName()
+    master_data_dir = os.path.normpath(array.master.getSegmentDataDirectory())
+    master_port = array.master.getSegmentPort()
+
+    standby_hostname = unix.getLocalHostname()
+    standby_data_dir = os.path.normpath(options.master_data_dir)
+    standby_port = options.standby_port
+
+    if not (master_hostname == standby_hostname and
+            master_data_dir == standby_data_dir and
+            master_port == standby_port):
         logger.fatal('Error activating standby master: %s' % str(err))
         return GPACTIVATESTANDBY_FAILED
 
@@ -403,9 +413,9 @@ setup_tool_logging(EXECNAME, unix.getLocalHostname(), unix.getUserName())
 if options_.logfile:
     setup_tool_logging(EXECNAME, unix.getLocalHostname(), unix.getUserName(), logdir=options_.logfile)
 
-read_standby_port_from_postgresqlconf(options_)
-
 try:
+    read_standby_port_from_postgresqlconf(options_)
+
     print_summary(options_)
 
 

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -242,7 +242,10 @@ def check_original_master_status(options):
 #-------------------------------------------------------------------------
 def read_standby_port_from_postgresqlconf(options):
         logger.info("Obtaining standby's port from standby data directory")
-        pgconf_dict = pgconf.readfile(options.master_data_dir + "/postgresql.conf")
+        try:
+            pgconf_dict = pgconf.readfile(options.master_data_dir + "/postgresql.conf")
+        except Exception as e:
+            raise GpActivateStandbyException("Couldn't read postgresql.conf in specified directory: %s." % str(e))
         options.standby_port = pgconf_dict.int('port')
 
 #-------------------------------------------------------------------------
@@ -471,6 +474,6 @@ except GpActivateStandbyException as e:
 
 except Exception as e:
     logger.fatal('Error activating standby master: %s' % str(e))
-    sys.exit(GPACTIVATESTANDBY_FAILED)
+    sys.exit(GPACTIVATESTANDBY_INTERNAL_FAILURE)
 
 sys.exit(GPACTIVATESTANDBY_SUCCESS)

--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -32,6 +32,7 @@ try:
     from gppylib.gpparseopts import OptParser, OptChecker, OptionGroup, SUPPRESS_HELP
     from gppylib.gplog import get_default_logger, setup_tool_logging, enable_verbose_logging, get_logger_if_verbose
     from gppylib import gparray
+    from gppylib import pgconf
     from gppylib.userinput import ask_yesno
 except ImportError as e_:
     sys.exit('ERROR: Cannot import modules.  Please check that you '
@@ -147,12 +148,12 @@ def print_results(array, hostname, options, successfully=False):
     
     logger.info('-----------------------------------------------------')
     if successfully:
-        logger.info('The activation of the standby coordinator has completed successfully.')
+        logger.info('The activation of the standby master has completed successfully.')
     else:
-        logger.info('The activation of the standby coordinator has completed.')
+        logger.info('The activation of the standby master has completed.')
         logger.warning('Some non-critical exceptions were encountered during activation process.')
         logger.warning('Cluster state needs to be analyzed before proceeding with further instructions.')
-    logger.info('%s is now the new primary coordinator.' % hostname)
+    logger.info('%s is now the new primary master.' % hostname)
     logger.info('You will need to update your user access mechanism to reflect')
     logger.info('the change of master hostname.')
     logger.info('Do not re-start the failed master while the fail-over master is')
@@ -188,7 +189,7 @@ def print_summary(options):
         
     logger.info('-----------------------------------------------------')
     logger.info('Standby data directory    = %s' % options.master_data_dir)
-    logger.info('Standby port              = %s' % str(os.getenv('PGPORT')))
+    logger.info('Standby port              = %s' % options.standby_port)
     if options.logfile:
         logger.info('Log directory             = %s' % options.logfile)
     logger.info('Standby running           = %s' % ('yes' if standby_running else 'no'))
@@ -239,11 +240,17 @@ def check_original_master_status(options):
         raise GpActivateStandbyException('Active postgres process on master')
  
 #-------------------------------------------------------------------------
-def get_config():
+def read_standby_port_from_postgresqlconf(options):
+        logger.info("Obtaining standby's port from standby data directory")
+        pgconf_dict = pgconf.readfile(options.master_data_dir + "/postgresql.conf")
+        options.standby_port = pgconf_dict.int('port')
+
+#-------------------------------------------------------------------------
+def get_config(port=0):
     """Retrieves configuration information from the catalog."""
     
     logger.info('Reading current configuration...')
-    dburl = dbconn.DbURL()
+    dburl = dbconn.DbURL(port=port)
     array = gparray.GpArray.initFromCatalog(dburl, utility=True)
     
     return array
@@ -315,7 +322,7 @@ def stop_master():
     gp.GpStop.local('Stop GPDB', masterOnly=True, fast=True)
  
 #-------------------------------------------------------------------------
-def promote_standby(master_data_dir):
+def promote_standby(master_data_dir, port):
     """Promote standby"""
 
     logger.info('Promoting standby...')
@@ -326,13 +333,10 @@ def promote_standby(master_data_dir):
     logger.debug('Waiting for connection...')
     for i in range(600):
         try:
-            dburl = dbconn.DbURL()
-            with dbconn.connect(dburl, utility=True, logConn=False) as conn:
-                # When the new master is available for connections, we should
-                # run a CHECKPOINT to force the new TimeLineID to be written to
-                # the pg_control file.
-                dbconn.execSQL(conn, 'CHECKPOINT')
-            logger.info('Standby master is promoted')
+            dburl = dbconn.DbURL(port=port)
+            conn = dbconn.connect(dburl, utility=True, logConn=False)
+            dbconn.execSQL(conn, 'CHECKPOINT')
+            conn.close()
             return True
         except pygresql.InternalError as e:
             pass
@@ -342,25 +346,25 @@ def promote_standby(master_data_dir):
 
 
 #-------------------------------------------------------------------------
-def check_standby_activation(options_, err):
+def check_standby_activation(options, err):
     """
     Check if standby was promoted and running.
     """
 
     # Here we check that gpstop or something else accidentally hasn't stopped
     # our standby we're activating.
-    pid = gp.get_postmaster_pid_locally(options_.coordinator_data_dir)
+    pid = gp.get_postmaster_pid_locally(options.master_data_dir)
     if pid > 0:
         # We should wrap this in try/catch because we could get here after
         # unsuccessful promotion and standby may not be able to accept queries
         try:
-            array = get_config()
+            array = get_config(options.standby_port)
         except Exception as e:
             logger.warning("Couldn't get cluster configuration.")
             return False
-        if array.coordinator.isSegmentCoordinator(current_role=True):
+        if array.master.isSegmentMaster(current_role=True):
             logger.warning('Encountered exception: %s.' %str(err))
-            print_results(array, unix.getLocalHostname(), options_, False)
+            print_results(array, unix.getLocalHostname(), options, False)
             return True
     return False
 
@@ -381,6 +385,7 @@ setup_tool_logging(EXECNAME, unix.getLocalHostname(), unix.getUserName())
 
 # parse args and options
 (options_, args_) = parseargs()
+read_standby_port_from_postgresqlconf(options_)
 
 # if we got a new log dir, we can now set it up.
 if options_.logfile:
@@ -401,14 +406,14 @@ try:
 
     # promote standby, only if the standby is running in recovery
     if not requires_restart:
-        res = promote_standby(options_.master_data_dir)
+        res = promote_standby(options_.master_data_dir, options_.standby_port)
         if not res:
             raise GpActivateStandbyException('Either the set port is incorrect or '
                                              'the postmaster could not come up.')
 
     # now we can access the catalog.  promote action has already updated
     # catalog, so array.master is the old (promoted) standby at this point.
-    array_ = get_config()
+    array_ = get_config(options_.standby_port)
 
     # If we forced to start utility master, this is the time to restart
     # cluster so that the new master becomes dispatch mode.
@@ -428,10 +433,10 @@ except (ExecutionError, GpActivateStandbyException) as e:
     if (check_standby_activation(options_, e)):
         sys.exit(1)
     else:
-        logger.fatal('Error activating standby coordinator: %s' % str(e))
+        logger.fatal('Error activating standby master: %s' % str(e))
         sys.exit(2)
 except Exception as e:
-    logger.fatal('Error activating standby coordinator: %s' % str(e))
+    logger.fatal('Error activating standby master: %s' % str(e))
     sys.exit(2)
 
 sys.exit(0)

--- a/gpMgmt/doc/gpactivatestandby_help
+++ b/gpMgmt/doc/gpactivatestandby_help
@@ -128,6 +128,22 @@ OPTIONS
 
  Displays the online help. 
 
+*****************************************************
+EXIT STATUS
+*****************************************************
+
+Normally, the exit status is 0, which means that the standby was promoted and
+successfully activated as the master without encountering any errors. 
+
+An exit status of 1 means that the utility encountered an unexpected internal
+failure that is not handled by the normal error-handling path.
+
+An exit status of 2 means that the utility encountered an expected error that
+is somewhat handled appropriately.
+
+An exit status of 3 means that the standby was successfully promoted, but some
+non-critical errors were encountered that could not be ignored and should be
+examined. These errors do not mean that the utility failed in its purpose.
 
 *****************************************************
 EXAMPLES

--- a/gpMgmt/doc/gpactivatestandby_help
+++ b/gpMgmt/doc/gpactivatestandby_help
@@ -133,13 +133,13 @@ EXIT STATUS
 *****************************************************
 
 Normally, the exit status is 0, which means that the standby was promoted and
-successfully activated as the master without encountering any errors. 
+successfully activated as the master without encountering any errors.
 
 An exit status of 1 means that the utility encountered an unexpected internal
 failure that is not handled by the normal error-handling path.
 
-An exit status of 2 means that the utility encountered an expected error that
-is somewhat handled appropriately.
+An exit status of 2 means that the utility encountered somewhat an expected
+error that is handled appropriately.
 
 An exit status of 3 means that the standby was successfully promoted, but some
 non-critical errors were encountered that could not be ignored and should be

--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -41,7 +41,7 @@ Feature: gpactivatestandby
         Then gpinitstandby should return a return code of 0
         And verify the standby master entries in catalog
         And the user runs gpactivatestandby with options "-d invalid_directory"
-        Then gpactivatestandby should return a return code of 1
+        Then gpactivatestandby should return a return code of 2
 
     Scenario: gpstate after running gpactivatestandby works
         Given the database is running

--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -76,20 +76,6 @@ Feature: gpactivatestandby
           And the tablespace is valid on the standby master
           And clean up and revert back to original master
 
-    Scenario: master can be made on dir with trailing slash
-        Given the database is running
-          And the standby is not initialized
-
-         When the user runs gpinitstandby with options "-S /tmp/standby_data/"
-         Then gpinitstandby should return a return code of 0
-          And verify the standby master entries in catalog
-        
-         When the master goes down
-          And the user runs gpactivatestandby with options "-d /tmp/standby_data/"
-         Then gpactivatestandby should return a return code of 0
-          And verify the standby master is now acting as master
-          And clean up and revert back to original master
-
     Scenario: activation still happens when non-critical exception is thrown
         Given the database is running
           And the standby is not initialized
@@ -112,6 +98,20 @@ Feature: gpactivatestandby
          Then gprecoverseg should return a return code of 0
           And the user runs command "gprecoverseg -a -s -r" from standby coordinator
           And gprecoverseg should return a return code of 0
+          And clean up and revert back to original coordinator
+
+    Scenario: coordinator can be made on dir with trailing slash
+        Given the database is running
+          And the standby is not initialized
+
+         When the user runs gpinitstandby with options "-S /tmp/standby_data/"
+         Then gpinitstandby should return a return code of 0
+          And verify the standby coordinator entries in catalog
+        
+         When the coordinator goes down
+          And the user runs gpactivatestandby with options "-d /tmp/standby_data/"
+         Then gpactivatestandby should return a return code of 0
+          And verify the standby coordinator is now acting as coordinator
           And clean up and revert back to original coordinator
 
 ########################### @concourse_cluster tests ###########################

--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -84,30 +84,6 @@ Feature: gpactivatestandby
          Then gpinitstandby should return a return code of 0
           And verify the standby master entries in catalog
         
-         When user immediately stops all primary processes for content 1 
-         And all files in pg_wal directory are deleted from data directory of preferred primary of content 1
-         And the standby master goes down
-         Then the master goes down
-         
-         When the user runs gpactivatestandby with options "-f"
-         Then gpactivatestandby should return a return code of 1
-          And verify the standby master is now acting as master
-          And gpactivatestandby should print a "Encountered exception" warning
-
-         When the user runs command "gprecoverseg -a --differential" from standby master
-         Then gprecoverseg should return a return code of 0
-          And the user runs command "gprecoverseg -a -s -r" from standby master
-          And gprecoverseg should return a return code of 0
-          And clean up and revert back to original master
-
-    Scenario: activation still happens when non-critical exception is thrown
-        Given the database is running
-          And the standby is not initialized
-
-         When the user runs gpinitstandby with options " "
-         Then gpinitstandby should return a return code of 0
-          And verify the standby master entries in catalog
-        
          When all files in pg_xlog directory are deleted from data directory of preferred primary of content 1
           And the standby master goes down
          Then the master goes down

--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -41,7 +41,7 @@ Feature: gpactivatestandby
         Then gpinitstandby should return a return code of 0
         And verify the standby master entries in catalog
         And the user runs gpactivatestandby with options "-d invalid_directory"
-        Then gpactivatestandby should return a return code of 2
+        Then gpactivatestandby should return a return code of 1
 
     Scenario: gpstate after running gpactivatestandby works
         Given the database is running
@@ -82,37 +82,37 @@ Feature: gpactivatestandby
 
          When the user runs gpinitstandby with options " "
          Then gpinitstandby should return a return code of 0
-          And verify the standby coordinator entries in catalog
+          And verify the standby master entries in catalog
         
          When user immediately stops all primary processes for content 1 
          And all files in pg_wal directory are deleted from data directory of preferred primary of content 1
-         And the standby coordinator goes down
-         Then the coordinator goes down
+         And the standby master goes down
+         Then the master goes down
          
          When the user runs gpactivatestandby with options "-f"
          Then gpactivatestandby should return a return code of 1
-          And verify the standby coordinator is now acting as coordinator
+          And verify the standby master is now acting as master
           And gpactivatestandby should print a "Encountered exception" warning
 
-         When the user runs command "gprecoverseg -a --differential" from standby coordinator
+         When the user runs command "gprecoverseg -a --differential" from standby master
          Then gprecoverseg should return a return code of 0
-          And the user runs command "gprecoverseg -a -s -r" from standby coordinator
+          And the user runs command "gprecoverseg -a -s -r" from standby master
           And gprecoverseg should return a return code of 0
-          And clean up and revert back to original coordinator
+          And clean up and revert back to original master
 
-    Scenario: coordinator can be made on dir with trailing slash
+    Scenario: master can be made on dir with trailing slash
         Given the database is running
           And the standby is not initialized
 
          When the user runs gpinitstandby with options "-S /tmp/standby_data/"
          Then gpinitstandby should return a return code of 0
-          And verify the standby coordinator entries in catalog
+          And verify the standby master entries in catalog
         
-         When the coordinator goes down
+         When the master goes down
           And the user runs gpactivatestandby with options "-d /tmp/standby_data/"
          Then gpactivatestandby should return a return code of 0
-          And verify the standby coordinator is now acting as coordinator
-          And clean up and revert back to original coordinator
+          And verify the standby master is now acting as master
+          And clean up and revert back to original master
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster

--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -90,6 +90,30 @@ Feature: gpactivatestandby
           And verify the standby master is now acting as master
           And clean up and revert back to original master
 
+    Scenario: activation still happens when non-critical exception is thrown
+        Given the database is running
+          And the standby is not initialized
+
+         When the user runs gpinitstandby with options " "
+         Then gpinitstandby should return a return code of 0
+          And verify the standby coordinator entries in catalog
+        
+         When user immediately stops all primary processes for content 1 
+         And all files in pg_wal directory are deleted from data directory of preferred primary of content 1
+         And the standby coordinator goes down
+         Then the coordinator goes down
+         
+         When the user runs gpactivatestandby with options "-f"
+         Then gpactivatestandby should return a return code of 1
+          And verify the standby coordinator is now acting as coordinator
+          And gpactivatestandby should print a "Encountered exception" warning
+
+         When the user runs command "gprecoverseg -a --differential" from standby coordinator
+         Then gprecoverseg should return a return code of 0
+          And the user runs command "gprecoverseg -a -s -r" from standby coordinator
+          And gprecoverseg should return a return code of 0
+          And clean up and revert back to original coordinator
+
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 

--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -89,7 +89,7 @@ Feature: gpactivatestandby
          Then the master goes down
          
          When the user runs gpactivatestandby with options "-f"
-         Then gpactivatestandby should return a return code of 1
+         Then gpactivatestandby should return a return code of 3
           And verify the standby master is now acting as master
           And gpactivatestandby should print a "Encountered exception" warning
 

--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -100,6 +100,29 @@ Feature: gpactivatestandby
           And gprecoverseg should return a return code of 0
           And clean up and revert back to original master
 
+    Scenario: activation still happens when non-critical exception is thrown
+        Given the database is running
+          And the standby is not initialized
+
+         When the user runs gpinitstandby with options " "
+         Then gpinitstandby should return a return code of 0
+          And verify the standby master entries in catalog
+        
+         When all files in pg_xlog directory are deleted from data directory of preferred primary of content 1
+          And the standby master goes down
+         Then the master goes down
+         
+         When the user runs gpactivatestandby with options "-f"
+         Then gpactivatestandby should return a return code of 1
+          And verify the standby master is now acting as master
+          And gpactivatestandby should print a "Encountered exception" warning
+
+         When the user runs command "gprecoverseg -a --differential" from standby master
+         Then gprecoverseg should return a return code of 0
+          And the user runs command "gprecoverseg -a -s -r" from standby master
+          And gprecoverseg should return a return code of 0
+          And clean up and revert back to original master
+
     Scenario: master can be made on dir with trailing slash
         Given the database is running
           And the standby is not initialized

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -426,8 +426,8 @@ def impl(context, env_var):
     del context.orig_env[env_var]
 
 
-@given('all files in pg_wal directory are deleted from data directory of preferred primary of content {content_ids}')
-@when('all files in pg_wal directory are deleted from data directory of preferred primary of content {content_ids}')
+@given('all files in pg_xlog directory are deleted from data directory of preferred primary of content {content_ids}')
+@when('all files in pg_xlog directory are deleted from data directory of preferred primary of content {content_ids}')
 def impl(context, content_ids):
     all_segments = GpArray.initFromCatalog(dbconn.DbURL()).getDbList()
     segments = [seg for seg in all_segments if seg.getSegmentPreferredRole() == ROLE_PRIMARY and

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -426,7 +426,8 @@ def impl(context, env_var):
     del context.orig_env[env_var]
 
 
-@given('all files in pg_xlog directory are deleted from data directory of preferred primary of content {content_ids}')
+@given('all files in pg_wal directory are deleted from data directory of preferred primary of content {content_ids}')
+@when('all files in pg_wal directory are deleted from data directory of preferred primary of content {content_ids}')
 def impl(context, content_ids):
     all_segments = GpArray.initFromCatalog(dbconn.DbURL()).getDbList()
     segments = [seg for seg in all_segments if seg.getSegmentPreferredRole() == ROLE_PRIMARY and
@@ -1440,6 +1441,7 @@ def stop_segments(context, where_clause):
 
 
 @given('user immediately stops all {segment_type} processes for content {content}')
+@when('user immediately stops all {segment_type} processes for content {content}')
 @then('user immediately stops all {segment_type} processes for content {content}')
 def stop_all_primary_or_mirror_segments(context, segment_type, content):
     if segment_type not in ("primary", "mirror"):


### PR DESCRIPTION
In some cases, the `gpactivatestandby` utility exits with status code 2, which
indicates that an exception was caught and handled. This can be confusing
because, depending on the exception, the standby may or may not have been
successfully promoted.

To avoid this ambiguity, handle certain exceptions more gracefully and report
the actual cluster state to the user. To do this, check whether the standby is
active and has been promoted, then return the appropriate exit code.

The exit codes now have the following meanings:

-   0 - Standby activated successfully
-   1 - Command encountered an unexpected internal failure that couldn't be
handled by the normal error-handling path
-   2 - Standby activation failed
-   3 - Standby activated successfully but exceptions were encountered

This patch also removes the unused `warnings_generated` variable. Its value was
never used because an exception was always raised before it could affect the
exit status.
It also reworks how port and hostname of standby are got: from now on we're not
getting them from global variables: port is got from `postgresql.conf` file
and hostname is always `localhost` as this utility is always launched from
corresponding host. These things have been changed in this patch because
first: other utilities that are being used inside `gpactivatestandby` take port
and other parameters not from global variables, but from files
(`postgresql.conf`, `postmaster.pid`), and second: we can not determine if
standby was promoted successfully if we're using port and hostname from
env. variable (as it was mentioned, underlying utils for promotion, i.e.
`gpstart`, use port from configuration file, not env. variable, and hostname is
always `localhost` for them for obvious reasons).