### PR TITLE
GG-701: Fix gpload tests with python 3 on dual-stack host

### DIFF
--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -44,6 +44,7 @@ def get_ip(hostname=None):
     for family, _, _, _, sockaddr in hostinfo:
         if family == socket.AF_INET and ipv4 is None:
             ipv4 = sockaddr[0]
+            break
         elif family == socket.AF_INET6 and ipv6 is None:
             ipv6 = sockaddr[0]
     return ipv4 or ipv6

--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -38,17 +38,15 @@ def get_port():
 def get_ip(hostname=None):
     if hostname is None:
         hostname = socket.gethostname()
-    else:
-        hostname = hostname
-    hostinfo = socket.getaddrinfo(hostname, None)
-    ipaddrlist = list(set([(ai[4][0]) for ai in hostinfo]))
-    for myip in ipaddrlist:
-        if myip.find(":") > 0:
-            ipv6 = myip
-            return ipv6
-        elif myip.find(".") > 0:
-            ipv4 = myip
-            return ipv4
+    hostinfo = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    ipv4 = None
+    ipv6 = None
+    for family, _, _, _, sockaddr in hostinfo:
+        if family == socket.AF_INET and ipv4 is None:
+            ipv4 = sockaddr[0]
+        elif family == socket.AF_INET6 and ipv6 is None:
+            ipv6 = sockaddr[0]
+    return ipv4 or ipv6
 
 def getPortMasterOnly(host = 'localhost',master_value = None,
                       user = os.environ.get('USER'),gphome = os.environ['GPHOME'],

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
@@ -62,17 +62,16 @@ def get_port():
 def get_ip(hostname=None):
     if hostname is None:
         hostname = socket.gethostname()
-    else:
-        hostname = hostname
-    hostinfo = socket.getaddrinfo(hostname, None)
-    ipaddrlist = list(set([(ai[4][0]) for ai in hostinfo]))
-    for myip in ipaddrlist:
-        if myip.find(":") > 0:
-            ipv6 = myip
-            return ipv6
-        elif myip.find(".") > 0:
-            ipv4 = myip
-            return ipv4
+    hostinfo = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    ipv4 = None
+    ipv6 = None
+    for family, _, _, _, sockaddr in hostinfo:
+        if family == socket.AF_INET and ipv4 is None:
+            ipv4 = sockaddr[0]
+            break
+        elif family == socket.AF_INET6 and ipv6 is None:
+            ipv6 = sockaddr[0]
+    return ipv4 or ipv6
 
 
 def run(cmd):


### PR DESCRIPTION
get_ip() in TEST.py and TEST_local_base.py used getaddrinfo results stored in 
a set, so the loop order was non-deterministic and could return either an IPv4 
or IPv6 address for the same host on different runs. On dual-stack hosts this 
made gpload tests flaky/fail depending on which address type won.

This commit rewrites get_ip() to query getaddrinfo with AF_UNSPEC/SOCK_STREAM, 
collect the first IPv4 and first IPv6 address separately, and 
deterministically prefer IPv4 (falling back to IPv6 only if no IPv4 address 
exists).

GG-701