### PR TITLE
Add support for local (coordinator-only) extensions

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1455,6 +1455,47 @@ class gpexpand(object):
         statements = ["delete from pg_catalog.%s" % tab for tab in MASTER_ONLY_TABLES]
 
         """
+        Purge every extension-member table unconditionally, regardless of
+        whether the owning extension is local or not. A brand-new segment's
+        pg_basebackup clone of the coordinator has no business holding
+        pre-existing rows for any table: for a local (coordinator-only)
+        extension the data is never supposed to live on a segment at all,
+        and for a normally-distributed extension table the coordinator's
+        own local storage never holds any row data to begin with, so the
+        clone can't have leaked anything real - the delete is a no-op
+        there. Any legitimate rows a normally-distributed table needs on
+        the new segments come from the standard gpexpand redistribution
+        phase.
+
+        The table list is looked up once per database, via the coordinator
+        (self.dburl), and reused for every new segment below, rather than
+        being re-queried per (segment, database) pair: a new segment's
+        catalog at this point is an untouched clone of the coordinator's -
+        the same assumption the MASTER_ONLY_TABLES cleanup above already
+        relies on - so the coordinator's answer is exactly what each
+        segment's own catalog would give too.
+        """
+        extTablesSql = '''select quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name from
+            pg_class c
+            join pg_namespace n on c.relnamespace = n.oid
+            join pg_depend d on c.oid = d.objid
+            where
+            c.relkind = 'r' and
+            d.deptype = 'e' and
+            d.classid = 'pg_class'::regclass and
+            d.refclassid = 'pg_extension'::regclass'''
+
+        db_statements_by_dbname = {}
+        url = copy.deepcopy(self.dburl)
+        for database in databases:
+            if database[0] == 'template0':
+                continue
+            url.pgdb = database[0]
+            with closing (dbconn.connect(url, encoding='UTF8')) as conn:
+                cursor = dbconn.execSQL(conn, extTablesSql)
+                db_statements_by_dbname[database[0]] = statements + ["delete from %s" % row[0] for row in cursor]
+
+        """
           Connect to each database in the new segments, and clean up the catalog tables.
         """
         for seg in newSegments:
@@ -1468,37 +1509,7 @@ class gpexpand(object):
                                      , dbname=database[0]
                                      )
 
-
-                url = copy.deepcopy(self.dburl)
-                url.pgdb = database[0]
-                db_statements = statements
-                with closing (dbconn.connect(url, encoding='UTF8')) as conn:
-                    """
-                    Purge every extension-member table unconditionally,
-                    regardless of whether the owning extension is local or
-                    not. A brand-new segment's pg_basebackup clone of the
-                    coordinator has no business holding pre-existing rows
-                    for any table: for a local (coordinator-only) extension
-                    the data is never supposed to live on a segment at all,
-                    and for a normally-distributed extension table the
-                    coordinator's own local storage never holds any row
-                    data to begin with, so the clone can't have leaked
-                    anything real - the delete is a no-op there. Any
-                    legitimate rows a normally-distributed table needs on
-                    the new segments come from the standard gpexpand
-                    redistribution phase.
-                    """
-                    extTablesSql = '''select quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name from
-                        pg_class c
-                        join pg_namespace n on c.relnamespace = n.oid
-                        join pg_depend d on c.oid = d.objid
-                        where
-                        c.relkind = 'r' and
-                        d.deptype = 'e' and
-                        d.classid = 'pg_class'::regclass and
-                        d.refclassid = 'pg_extension'::regclass'''
-                    cursor = dbconn.execSQL(conn, extTablesSql)
-                    db_statements = db_statements + ["delete from %s" % row[0] for row in cursor]
+                db_statements = db_statements_by_dbname[database[0]]
 
                 name = "gpexpand execute segment cleanup commands. seg dbid = %s, command = %s" % (
                     seg.getSegmentDbId(), str(db_statements))

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1467,11 +1467,44 @@ class gpexpand(object):
                                      , port=seg.getSegmentPort()
                                      , dbname=database[0]
                                      )
