### PR TITLE
GG-712: Fix HAVE_LIBZSTD being lost when configure is regenerated

### DIFF
--- a/configure
+++ b/configure
@@ -269,10 +269,10 @@ fi
     $as_echo "$0: be upgraded to zsh 4.3.4 or later."
   else
     $as_echo "$0: Please tell bug-autoconf@gnu.org and
-$0: support@greengagedb.org about your system, including any
-$0: error possibly output before this message. Then install
-$0: a modern shell, or manually run the script under such a
-$0: shell if you do have one."
+$0: support@greengagedb.org about your system, including
+$0: any error possibly output before this message. Then
+$0: install a modern shell, or manually run the script
+$0: under such a shell if you do have one."
   fi
   exit 1
 fi
@@ -1934,9 +1934,9 @@ $as_echo "$as_me: WARNING: $2: see the Autoconf documentation" >&2;}
 $as_echo "$as_me: WARNING: $2:     section \"Present But Cannot Be Compiled\"" >&2;}
     { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2: proceeding with the compiler's result" >&5
 $as_echo "$as_me: WARNING: $2: proceeding with the compiler's result" >&2;}
-( $as_echo "## ------------------------------------ ##
+( $as_echo "## -------------------------------------- ##
 ## Report this to support@greengagedb.org ##
-## ------------------------------------ ##"
+## -------------------------------------- ##"
      ) | sed "s/^/$as_me: WARNING:     /" >&2
     ;;
 esac
@@ -3311,6 +3311,8 @@ else
 fi
 
 
+
+
 #
 # include debug extensions in gpcontrib
 #
@@ -3393,6 +3395,7 @@ else
   enable_gpperfmon=no
 
 fi
+
 
 
 
@@ -6801,7 +6804,6 @@ $as_echo "$as_me: No compiler with C++11 support was found" >&6;}
 $as_echo "#define HAVE_CXX11 1" >>confdefs.h
 
   fi
-
 
 
 
@@ -11182,12 +11184,11 @@ fi
 fi
 
 if test "$with_zstd" = yes; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ZSTD_compressCCtx in -l:libzstd.a" >&5
-printf %s "checking for ZSTD_compressCCtx in -l:libzstd.a... " >&6; }
-if test ${ac_cv_lib__libzstd_a_ZSTD_compressCCtx+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ZSTD_compressCCtx in -l:libzstd.a" >&5
+$as_echo_n "checking for ZSTD_compressCCtx in -l:libzstd.a... " >&6; }
+if ${ac_cv_lib__libzstd_a_ZSTD_compressCCtx+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_check_lib_save_LIBS=$LIBS
 LIBS="-l:libzstd.a  $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -11196,36 +11197,35 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char ZSTD_compressCCtx ();
 int
-main (void)
+main ()
 {
 return ZSTD_compressCCtx ();
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_lib__libzstd_a_ZSTD_compressCCtx=yes
-else $as_nop
+else
   ac_cv_lib__libzstd_a_ZSTD_compressCCtx=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib__libzstd_a_ZSTD_compressCCtx" >&5
-printf "%s\n" "$ac_cv_lib__libzstd_a_ZSTD_compressCCtx" >&6; }
-if test "x$ac_cv_lib__libzstd_a_ZSTD_compressCCtx" = xyes
-then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib__libzstd_a_ZSTD_compressCCtx" >&5
+$as_echo "$ac_cv_lib__libzstd_a_ZSTD_compressCCtx" >&6; }
+if test "x$ac_cv_lib__libzstd_a_ZSTD_compressCCtx" = xyes; then :
 
-	LIBS="-l:libzstd.a $LIBS"
+$as_echo "#define HAVE_LIBZSTD 1" >>confdefs.h
 
-printf "%s\n" "#define HAVE_LIBZSTD 1" >>confdefs.h
-
-
-else $as_nop
+                LIBS="-l:libzstd.a $LIBS"
+else
   as_fn_error $? "zstd library not found
 If you have libzstd already installed, see config.log for details on the
 failure.  It is possible the compiler isn't looking in the proper directory.
@@ -18411,8 +18411,6 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking which random number source to use" >&5
 $as_echo_n "checking which random number source to use... " >&6; }
 
-
-
 if test x"$USE_OPENSSL_RANDOM" = x"1" ; then
 
 $as_echo "#define USE_OPENSSL_RANDOM 1" >>confdefs.h
@@ -18443,6 +18441,7 @@ if test "$PORTNAME" != "win32"; then
 else
   LATCH_IMPLEMENTATION="src/backend/port/win32_latch.c"
 fi
+
 
 # If not set in template file, set bytes to use libc memset()
 if test x"$MEMSET_LOOP_LIMIT" = x"" ; then

--- a/configure.in
+++ b/configure.in
@@ -1404,7 +1404,13 @@ Use --without-zlib to disable zlib support.])])
 fi
 
 if test "$with_zstd" = yes; then
