### PR TITLE
CI-6178 Add workflow to run resgroup v2 tests

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -33,7 +33,8 @@ operating systems:
   - Behave tests
   - Regression tests
   - Orca tests
-  - Resource group tests
+  - Resource group tests (cgroup v1)
+  - Resource group v2 tests (cgroup v2, version 7.x only)
   - JIT tests (version 7.x only)
   - pg_upgrade test (Ubuntu 22.04 only, no matrix)
 - **Upload**: Retags and pushes final Docker images to GHCR and optionally

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -109,6 +109,24 @@ jobs:
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
+  resgroup-v2-tests:
+    needs: build
+    if: github.event_name == 'pull_request'  # Only for PR
+    strategy:
+      fail-fast: false
+      matrix:
+        target_os: [ubuntu]
+    permissions:
+      contents: read  # Explicit for default behavior
+      packages: read  # Explicit for GHCR access clarity
+      actions: write  # Required for artifact upload
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup-v2.yml@v57
+    with:
+      version: 7
+      target_os: ${{ matrix.target_os }}
+    secrets:
+      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+
   jit-tests:
     needs: build
     if: github.event_name == 'pull_request'  # Only for PR


### PR DESCRIPTION
## Add workflow to run resgroup v2 tests (#581)

- added new workflow to run resgroup v2 tests;
- added info about new tests to readme.

Task: CI-6178