+
+
+                url = copy.deepcopy(self.dburl)
+                url.pgdb = database[0]
+                db_statements = statements
+                with closing (dbconn.connect(url, encoding='UTF8')) as conn:
+                    """
+                    Purge every extension-member table unconditionally,
+                    regardless of whether the owning extension is local or
+                    not. A brand-new segment's pg_basebackup clone of the
+                    coordinator has no business holding pre-existing rows
+                    for any table: for a local (coordinator-only) extension
+                    the data is never supposed to live on a segment at all,
+                    and for a normally-distributed extension table the
+                    coordinator's own local storage never holds any row
+                    data to begin with, so the clone can't have leaked
+                    anything real - the delete is a no-op there. Any
+                    legitimate rows a normally-distributed table needs on
+                    the new segments come from the standard gpexpand
+                    redistribution phase.
+                    """
+                    extTablesSql = '''select quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name from
+                        pg_class c
+                        join pg_namespace n on c.relnamespace = n.oid
+                        join pg_depend d on c.oid = d.objid
+                        where
+                        c.relkind = 'r' and
+                        d.deptype = 'e' and
+                        d.classid = 'pg_class'::regclass and
+                        d.refclassid = 'pg_extension'::regclass'''
+                    cursor = dbconn.execSQL(conn, extTablesSql)
+                    db_statements = db_statements + ["delete from %s" % row[0] for row in cursor]
+
                 name = "gpexpand execute segment cleanup commands. seg dbid = %s, command = %s" % (
-                    seg.getSegmentDbId(), str(statements))
+                    seg.getSegmentDbId(), str(db_statements))
                 execSQLCmd = ExecuteSQLStatementsCommand(name=name
                                                          , url=dburl
-                                                         , sqlCommandList=statements
+                                                         , sqlCommandList=db_statements
                                                          )
                 self.pool.addCommand(execSQLCmd)
 

--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -67,6 +67,7 @@
 
 /* Globally visible state variables */
 bool		creating_extension = false;
+bool		creating_extension_local = false;
 Oid			CurrentExtensionObject = InvalidOid;
 
 /* File visible "segment" variable for GUCs state */
@@ -87,6 +88,7 @@ typedef struct ExtensionControlFile
 	bool		superuser;		/* must be superuser to install? */
 	int			encoding;		/* encoding of the script file, or -1 */
 	List	   *requires;		/* names of prerequisite extensions */
+	bool		local;			/* must the extension run coordinator-only? */
 } ExtensionControlFile;
 
 /*
@@ -572,6 +574,14 @@ parse_extension_control_file(ExtensionControlFile *control,
 						item->name)));
 			}
 		}
+		else if (strcmp(item->name, "gg_local") == 0)
+		{
+			if (!parse_bool(item->value, &control->local))
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("parameter \"%s\" requires a Boolean value",
+								item->name)));
+		}
 		else
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
@@ -605,6 +615,7 @@ read_extension_control_file(const char *extname)
 	control->relocatable = false;
 	control->superuser = true;
 	control->encoding = -1;
+	control->local = false;
 
 	/*
 	 * Parse the primary control file.
@@ -896,6 +907,8 @@ execute_extension_script(Node *stmt,
 	 * things. On failure, ensure we reset these variables.
 	 */
 	creating_extension = true;
+	if (Gp_role != GP_ROLE_EXECUTE)
+		creating_extension_local = control->local;
 	CurrentExtensionObject = extensionOid;
 
 	/*
@@ -990,6 +1003,7 @@ execute_extension_script(Node *stmt,
 		 * during abort transaction. (refer: AtAbort_Extension_QE()).
 		 */
 		creating_extension = false;
+		creating_extension_local = false;
 		CurrentExtensionObject = InvalidOid;
 
 		/*
@@ -1001,6 +1015,7 @@ execute_extension_script(Node *stmt,
 	PG_END_TRY();
 
 	creating_extension = false;
+	creating_extension_local = false;
 	CurrentExtensionObject = InvalidOid;
 
 	/*

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -773,12 +773,7 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId, char relstorage, boo
 		policy = intoPolicy;
 	}
 	else
-	{
-		if (creating_extension_local)
-			policy = NULL; /* POLICYTYPE_ENTRY for local extensions */
-		else
-			policy = getPolicyForDistributedBy(stmt->distributedBy, descriptor);
-	}
+		policy = getPolicyForDistributedBy(stmt->distributedBy, descriptor);
 
 	/* Greengage specific code */
 	if (list_length(schema) == 0)

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -70,6 +70,7 @@
 #include "commands/copy.h"
 #include "commands/comment.h"
 #include "commands/defrem.h"