-  AC_CHECK_LIB(:libzstd.a, ZSTD_compressCCtx, [],
+  dnl Spell out the action-if-found: the library is linked as -l:libzstd.a, so
+  dnl the name autoconf would derive for the automatic define does not match
+  dnl the HAVE_LIBZSTD the tree actually tests for.
+  AC_CHECK_LIB(:libzstd.a, ZSTD_compressCCtx,
+               [AC_DEFINE(HAVE_LIBZSTD, 1,
+                          [Define to 1 if you have the `zstd' library (-lzstd).])
+                LIBS="-l:libzstd.a $LIBS"],
                [AC_MSG_ERROR([zstd library not found
 If you have libzstd already installed, see config.log for details on the
 failure.  It is possible the compiler isn't looking in the proper directory.

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -157,6 +157,10 @@
    don't. */
 #undef HAVE_DECL_F_FULLFSYNC
 
+/* Define to 1 if you have the declaration of `gss_store_cred_into', and to 0
+   if you don't. */
+#undef HAVE_DECL_GSS_STORE_CRED_INTO
+
 /* Define to 1 if you have the declaration of `posix_fadvise', and to 0 if you
    don't. */
 #undef HAVE_DECL_POSIX_FADVISE
@@ -298,7 +302,7 @@
 /* Define to 1 if you have the <gssapi.h> header file. */
 #undef HAVE_GSSAPI_H
 
-/* Define to 1 if you have the <gssapi_ext.h> header file */
+/* Define to 0 if you do not have GSSAPI extension support. */
 #undef HAVE_GSSAPI_PROXY
 
 /* Define to 1 if you have the <history.h> header file. */
@@ -783,12 +787,6 @@
 /* Define to 1 if you have the `X509_get_signature_nid' function. */
 #undef HAVE_X509_GET_SIGNATURE_NID
 
-/* Define to 1 if your compiler understands __builtin_bswap16. */
-#undef HAVE__BUILTIN_BSWAP16
-
-/* Define to 1 if your compiler understands __builtin_bswap32. */
-#undef HAVE__BUILTIN_BSWAP32
-
 /* Define to 1 if you have the <yaml.h> header file. */
 #undef HAVE_YAML_H
 
@@ -935,21 +933,18 @@
 /* Define to 1 to build with Bonjour support. (--with-bonjour) */
 #undef USE_BONJOUR
 
-/* Define to use /dev/urandom for random number generation */
-#undef USE_DEV_URANDOM
-
 /* Define to 1 to build with libcurl support. (--with-libcurl) */
 #undef USE_CURL
 
 /* Define to 1 to build with debug_ntuplestore. (--enable-ntuplestore) */
 #undef USE_DEBUG_NTUPLESTORE
 
+/* Define to use /dev/urandom for random number generation */
+#undef USE_DEV_URANDOM
+
 /* Define to 1 if you want float4 values to be passed by value. (Always
    defined in GPDB) */
 #undef USE_FLOAT4_BYVAL
-
-/* Define to use /dev/urandom for random number generation */
-#undef USE_DEV_URANDOM
 
 /* Define to 1 if you want float8, int8, etc values to be passed by value.
    (Always defined in GPDB) */
@@ -978,14 +973,14 @@
 /* Define to select named POSIX semaphores. */
 #undef USE_NAMED_POSIX_SEMAPHORES
 
-/* Define to 1 to build with Greengage ORCA optimizer. (--enable-orca) */
-#undef USE_ORCA
-
 /* Define to build with OpenSSL support. (--with-openssl) */
 #undef USE_OPENSSL
 
 /* Define to use OpenSSL for random number generation */
 #undef USE_OPENSSL_RANDOM
+
+/* Define to 1 to build with Greengage ORCA optimizer. (--enable-orca) */
+#undef USE_ORCA
 
 /* Define to 1 to build with PAM support. (--with-pam) */
 #undef USE_PAM


### PR DESCRIPTION
### Fix HAVE_LIBZSTD being lost when configure is regenerated

The zstd probe in the committed configure was spliced in by hand from an autoconf 2.71 run without updating configure.in, so the two disagree. configure.in calls AC_CHECK_LIB(:libzstd.a, ...) with an empty action-if-found, which makes autoconf derive HAVE_LIB_LIBZSTD_A, while the committed configure defines HAVE_LIBZSTD -- the macro the tree actually tests, in 12 files.  Running `make -C gpAux autoconf` would therefore have silently disabled zstd support.

Spell out the action-if-found so configure.in reproduces the behaviour the committed configure already had, and regenerate with autoconf 2.69.

Regenerating also syncs pre-existing drift in pg_config.h.in: a duplicated USE_DEV_URANDOM entry, a missing HAVE_DECL_GSS_STORE_CRED_INTO template whose define was being dropped, and two HAVE__BUILTIN_BSWAP* templates that no configure run defines.  None of these change behaviour.

Task: [[GG-712](https://tracker.yandex.ru/GG-712)]
