### PR TITLE
GG-699: Fix 'gpinitstandby' test step ignoring the '-S' standby directory

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -79,6 +79,20 @@ Feature: gpactivatestandby
           And the tablespace is valid on the standby coordinator
           And clean up and revert back to original coordinator
 
+    Scenario: coordinator can be made on dir with trailing slash
+        Given the database is running
+          And the standby is not initialized
+
+         When the user runs gpinitstandby with options "-S /tmp/standby_data/"
+         Then gpinitstandby should return a return code of 0
+          And verify the standby coordinator entries in catalog
+        
+         When the coordinator goes down
+          And the user runs gpactivatestandby with options "-d /tmp/standby_data/"
+         Then gpactivatestandby should return a return code of 0
+          And verify the standby coordinator is now acting as coordinator
+          And clean up and revert back to original coordinator
+
     Scenario: activation still happens when non-critical exception is thrown
         Given the database is running
           And the standby is not initialized
@@ -100,20 +114,6 @@ Feature: gpactivatestandby
          Then gprecoverseg should return a return code of 0
           And the user runs command "gprecoverseg -a -s -r" from standby coordinator
           And gprecoverseg should return a return code of 0
-          And clean up and revert back to original coordinator
-
-    Scenario: coordinator can be made on dir with trailing slash
-        Given the database is running
-          And the standby is not initialized
-
-         When the user runs gpinitstandby with options "-S /tmp/standby_data/"
-         Then gpinitstandby should return a return code of 0
-          And verify the standby coordinator entries in catalog
-        
-         When the coordinator goes down
-          And the user runs gpactivatestandby with options "-d /tmp/standby_data/"
-         Then gpactivatestandby should return a return code of 0
-          And verify the standby coordinator is now acting as coordinator
           And clean up and revert back to original coordinator
 
 ########################### @concourse_cluster tests ###########################

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import pipes
+import shlex
 import shutil
 import socket
 import tempfile
@@ -98,6 +99,42 @@ def _cluster_contains_standard_demo_segments():
         actual_segments.add( (seg.content, seg.role, seg.preferred_role) )
 
     return expected_segments == actual_segments
+
+def _options_as_list(options):
+    """
+    Normalize options into a list of tokens.
+    """
+    if options is None:
+        return []
+
+    if isinstance(options, str):
+        return shlex.split(options)
+
+    return list(options)
+
+def _get_option_value(options, flag):
+    """
+    Return the value following a flag.
+
+    Example:
+      _get_option_value(["-S", "/data/standby"], "-S")
+    """
+
+    if flag not in options:
+        return None
+
+    reverse_idx = options[::-1].index(flag)
+    idx = len(options) - 1 - reverse_idx
+
+    try:
+        value = options[idx + 1]
+    except IndexError:
+        raise ValueError("Option %s requires a value" % flag)
+
+    if not value or value.startswith("-"):
+        raise ValueError("Option %s requires a value" % flag)
+
+    return value
 
 @given('a standard local demo cluster is running')
 def impl(context):
@@ -1188,7 +1225,11 @@ def init_standby(context, coordinator_hostname, options, segment_hostname):
     remote = (coordinator_hostname != segment_hostname)
     # -n option assumes gpinitstandby already ran and put standby in catalog
     if "-n" not in options:
-        if remote:
+        if "-S" in options:
+            opts = _options_as_list(options)
+            standby_data_dir = _get_option_value(opts, '-S')
+            context.standby_data_dir = standby_data_dir
+        elif remote:
             context.standby_data_dir = coordinator_data_dir
         else:
             context.standby_data_dir = tempfile.mkdtemp() + "/standby_datadir"
@@ -1386,7 +1427,9 @@ def impl(context):
     coordinator.run()
 
     cmd = "gpactivatestandby -a -d %s" % coordinator_data_dir
-    run_gpcommand(context, cmd)
+    rc, error, _ = run_gpcommand(context, cmd)
+    if (rc != 0):
+        raise Exception('Error executing to return previous coordinator: %s.' % error)
 
 # from https://stackoverflow.com/questions/2838244/get-open-tcp-port-in-python/2838309#2838309
 def get_open_port():

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1223,16 +1223,21 @@ def impl(context):
 
 def init_standby(context, coordinator_hostname, options, segment_hostname):
     remote = (coordinator_hostname != segment_hostname)
+    opts = _options_as_list(options)
     # -n option assumes gpinitstandby already ran and put standby in catalog
-    if "-n" not in options:
-        if "-S" in options:
-            opts = _options_as_list(options)
+    if "-n" not in opts:
+        if "-S" in opts:
             standby_data_dir = _get_option_value(opts, '-S')
-            context.standby_data_dir = standby_data_dir
+            context.standby_data_dir = os.path.normpath(standby_data_dir)
         elif remote:
             context.standby_data_dir = coordinator_data_dir
         else:
             context.standby_data_dir = tempfile.mkdtemp() + "/standby_datadir"
+
+        if "-P" in opts:
+            standby_port = _get_option_value(opts, '-P')
+            context.standby_port = standby_port
+
     run_gpinitstandby(context, context.standby_hostname, context.standby_port, context.standby_data_dir, options,
                       remote)
     context.coordinator_hostname = coordinator_hostname
@@ -1427,9 +1432,8 @@ def impl(context):
     coordinator.run()
 
     cmd = "gpactivatestandby -a -d %s" % coordinator_data_dir
-    rc, error, _ = run_gpcommand(context, cmd)
-    if (rc != 0):
-        raise Exception('Error executing to return previous coordinator: %s.' % error)
+    run_gpcommand(context, cmd)
+    check_return_code(context, 0)
 
 # from https://stackoverflow.com/questions/2838244/get-open-tcp-port-in-python/2838309#2838309
 def get_open_port():


### PR DESCRIPTION
Previously trailing slash test on `gpactivatestandby` utility could have left
the cluster in unstable state. It was happening because standby's datadir could
be specified with `-S` option during the process of standby initialization, but
wouldn't be captured in context of the test (`gpinitstandby` step didn't parse
this option at all, and putted in context of the test coordinator's  directory
or randomly generated one). This was leading to incorrect `clean up and revert
back to original coordinator` step execution, which had no verification of
return codes at the end.

To fix it parsing of this flag `-S` was added, to account in context if user
specifies custom datadir. And additionally verification of return code was
added for `clean up and revert back to original coordinator`, so the errors of
execution wouldn't go unnoticed.