+#include "commands/extension.h"
 #include "commands/sequence.h"
 #include "commands/tablecmds.h"
 #include "commands/tablespace.h"
@@ -772,7 +773,12 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId, char relstorage, boo
 		policy = intoPolicy;
 	}
 	else
-		policy = getPolicyForDistributedBy(stmt->distributedBy, descriptor);
+	{
+		if (creating_extension_local)
+			policy = NULL; /* POLICYTYPE_ENTRY for local extensions */
+		else
+			policy = getPolicyForDistributedBy(stmt->distributedBy, descriptor);
+	}
 
 	/* Greengage specific code */
 	if (list_length(schema) == 0)

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -70,7 +70,6 @@
 #include "commands/copy.h"
 #include "commands/comment.h"
 #include "commands/defrem.h"
-#include "commands/extension.h"
 #include "commands/sequence.h"
 #include "commands/tablecmds.h"
 #include "commands/tablespace.h"

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -55,6 +55,7 @@
 #include "cdb/cdbendpoint.h"
 #include "catalog/gp_policy.h"
 #include "commands/defrem.h"
+#include "commands/extension.h"
 #include "access/htup_details.h"
 #include "optimizer/clauses.h"
 #include "optimizer/tlist.h"
@@ -3321,6 +3322,22 @@ transformCreateTableAsStmt(ParseState *pstate, CreateTableAsStmt *stmt)
 {
 	Query	   *result;
 	Query	   *query;
+
+	/*
+	 * CREATE TABLE AS / CREATE MATERIALIZED VIEW are not supported inside a
+	 * local extension's install/upgrade script.
+	 * Unlike plain CREATE TABLE, their distribution-policy assignment is
+	 * not aware of creating_extension_local, and even suppressing that
+	 * policy assignment is not sufficient on its own: the populate phase
+	 * still dispatches as a normal writer-gang operation across segments.
+	 * Until that is fixed, reject this outright.
+	 */
+	if (creating_extension_local)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("CREATE TABLE AS and CREATE MATERIALIZED VIEW are not "
+						"supported inside a local extension script"),
+				 errhint("Use CREATE TABLE followed by INSERT INTO ... SELECT instead.")));
 
 	/* transform contained query */
 	query = transformStmt(pstate, stmt->query);

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -456,8 +456,8 @@ transformCreateStmt(CreateStmt *stmt, const char *queryString, bool createPartit
 		if (creating_extension_local &&
 			(stmt->partitionBy != NULL || stmt->is_part_child))
 			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-					 errmsg("cannot create partition table in inside a local extension script")));
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("cannot create partition table inside a local extension script")));
 
 		AssertImply(stmt->is_part_parent,
 					stmt->distributedBy == NULL);

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -43,6 +43,7 @@
 #include "catalog/pg_type_encoding.h"
 #include "commands/comment.h"
 #include "commands/defrem.h"
+#include "commands/extension.h"
 #include "commands/tablecmds.h"
 #include "commands/tablespace.h"
 #include "miscadmin.h"
@@ -444,6 +445,19 @@ transformCreateStmt(CreateStmt *stmt, const char *queryString, bool createPartit
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
 					 errmsg("cannot create partition table in utility mode")));
+
+		/*
+		 * Partitioned tables aren't supported inside a local extension
+		 * script: transformDistributedBy() unconditionally nulls out
+		 * distributedBy for creating_extension_local below, but partition
+		 * children require it non-NULL (see the numsegments handling
+		 * further down).
+		 */
+		if (creating_extension_local &&
+			(stmt->partitionBy != NULL || stmt->is_part_child))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
+					 errmsg("cannot create partition table in inside a local extension script")));
 
 		AssertImply(stmt->is_part_parent,
 					stmt->distributedBy == NULL);
