### PR TITLE
Fix ggrebalance hanging during planning if the segment host is unreachable

### DIFF
--- a/gpMgmt/bin/ggrebalance_modules/planner.py
+++ b/gpMgmt/bin/ggrebalance_modules/planner.py
@@ -384,7 +384,7 @@ class PortAllocator:
                 ctxt=REMOTE,
                 remoteHost=host.address
             )
-            cmd.run()
+            cmd.run(validateAfter=True)
             
             is_available = cmd.is_port_available()
             
@@ -395,9 +395,7 @@ class PortAllocator:
             return is_available
             
         except Exception as e:
-            self.logger.warning(f"Failed to verify port {port} on {host.hostname}: {e}. Assuming available.")
-            # On error, assume available
-            return True
+            raise PlanningError(f"Failed to verify port {port} on {host.hostname}: {e}.")
     
     def _verify_and_allocate_port(self, host: Host, preferred_port: int) -> int:
         """

--- a/gpMgmt/bin/ggrebalance_modules/test/test_unit_resources.py
+++ b/gpMgmt/bin/ggrebalance_modules/test/test_unit_resources.py
@@ -1386,6 +1386,21 @@ class TestPortAllocator(GpTestCase):
         # Should return True without checking
         self.assertTrue(result)
         mock_port_is_available.assert_not_called()
+
+    def test_check_port_on_unavailable_host(self):
+        """Test port checking on the host which is not available"""
+        segments = []
+        gparray_mock = self._create_mock_gparray(segments)
+        allocator = PortAllocator(gparray_mock, self.logger, verify_ports=True)
+
+        host = Host(hostname='host1', address='10.0.0.1', status=HostStatus.NEW)
+        exception_occured = False
+        try:
+            allocator._check_port_on_host(host, 6000)
+        except Exception:
+            exception_occured = True
+        if not exception_occured:
+            self.fail()
     
     @patch('ggrebalance_modules.planner.PortIsAvailable')
     def test_verify_and_allocate_port_preferred_available(self, mock_port_is_available):

--- a/gpMgmt/bin/ggrebalance_modules/test/test_unit_resources.py
+++ b/gpMgmt/bin/ggrebalance_modules/test/test_unit_resources.py
@@ -183,6 +183,7 @@ class TestResourceEstimator(GpTestCase):
         self.options.skip_rebalance = False
         self.options.skip_resource_estimation = False
         self.options.batch_size = 16
+        self.options.solver_seed = 42
     
     @patch('ggrebalance_modules.planner.dbconn')
     def test_estimate_segment_sizes_from_unbalanced_cluster(self, mock_dbconn):


### PR DESCRIPTION
Fix ggrebalance hanging during planning if the segment host is unreachable

Problem description:
ggrebalance tool could hang during rebalance planning in case one of the segment
hosts was unreachable at that time.

Root cause:
ggrebalance hung at the stage of searching for an available port on the segment
host. The ssh command for port probing timed out, but the timeout error was not
properly handled, and it was interpreted as just a busy port. Therefore, the
planner continued to check the next port and so on, till the port limit was
exceeded.

Fix:
Add handling of the ssh command return code and throw a planner exception in
case of any error.