@@ -1849,10 +1863,38 @@ transformDistributedBy(CreateStmtContext *cxt,
 	int			numsegments;
 
 	/*
-	 * utility mode creates can't have a policy.  Only the QD can have policies
+	 * utility mode creates can't have a policy.  Only the QD can have policies.
+	 *
+	 * IsBinaryUpgrade normally bypasses this, since --binary-upgrade restore
+	 * runs entirely in utility mode but still needs real policies computed
+	 * for tables that were actually distributed (pg_dump always emits an
+	 * explicit DISTRIBUTED BY/RANDOMLY/REPLICATED clause for those). But if
+	 * there is no such clause, the source table had no gp_distribution_policy
+	 * row at all, i.e. it was entry-distributed -- fall through to the
+	 * ordinary utility-mode behavior instead of guessing a default policy.
 	 */
-	if (Gp_role != GP_ROLE_DISPATCH && !IsBinaryUpgrade)
+	if (Gp_role != GP_ROLE_DISPATCH &&
+		(!IsBinaryUpgrade || distributedBy == NULL))
 		return NULL;
+
+	/*
+	 * POLICYTYPE_ENTRY for local extensions. An explicit distribution
+	 * (given directly, or inherited via LIKE ... INCLUDING DISTRIBUTION, or
+	 * inherited by a partition child from its parent) can't be honored, but
+	 * silently discarding it and returning NULL here isn't safe either:
+	 * some callers (partition children, writable external tables) assume a
+	 * non-NULL result whenever they passed in a non-NULL distributedBy or
+	 * likeDistributedBy, and dereference it right after the call. Error out
+	 * instead of handing them a NULL they don't check for.
+	 */
+	if (creating_extension_local)
+	{
+		if (distributedBy != NULL || likeDistributedBy != NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("explicit distribution is not supported inside a local extension script")));
+		return NULL;
+	}
 
 	if (distributedBy && distributedBy->numsegments > 0)
 		/* If numsegments is set in DISTRIBUTED BY use the specified value */

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -15897,9 +15897,9 @@ processExtensionTables(Archive *fout, ExtensionInfo extinfo[],
 						 * A config table is coordinator-only (entry policy)
 						 * if it has no distribution policy row.
 						 */
+						Assert(configtbl->distclause);
 						configtbl->dataObj->isCoordOnly =
-							(configtbl->distclause == NULL ||
-							 configtbl->distclause[0] == '\0');
+							 configtbl->distclause[0] == '\0';
 					}
 				}
 			}

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -2097,7 +2097,7 @@ dumpTableData(Archive *fout, TableDataInfo *tdinfo)
 	DataDumperPtr dumpFn;
 	char	   *copyStmt;
 
-	if (!dump_inserts)
+	if (!dump_inserts && !tdinfo->isCoordOnly)
 	{
 		/* Dump/restore using COPY */
 		dumpFn = dumpTableData_copy;
@@ -2111,6 +2111,13 @@ dumpTableData(Archive *fout, TableDataInfo *tdinfo)
 	}
 	else
 	{
+		if (tdinfo->oids)
+		{
+			write_msg(NULL, "options -o/--oids cannot be used "
+							"with coordinator-only tables \n");
+			write_msg(NULL, "(The INSERT command cannot set OIDs.)\n");
+			exit_nicely(1);
+		}
 		/* Restore using INSERT */
 		dumpFn = dumpTableData_insert;
 		copyStmt = NULL;
@@ -2250,6 +2257,7 @@ makeTableDataInfo(TableInfo *tbinfo, bool oids)
 	tdinfo->tdtable = tbinfo;
 	tdinfo->oids = oids;
 	tdinfo->filtercond = NULL;	/* might get set later */
+	tdinfo->isCoordOnly = false;/* might get set later */
 	addObjectDependency(&tdinfo->dobj, tbinfo->dobj.dumpId);
 
 	tbinfo->dataObj = tdinfo;
@@ -15884,6 +15892,14 @@ processExtensionTables(Archive *fout, ExtensionInfo extinfo[],
 					{
 						if (strlen(extconditionarray[j]) > 0)
 							configtbl->dataObj->filtercond = pg_strdup(extconditionarray[j]);
+
+						/*
+						 * A config table is coordinator-only (entry policy)
+						 * if it has no distribution policy row.
+						 */
+						configtbl->dataObj->isCoordOnly =
+							(configtbl->distclause == NULL ||
+							 configtbl->distclause[0] == '\0');
 					}
 				}
 			}

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -372,6 +372,7 @@ typedef struct _tableDataInfo
 	TableInfo  *tdtable;		/* link to table to dump */
 	bool		oids;			/* include OIDs in data? */
 	char	   *filtercond;		/* WHERE condition to limit rows dumped */
+	bool		isCoordOnly;	/* the table has data only on coordinator? */
 } TableDataInfo;
 
 typedef struct _indxInfo

--- a/src/include/commands/extension.h
+++ b/src/include/commands/extension.h
@@ -24,6 +24,7 @@
  * installation script.
  */
 extern PGDLLIMPORT bool creating_extension;
+extern PGDLLIMPORT bool creating_extension_local;
 extern PGDLLIMPORT Oid CurrentExtensionObject;
 
 


### PR DESCRIPTION
Add support for local (coordinator-only) extensions

This patch adds a local extension mode that lets an ordinary, MPP-incompatible
PostgreSQL extension (e.g. pg_cron-style extensions that assume a single-node
Postgres and use plain heap tables plus a persistent background worker) install
and run correctly on the coordinator only, instead of requiring every table it
creates to be dispatched and distributed across segments.

To make an extension local, a special flag should be added to the .control file
of the extension - 'gg_local = true'.

While that extension's install/upgrade script is executing, every plain
CREATE TABLE it issues is given POLICYTYPE_ENTRY (no gp_distribution_policy
row — i.e. the table lives only on the coordinator) instead of the usual
hash/random distribution a table gets when created via CREATE EXTENSION in
dispatch mode.

How entry policy is assigned:
- creating_extension_local (extension.c) is a new global, set from the control
file's local flag for the duration of execute_extension_script(), mirroring the
existing creating_extension flag. It's only set outside GP_ROLE_EXECUTE, so it
never leaks onto a QE.
- When creating_extension_local is set, `transformDistributedBy()` returns
NULL (entry policy) for a plain CREATE TABLE with no explicit distribution.

'transformDistributedBy()' now also returns NULL (entry policy) if
IsBinaryUpgrade is set and no explicit policy is supplied. It is needed for
the '--binary-upgrade' scenario.
'pg_upgrade/pg_restore --binary-upgrade' restores everything through a
coordinator-only postmaster running in utility mode. Before this change,
transformDistributedBy()'s utility-mode bypass for IsBinaryUpgrade computed
a real (hash/random) policy for every restored table, including ones that were
actually entry-distributed on the source — since dump never carries a
DISTRIBUTED BY clause for those. That produced tables with a hash policy.
Now we only compute a policy when the restore actually carries a distribution
clause; fall through to entry policy otherwise. This is safe because pg_dump
always emits an explicit DISTRIBUTED BY/RANDOMLY/REPLICATED clause for any
table that has a real policy — omitting the clause is only ever the
entry-table case.

pg_dump is updated to support config tables (the tables marked with
'pg_extension_config_dump()') of the local extensions. 'dumpTableData()' now
forces INSERT-based dumping (not COPY) for a table with no distribution policy,
since COPY would otherwise dispatch as a writer-gang operation across segments —
which doesn't work for a coordinator-only table. -o/--oids option of pg_dump
combined with such a table is rejected, matching existing pg_dump's check
for INSERT-mode dumps.

gpexpand is also updated. A segment newly added by gpexpand is bootstrapped
by cloning the coordinator's data directory, so it can inherit data for any
extension-owned table that physically exists there — most notably a local
extension's coordinator-only tables, which have real data on the coordinator's
own storage (unlike a normally-distributed table, where the coordinator never
holds row data to begin with). cleanup_new_segments() now discovers every
extension-member table (via pg_depend/pg_extension, not scoped to local
extensions specifically) and issues a DELETE for each.

Current limitations:
- Partitioned tables are rejected inside a local extension script, as
supporting them would require reworking assumptions baked into the legacy
GPDB partitioning code.
- CREATE TABLE AS / CREATE MATERIALIZED VIEW are rejected: their
distribution-policy assignment goes through a different path
(setQryDistributionPolicy()/apply_motion()) that isn't aware of
creating_extension_local, and even suppressing that isn't sufficient on its
own — the populate phase still dispatches as a normal writer-gang operation.
Use CREATE TABLE + INSERT INTO ... SELECT instead.
- If the table does carry an explicit distribution — a plain DISTRIBUTED BY
clause, LIKE ... INCLUDING DISTRIBUTION - such cases are rejected as well.
As the feature is targeting native PG extensions, that is unlikely to happen in
real life.
- Still there can be SQL commands not supported by the Greengage. For ex.
queries with multiple writing CTEs.

New tests are not included in this patch, as yet there is no real extension
in our src code tree, that we can use as a local one.