### PR TITLE
Add support for local (coordinator-only) extensions

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -23,6 +23,7 @@ all:
 	$(MAKE) -C contrib/dblink all
 	$(MAKE) -C contrib/indexscan all
 	$(MAKE) -C contrib/pageinspect all  # needed by src/test/isolation
+	$(MAKE) -C contrib/gp_local_test all  # needed by src/test/regress
 	$(MAKE) -C contrib/hstore all
 	$(MAKE) -C contrib/ltree all
 	$(MAKE) -C contrib/pgcrypto all
@@ -75,6 +76,7 @@ install:
 	$(MAKE) -C contrib/dblink $@
 	$(MAKE) -C contrib/indexscan $@
 	$(MAKE) -C contrib/pageinspect $@  # needed by src/test/isolation
+	$(MAKE) -C contrib/gp_local_test $@  # needed by src/test/regress
 	$(MAKE) -C contrib/hstore $@
 	$(MAKE) -C contrib/ltree $@
 	$(MAKE) -C contrib/pgcrypto $@

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -58,7 +58,8 @@ SUBDIRS += \
 		formatter \
 		formatter_fixedwidth \
 		extprotocol \
-		indexscan
+		indexscan \
+		gp_local_test
 
 ifeq ($(with_openssl),yes)
 SUBDIRS += sslinfo

--- a/contrib/gp_local_test/Makefile
+++ b/contrib/gp_local_test/Makefile
@@ -1,0 +1,19 @@
+# contrib/gp_local_test/Makefile
+
+EXTENSION = gp_local_test
+DATA = gp_local_test--1.0.sql \
+       gp_local_test--1.1.sql \
+       gp_local_test--1.0--1.1.sql \
+       gp_local_test--1.1--1.0.sql
+PGFILEDESC = "gp_local_test - sample extension for testing local (coordinator-only) extensions"
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = contrib/gp_local_test
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/contrib/gp_local_test/gp_local_test--1.0--1.1.sql
+++ b/contrib/gp_local_test/gp_local_test--1.0--1.1.sql
@@ -1,0 +1,41 @@
+-- gp_local_test--1.0--1.1.sql
+\echo Use "ALTER EXTENSION gp_local_test UPDATE TO '1.1'" to load this file. \quit
+
+ALTER TABLE @extschema@.state ADD COLUMN last_reset timestamptz;
+
+CREATE TABLE @extschema@.history (
+    id         serial PRIMARY KEY,
+    code       text NOT NULL,
+    old_value  integer NOT NULL,
+    new_value  integer NOT NULL,
+    changed_at timestamptz UNIQUE NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION @extschema@.bump_counter(p_code text) RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_old integer;
+    v_new integer;
+BEGIN
+    UPDATE @extschema@.state
+       SET value = value + 1,
+           updated_at = now()
+     WHERE code = p_code
+    RETURNING value - 1, value INTO v_old, v_new;
+
+    INSERT INTO @extschema@.history (code, old_value, new_value)
+    VALUES (p_code, v_old, v_new);
+
+    RETURN v_new;
+END;
+$$;
+
+CREATE FUNCTION @extschema@.reset_counter(p_code text) RETURNS void
+LANGUAGE sql
+AS $$
+    UPDATE @extschema@.state
+       SET value = 0,
+           last_reset = now()
+     WHERE code = p_code;
+$$;

--- a/contrib/gp_local_test/gp_local_test--1.0.sql
+++ b/contrib/gp_local_test/gp_local_test--1.0.sql
@@ -1,0 +1,47 @@
+-- gp_local_test--1.0.sql
+\echo Use "CREATE EXTENSION gp_local_test" to load this file. \quit
+
+-- Deliberately vanilla: no DISTRIBUTED BY, no Greengage-specific clauses.
+-- id is PRIMARY KEY *and* code is independently UNIQUE — two
+-- non-overlapping unique constraints, which fails under Greengage's
+-- default hash-distributed policy but is perfectly ordinary Postgres.
+CREATE TABLE @extschema@.state (
+    id         serial PRIMARY KEY,
+    code       text UNIQUE NOT NULL,
+    value      integer NOT NULL DEFAULT 0,
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+INSERT INTO @extschema@.state (code, value) VALUES ('counter', 0);
+
+-- Genuine "config" table: DBA-tunable settings that must survive
+-- backup/restore even though the rest of the extension's schema is
+-- recreated fresh by re-running this script. Marked via
+-- pg_extension_config_dump() per the standard PostgreSQL convention
+-- so pg_dump/gpbackup include its row data instead of treating it as
+-- pure extension-owned reference data.
+CREATE TABLE @extschema@.settings (
+    key   text PRIMARY KEY,
+    value text NOT NULL
+);
+
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.settings', '');
+
+-- Plain SQL-language function, no EXECUTE ON clause at all —
+-- exercises the "function defaults" side of the mechanism.
+CREATE FUNCTION @extschema@.bump_counter(p_code text) RETURNS integer
+LANGUAGE sql
+AS $$
+    UPDATE @extschema@.state
+       SET value = value + 1,
+           updated_at = now()
+     WHERE code = p_code
+    RETURNING value;
+$$;
+
+-- Plain SQL-language read, also no EXECUTE ON clause.
+CREATE FUNCTION @extschema@.current_counter(p_code text) RETURNS integer
+LANGUAGE sql STRICT
+AS $$
+    SELECT value FROM @extschema@.state WHERE code = p_code;
+$$;

--- a/contrib/gp_local_test/gp_local_test--1.1--1.0.sql
+++ b/contrib/gp_local_test/gp_local_test--1.1--1.0.sql
@@ -1,0 +1,20 @@
+-- gp_local_test--1.1--1.0.sql
+\echo Use "ALTER EXTENSION gp_local_test UPDATE TO '1.0'" to load this file. \quit
+
+DROP FUNCTION @extschema@.reset_counter(text);
+
+-- Revert bump_counter to the pre-1.1 body (no history logging)
+CREATE OR REPLACE FUNCTION @extschema@.bump_counter(p_code text) RETURNS integer
+LANGUAGE sql
+AS $$
+    UPDATE @extschema@.state
+       SET value = value + 1,
+           updated_at = now()
+     WHERE code = p_code
+    RETURNING value;
+$$;
+
+DROP TABLE @extschema@.history;
+
+ALTER TABLE @extschema@.state DROP COLUMN last_reset;
+

--- a/contrib/gp_local_test/gp_local_test--1.1.sql
+++ b/contrib/gp_local_test/gp_local_test--1.1.sql
@@ -1,0 +1,78 @@
+-- gp_local_test--1.1.sql
+\echo Use "CREATE EXTENSION gp_local_test" to load this file. \quit
+
+-- Deliberately vanilla: no DISTRIBUTED BY, no Greengage-specific clauses.
+-- id is PRIMARY KEY *and* code is independently UNIQUE — two
+-- non-overlapping unique constraints, which fails under Greengage's
+-- default hash-distributed policy but is perfectly ordinary Postgres.
+CREATE TABLE @extschema@.state (
+    id         serial PRIMARY KEY,
+    code       text UNIQUE NOT NULL,
+    value      integer NOT NULL DEFAULT 0,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    last_reset timestamptz
+);
+
+INSERT INTO @extschema@.state (code, value) VALUES ('counter', 0);
+
+-- Genuine "config" table: DBA-tunable settings that must survive
+-- backup/restore even though the rest of the extension's schema is
+-- recreated fresh by re-running this script. Marked via
+-- pg_extension_config_dump() per the standard PostgreSQL convention
+-- so pg_dump/gpbackup include its row data instead of treating it as
+-- pure extension-owned reference data.
+CREATE TABLE @extschema@.settings (
+    key   text PRIMARY KEY,
+    value text NOT NULL
+);
+
+INSERT INTO @extschema@.settings (key, value) VALUES ('bump_interval_seconds', '5');
+
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.settings', '');
+
+CREATE TABLE @extschema@.history (
+    id         serial PRIMARY KEY,
+    code       text NOT NULL,
+    old_value  integer NOT NULL,
+    new_value  integer NOT NULL,
+    changed_at timestamptz UNIQUE NOT NULL DEFAULT now()
+);
+
+-- plpgsql, no EXECUTE ON clause — logs each bump into history.
+CREATE FUNCTION @extschema@.bump_counter(p_code text) RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_old integer;
+    v_new integer;
+BEGIN
+    UPDATE @extschema@.state
+       SET value = value + 1,
+           updated_at = now()
+     WHERE code = p_code
+    RETURNING value - 1, value INTO v_old, v_new;
+
+    INSERT INTO @extschema@.history (code, old_value, new_value)
+    VALUES (p_code, v_old, v_new);
+
+    RETURN v_new;
+END;
+$$;
+
+-- Plain SQL-language function, no EXECUTE ON clause at all —
+-- exercises the "function defaults" side of the mechanism.
+CREATE FUNCTION @extschema@.reset_counter(p_code text) RETURNS void
+LANGUAGE sql
+AS $$
+    UPDATE @extschema@.state
+       SET value = 0,
+           last_reset = now()
+     WHERE code = p_code;
+$$;
+
+-- Plain SQL-language read, also no EXECUTE ON clause.
+CREATE FUNCTION @extschema@.current_counter(p_code text) RETURNS integer
+LANGUAGE sql STRICT
+AS $$
+    SELECT value FROM @extschema@.state WHERE code = p_code;
+$$;

--- a/contrib/gp_local_test/gp_local_test.control
+++ b/contrib/gp_local_test/gp_local_test.control
@@ -1,0 +1,7 @@
+# gp_local_test.control
+comment = 'Sample extension to test coordinator-only (LOCAL) semantics'
+default_version = '1.0'
+relocatable = false
+schema = 'ext_local_test'
+gg_local = true
+

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1459,6 +1459,7 @@ class gpexpand:
             where
             c.relkind = 'r' and
             d.deptype = 'e' and
+            d.objsubid = 0 and
             d.classid = 'pg_class'::regclass and
             d.refclassid = 'pg_extension'::regclass'''
 
@@ -1468,9 +1469,22 @@ class gpexpand:
             if database[0] == 'template0':
                 continue
             url.pgdb = database[0]
-            with closing (dbconn.connect(url, encoding='UTF8')) as conn:
-                cursor = dbconn.query(conn, extTablesSql)
-                db_statements_by_dbname[database[0]] = statements + ["delete from %s" % row[0] for row in cursor]
+            try:
+                with closing(dbconn.connect(url, encoding='UTF8')) as conn:
+                    ext_tables = [row[0] for row in dbconn.query(conn, extTablesSql)]
+            except Exception as e:
+                self.logger.warning(
+                    "Could not connect to database %s to look up extension-owned "
+                    "tables for new-segment cleanup, skipping: %s" % (database[0], str(e)))
+                ext_tables = []
+
+            db_statements = list(statements)
+            if ext_tables:
+                # A single TRUNCATE naming every extension table together, rather
+                # than one DELETE per table (order-dependent) or CASCADE (which
+                # could reach into unrelated, non-extension tables).
+                db_statements.append("truncate %s" % ", ".join(ext_tables))
+            db_statements_by_dbname[database[0]] = db_statements
 
         """
           Connect to each database in the new segments, and clean up the catalog tables.

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1432,6 +1432,47 @@ class gpexpand:
         statements = ["delete from pg_catalog.%s" % tab for tab in COORDINATOR_ONLY_TABLES]
 
         """
+        Purge every extension-member table unconditionally, regardless of
+        whether the owning extension is local or not. A brand-new segment's
+        pg_basebackup clone of the coordinator has no business holding
+        pre-existing rows for any table: for a local (coordinator-only)
+        extension the data is never supposed to live on a segment at all,
+        and for a normally-distributed extension table the coordinator's
+        own local storage never holds any row data to begin with, so the
+        clone can't have leaked anything real - the delete is a no-op
+        there. Any legitimate rows a normally-distributed table needs on
+        the new segments come from the standard gpexpand redistribution
+        phase.
+
+        The table list is looked up once per database, via the coordinator
+        (self.dburl), and reused for every new segment below, rather than
+        being re-queried per (segment, database) pair: a new segment's
+        catalog at this point is an untouched clone of the coordinator's -
+        the same assumption the MASTER_ONLY_TABLES cleanup above already
+        relies on - so the coordinator's answer is exactly what each
+        segment's own catalog would give too.
+        """
+        extTablesSql = '''select quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name from
+            pg_class c
+            join pg_namespace n on c.relnamespace = n.oid
+            join pg_depend d on c.oid = d.objid
+            where
+            c.relkind = 'r' and
+            d.deptype = 'e' and
+            d.classid = 'pg_class'::regclass and
+            d.refclassid = 'pg_extension'::regclass'''
+
+        db_statements_by_dbname = {}
+        url = copy.deepcopy(self.dburl)
+        for database in databases:
+            if database[0] == 'template0':
+                continue
+            url.pgdb = database[0]
+            with closing (dbconn.connect(url, encoding='UTF8')) as conn:
+                cursor = dbconn.query(conn, extTablesSql)
+                db_statements_by_dbname[database[0]] = statements + ["delete from %s" % row[0] for row in cursor]
+
+        """
           Connect to each database in the new segments, and clean up the catalog tables.
         """
         for seg in newSegments:
@@ -1444,11 +1485,14 @@ class gpexpand:
                                      , port=seg.getSegmentPort()
                                      , dbname=database[0]
                                      )
+
+                db_statements = db_statements_by_dbname[database[0]]
+
                 name = "gpexpand execute segment cleanup commands. seg dbid = %s, command = %s" % (
-                    seg.getSegmentDbId(), str(statements))
+                    seg.getSegmentDbId(), str(db_statements))
                 execSQLCmd = ExecuteSQLStatementsCommand(name=name
                                                          , url=dburl
-                                                         , sqlCommandList=statements
+                                                         , sqlCommandList=db_statements
                                                          )
                 self.pool.addCommand(execSQLCmd)
 

--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -74,6 +74,7 @@
 
 /* Globally visible state variables */
 bool		creating_extension = false;
+bool		creating_extension_local = false;
 Oid			CurrentExtensionObject = InvalidOid;
 
 /* File visible "segment" variable for GUCs state */
@@ -95,6 +96,7 @@ typedef struct ExtensionControlFile
 	bool		superuser;		/* must be superuser to install? */
 	int			encoding;		/* encoding of the script file, or -1 */
 	List	   *requires;		/* names of prerequisite extensions */
+	bool		local;			/* must the extension run coordinator-only? */
 } ExtensionControlFile;
 
 /*
@@ -591,6 +593,14 @@ parse_extension_control_file(ExtensionControlFile *control,
 								item->name)));
 			}
 		}
+		else if (strcmp(item->name, "gg_local") == 0)
+		{
+			if (!parse_bool(item->value, &control->local))
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("parameter \"%s\" requires a Boolean value",
+								item->name)));
+		}
 		else
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
@@ -624,6 +634,7 @@ read_extension_control_file(const char *extname)
 	control->relocatable = false;
 	control->superuser = true;
 	control->encoding = -1;
+	control->local = false;
 
 	/*
 	 * Parse the primary control file.
@@ -924,6 +935,8 @@ execute_extension_script(Node *stmt,
 	 * things. On failure, ensure we reset these variables.
 	 */
 	creating_extension = true;
+	if (Gp_role != GP_ROLE_EXECUTE)
+		creating_extension_local = control->local;
 	CurrentExtensionObject = extensionOid;
 
 	/*
@@ -1014,6 +1027,7 @@ execute_extension_script(Node *stmt,
 		 * during abort transaction. (refer: AtAbort_Extension_QE()).
 		 */
 		creating_extension = false;
+		creating_extension_local = false;
 		CurrentExtensionObject = InvalidOid;
 
 		/*
@@ -1025,6 +1039,7 @@ execute_extension_script(Node *stmt,
 	PG_END_TRY();
 
 	creating_extension = false;
+	creating_extension_local = false;
 	CurrentExtensionObject = InvalidOid;
 
 	/*

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -58,6 +58,7 @@
 #include "cdb/cdbendpoint.h"
 #include "catalog/gp_distribution_policy.h"
 #include "commands/defrem.h"
+#include "commands/extension.h"
 #include "access/htup_details.h"
 #include "optimizer/clauses.h"
 #include "optimizer/tlist.h"
@@ -3050,6 +3051,22 @@ transformCreateTableAsStmt(ParseState *pstate, CreateTableAsStmt *stmt)
 {
 	Query	   *result;
 	Query	   *query;
+
+	/*
+	 * CREATE TABLE AS / CREATE MATERIALIZED VIEW are not supported inside a
+	 * local extension's install/upgrade script.
+	 * Unlike plain CREATE TABLE, their distribution-policy assignment is
+	 * not aware of creating_extension_local, and even suppressing that
+	 * policy assignment is not sufficient on its own: the populate phase
+	 * still dispatches as a normal writer-gang operation across segments.
+	 * Until that is fixed, reject this outright.
+	 */
+	if (creating_extension_local)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("CREATE TABLE AS and CREATE MATERIALIZED VIEW are not "
+						"supported inside a local extension script"),
+				 errhint("Use CREATE TABLE followed by INSERT INTO ... SELECT instead.")));
 
 	/* transform contained query, not allowing SELECT INTO */
 	query = transformStmt(pstate, stmt->query);

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -45,6 +45,7 @@
 #include "catalog/pg_type.h"
 #include "commands/comment.h"
 #include "commands/defrem.h"
+#include "commands/extension.h"
 #include "commands/sequence.h"
 #include "commands/tablecmds.h"
 #include "commands/tablespace.h"
@@ -2392,10 +2393,57 @@ transformDistributedBy(ParseState *pstate,
 	int			numsegments;
 
 	/*
-	 * utility mode creates can't have a policy.  Only the QD can have policies
+	 * utility mode creates can't have a policy.  Only the QD can have policies.
+	 *
+	 * IsBinaryUpgrade normally bypasses this, since --binary-upgrade restore
+	 * runs entirely in utility mode but still needs real policies computed
+	 * for tables that were actually distributed (pg_dump always emits an
+	 * explicit DISTRIBUTED BY/RANDOMLY/REPLICATED clause for those). But if
+	 * there is no such clause, the source table had no gp_distribution_policy
+	 * row at all, i.e. it was entry-distributed -- fall through to the
+	 * ordinary utility-mode behavior instead of guessing a default policy.
 	 */
-	if (Gp_role != GP_ROLE_DISPATCH && !IsBinaryUpgrade)
+	if (Gp_role != GP_ROLE_DISPATCH &&
+		(!IsBinaryUpgrade || distributedBy == NULL))
 		return NULL;
+
+	if (creating_extension_local)
+	{
+		/*
+		 * Partitioned tables are not supported inside a local extension
+		 * script, matching the 6x local-extension patch. A partition child
+		 * of an externally-created parent that already has a real policy
+		 * can otherwise silently end up with an inconsistent (entry) policy
+		 * of its own: a plain "PARTITION OF parent FOR VALUES (...)" clause
+		 * sets neither distributedBy nor likeDistributedBy, so the explicit
+		 * distribution check below has nothing to catch. Separately,
+		 * gpexpand's redistribution-prep step cannot process an
+		 * entry-distributed partitioned table at all, and fails past the
+		 * point of rollback if it encounters one. Reject both the
+		 * partitioned parent (PARTITION BY) and any partition child
+		 * (PARTITION OF) outright until both of those are addressed.
+		 */
+		if (cxt->ispartitioned || cxt->partbound != NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("partitioned tables are not supported inside a local extension script")));
+
+		/*
+		 * POLICYTYPE_ENTRY for local extensions. An explicit distribution
+		 * (given directly, or inherited via LIKE ... INCLUDING DISTRIBUTION)
+		 * can't be honored, but silently discarding it and returning NULL
+		 * here isn't safe either: some callers (writable external tables)
+		 * assume a non-NULL result whenever they passed in a non-NULL
+		 * distributedBy or likeDistributedBy, and dereference it right
+		 * after the call. Error out instead of handing them a NULL they
+		 * don't check for.
+		 */
+		if (distributedBy != NULL || likeDistributedBy != NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("explicit distribution is not supported inside a local extension script")));
+		return NULL;
+	}
 
 	if (distributedBy && distributedBy->numsegments > 0)
 		/* If numsegments is set in DISTRIBUTED BY use the specified value */

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -2393,20 +2393,11 @@ transformDistributedBy(ParseState *pstate,
 	int			numsegments;
 
 	/*
-	 * utility mode creates can't have a policy.  Only the QD can have policies.
-	 *
-	 * IsBinaryUpgrade normally bypasses this, since --binary-upgrade restore
-	 * runs entirely in utility mode but still needs real policies computed
-	 * for tables that were actually distributed (pg_dump always emits an
-	 * explicit DISTRIBUTED BY/RANDOMLY/REPLICATED clause for those). But if
-	 * there is no such clause, the source table had no gp_distribution_policy
-	 * row at all, i.e. it was entry-distributed -- fall through to the
-	 * ordinary utility-mode behavior instead of guessing a default policy.
+	 * Checked ahead of the Gp_role/IsBinaryUpgrade fallback below: a local
+	 * extension's own install-script tables must always follow these rules
+	 * regardless of what mode the script happens to be running in -
+	 * normal or utility.
 	 */
-	if (Gp_role != GP_ROLE_DISPATCH &&
-		(!IsBinaryUpgrade || distributedBy == NULL))
-		return NULL;
-
 	if (creating_extension_local)
 	{
 		/*
@@ -2444,6 +2435,21 @@ transformDistributedBy(ParseState *pstate,
 					 errmsg("explicit distribution is not supported inside a local extension script")));
 		return NULL;
 	}
+
+	/*
+	 * utility mode creates can't have a policy.  Only the QD can have policies.
+	 *
+	 * IsBinaryUpgrade normally bypasses this, since --binary-upgrade restore
+	 * runs entirely in utility mode but still needs real policies computed
+	 * for tables that were actually distributed (pg_dump always emits an
+	 * explicit DISTRIBUTED BY/RANDOMLY/REPLICATED clause for those). But if
+	 * there is no such clause, the source table had no gp_distribution_policy
+	 * row at all, i.e. it was entry-distributed -- fall through to the
+	 * ordinary utility-mode behavior instead of guessing a default policy.
+	 */
+	if (Gp_role != GP_ROLE_DISPATCH &&
+		(!IsBinaryUpgrade || distributedBy == NULL))
+		return NULL;
 
 	if (distributedBy && distributedBy->numsegments > 0)
 		/* If numsegments is set in DISTRIBUTED BY use the specified value */

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -906,6 +906,18 @@ main(int argc, char **argv)
 	}
 
 	/*
+	 * Without dumpGpPolicy, no CREATE TABLE carries a DISTRIBUTED BY/
+	 * RANDOMLY/REPLICATED clause, so --binary-upgrade has no way to tell
+	 * what policy each table's transplanted segment files actually match --
+	 * whatever policy restore ends up assigning will be wrong.
+	 */
+	if (dopt.binary_upgrade && !dopt.dumpGpPolicy)
+	{
+		pg_log_error("options \"--binary-upgrade\" and \"--no-gp-syntax\" cannot be used together");
+		exit_nicely(1);
+	}
+
+	/*
 	 * Disable security label support if server version < v9.1.x (prevents
 	 * access to nonexistent pg_seclabel catalog)
 	 */

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -2341,7 +2341,8 @@ dumpTableData_insert(Archive *fout, const void *dcontext)
 	PGresult   *res;
 	int			nfields,
 				i;
-	int			rows_per_statement = dopt->dump_inserts;
+	int			rows_per_statement = dopt->dump_inserts > 0 ?
+		dopt->dump_inserts : DUMP_DEFAULT_ROWS_PER_INSERT;
 	int			rows_this_statement = 0;
 
 	/* Temporary allows to access to foreign tables to dump data */
@@ -2690,7 +2691,7 @@ dumpTableData(Archive *fout, const TableDataInfo *tdinfo)
 	else
 		copyFrom = fmtQualifiedDumpable(tbinfo);
 
-	if (dopt->dump_inserts == 0)
+	if (dopt->dump_inserts == 0 && !tdinfo->isCoordOnly)
 	{
 		/* Dump/restore using COPY */
 		dumpFn = dumpTableData_copy;
@@ -2863,6 +2864,7 @@ makeTableDataInfo(DumpOptions *dopt, TableInfo *tbinfo)
 	tdinfo->dobj.namespace = tbinfo->dobj.namespace;
 	tdinfo->tdtable = tbinfo;
 	tdinfo->filtercond = NULL;	/* might get set later */
+	tdinfo->isCoordOnly = false;/* might get set later */
 	addObjectDependency(&tdinfo->dobj, tbinfo->dobj.dumpId);
 
 	/* A TableDataInfo contains data, of course */
@@ -19765,6 +19767,14 @@ processExtensionTables(Archive *fout, ExtensionInfo extinfo[],
 					{
 						if (strlen(extconditionarray[j]) > 0)
 							configtbl->dataObj->filtercond = pg_strdup(extconditionarray[j]);
+
+						/*
+						 * A config table is coordinator-only (entry policy)
+						 * if it has no distribution policy row.
+						 */
+						Assert(configtbl->distclause);
+						configtbl->dataObj->isCoordOnly =
+							 configtbl->distclause[0] == '\0';
 					}
 				}
 			}

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -439,6 +439,7 @@ typedef struct _tableDataInfo
 	DumpableObject dobj;
 	TableInfo  *tdtable;		/* link to table to dump */
 	char	   *filtercond;		/* WHERE condition to limit rows dumped */
+	bool		isCoordOnly;	/* the table has data only on coordinator? */
 } TableDataInfo;
 
 typedef struct _indxInfo

--- a/src/include/commands/extension.h
+++ b/src/include/commands/extension.h
@@ -28,6 +28,7 @@
  * them from the extension first.
  */
 extern PGDLLIMPORT bool creating_extension;
+extern PGDLLIMPORT bool creating_extension_local;
 extern PGDLLIMPORT Oid CurrentExtensionObject;
 
 

--- a/src/test/regress/expected/gp_local_extension.out
+++ b/src/test/regress/expected/gp_local_extension.out
@@ -1,0 +1,242 @@
+-- Exercises the local (QD-only/coordinator-only) extension mechanism
+-- (the gg_local control-file flag) end to end, using the gp_local_test
+-- sample extension in contrib/.
+-- This test deliberately leaves the extension installed at the end (see
+-- the closing comment below), so guard against a prior run's leftover
+-- state to stay safely re-runnable against the same database.
+-- start_ignore
+DROP EXTENSION IF EXISTS gp_local_test;
+-- end_ignore
+CREATE EXTENSION gp_local_test;
+-- Every table the extension's install script created must have no
+-- distribution policy at all - that's the defining property of a
+-- QD-only table.
+SELECT count(*) FROM gp_distribution_policy
+ WHERE localoid IN ('ext_local_test.state'::regclass,
+                     'ext_local_test.settings'::regclass);
+ count 
+-------
+     0
+(1 row)
+
+-- QD-only tables live only on the coordinator (segment id -1), never
+-- dispatched to segments. EXPLAIN confirms the plan itself has no Motion
+-- node moving data from segments - it's a plain local scan.
+EXPLAIN (COSTS OFF) SELECT gp_segment_id, code, value FROM ext_local_test.state;
+            QUERY PLAN             
+-----------------------------------
+ Seq Scan on state
+ Optimizer: Postgres-based planner
+(2 rows)
+
+SELECT gp_segment_id, code, value FROM ext_local_test.state;
+ gp_segment_id |  code   | value 
+---------------+---------+-------
+            -1 | counter |     0
+(1 row)
+
+-- settings is registered via pg_extension_config_dump() with an empty
+-- (unfiltered) condition - the standard "config table" convention.
+SELECT extconfig IS NOT NULL AS has_config_tables, extcondition
+  FROM pg_extension WHERE extname = 'gp_local_test';
+ has_config_tables | extcondition 
+-------------------+--------------
+ t                 | {""}
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT key, value FROM ext_local_test.settings ORDER BY key;
+                 QUERY PLAN                 
+--------------------------------------------
+ Index Scan using settings_pkey on settings
+ Optimizer: Postgres-based planner
+(2 rows)
+
+SELECT key, value FROM ext_local_test.settings ORDER BY key;
+ key | value 
+-----+-------
+(0 rows)
+
+-- Exercise the extension's functions against the QD-only table, neither
+-- carrying any EXECUTE ON clause. Again, no Motion in the plan.
+EXPLAIN (COSTS OFF) SELECT ext_local_test.bump_counter('counter');
+            QUERY PLAN             
+-----------------------------------
+ Result
+ Optimizer: Postgres-based planner
+(2 rows)
+
+SELECT ext_local_test.bump_counter('counter');
+ bump_counter 
+--------------
+            1
+(1 row)
+
+SELECT ext_local_test.bump_counter('counter');
+ bump_counter 
+--------------
+            2
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT ext_local_test.current_counter('counter');
+            QUERY PLAN             
+-----------------------------------
+ Result
+ Optimizer: Postgres-based planner
+(2 rows)
+
+SELECT ext_local_test.current_counter('counter');
+ current_counter 
+-----------------
+               2
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT code, value FROM ext_local_test.state;
+            QUERY PLAN             
+-----------------------------------
+ Seq Scan on state
+ Optimizer: Postgres-based planner
+(2 rows)
+
+SELECT code, value FROM ext_local_test.state;
+  code   | value 
+---------+-------
+ counter |     2
+(1 row)
+
+-- Schema evolution: ALTER EXTENSION UPDATE must be able to add a column,
+-- a new table, and replace a function's language (SQL -> plpgsql) on a
+-- QD-only table, and the table must remain QD-only afterward.
+ALTER EXTENSION gp_local_test UPDATE TO '1.1';
+SELECT count(*) FROM gp_distribution_policy
+ WHERE localoid IN ('ext_local_test.state'::regclass,
+                     'ext_local_test.history'::regclass);
+ count 
+-------
+     0
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT ext_local_test.bump_counter('counter');
+            QUERY PLAN             
+-----------------------------------
+ Result
+ Optimizer: Postgres-based planner
+(2 rows)
+
+SELECT ext_local_test.bump_counter('counter');
+ bump_counter 
+--------------
+            3
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT code, old_value, new_value FROM ext_local_test.history ORDER BY id;
+                QUERY PLAN                
+------------------------------------------
+ Index Scan using history_pkey on history
+ Optimizer: Postgres-based planner
+(2 rows)
+
+SELECT code, old_value, new_value FROM ext_local_test.history ORDER BY id;
+  code   | old_value | new_value 
+---------+-----------+-----------
+ counter |         2 |         3
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT ext_local_test.reset_counter('counter');
+            QUERY PLAN             
+-----------------------------------
+ Result
+ Optimizer: Postgres-based planner
+(2 rows)
+
+SELECT ext_local_test.reset_counter('counter');
+ reset_counter 
+---------------
+ 
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT code, value FROM ext_local_test.state;
+            QUERY PLAN             
+-----------------------------------
+ Seq Scan on state
+ Optimizer: Postgres-based planner
+(2 rows)
+
+SELECT code, value FROM ext_local_test.state;
+  code   | value 
+---------+-------
+ counter |     0
+(1 row)
+
+-- And back down again.
+ALTER EXTENSION gp_local_test UPDATE TO '1.0';
+EXPLAIN (COSTS OFF) SELECT code, value FROM ext_local_test.state;
+            QUERY PLAN             
+-----------------------------------
+ Seq Scan on state
+ Optimizer: Postgres-based planner
+(2 rows)
+
+SELECT code, value FROM ext_local_test.state;
+  code   | value 
+---------+-------
+ counter |     0
+(1 row)
+
+-- Drop and re-create from scratch: the schema/tables/functions must not
+-- linger past DROP EXTENSION, and a fresh CREATE EXTENSION afterward must
+-- produce a fully working, QD-only extension again, not inherit any state
+-- from the dropped one.
+DROP EXTENSION gp_local_test;
+CREATE EXTENSION gp_local_test;
+SELECT count(*) FROM gp_distribution_policy
+ WHERE localoid IN ('ext_local_test.state'::regclass,
+                     'ext_local_test.settings'::regclass);
+ count 
+-------
+     0
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT gp_segment_id, code, value FROM ext_local_test.state;
+            QUERY PLAN             
+-----------------------------------
+ Seq Scan on state
+ Optimizer: Postgres-based planner
+(2 rows)
+
+SELECT gp_segment_id, code, value FROM ext_local_test.state;
+ gp_segment_id |  code   | value 
+---------------+---------+-------
+            -1 | counter |     0
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT ext_local_test.bump_counter('counter');
+            QUERY PLAN             
+-----------------------------------
+ Result
+ Optimizer: Postgres-based planner
+(2 rows)
+
+SELECT ext_local_test.bump_counter('counter');
+ bump_counter 
+--------------
+            1
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT ext_local_test.current_counter('counter');
+            QUERY PLAN             
+-----------------------------------
+ Result
+ Optimizer: Postgres-based planner
+(2 rows)
+
+SELECT ext_local_test.current_counter('counter');
+ current_counter 
+-----------------
+               1
+(1 row)
+
+-- Deliberately left installed (not dropped) here: gpcheckcat's normal
+-- installcheck-world pass and the pg_upgrade test (test_gpdb.sh), which
+-- both examine the "regression" database as it stands at the end of this
+-- suite, then get to exercise a real QD-only extension's catalog state
+-- and pg_upgrade path too, not just this test's own assertions.

--- a/src/test/regress/greengage_schedule
+++ b/src/test/regress/greengage_schedule
@@ -373,4 +373,6 @@ test: gp_orphaned_files
 test: libpq
 
 test: alter_rebalance
+
+test: gp_local_extension
 # end of tests

--- a/src/test/regress/sql/gp_local_extension.sql
+++ b/src/test/regress/sql/gp_local_extension.sql
@@ -1,0 +1,91 @@
+-- Exercises the local (QD-only/coordinator-only) extension mechanism
+-- (the gg_local control-file flag) end to end, using the gp_local_test
+-- sample extension in contrib/.
+
+-- This test deliberately leaves the extension installed at the end (see
+-- the closing comment below), so guard against a prior run's leftover
+-- state to stay safely re-runnable against the same database.
+-- start_ignore
+DROP EXTENSION IF EXISTS gp_local_test;
+-- end_ignore
+
+CREATE EXTENSION gp_local_test;
+
+-- Every table the extension's install script created must have no
+-- distribution policy at all - that's the defining property of a
+-- QD-only table.
+SELECT count(*) FROM gp_distribution_policy
+ WHERE localoid IN ('ext_local_test.state'::regclass,
+                     'ext_local_test.settings'::regclass);
+
+-- QD-only tables live only on the coordinator (segment id -1), never
+-- dispatched to segments. EXPLAIN confirms the plan itself has no Motion
+-- node moving data from segments - it's a plain local scan.
+EXPLAIN (COSTS OFF) SELECT gp_segment_id, code, value FROM ext_local_test.state;
+SELECT gp_segment_id, code, value FROM ext_local_test.state;
+
+-- settings is registered via pg_extension_config_dump() with an empty
+-- (unfiltered) condition - the standard "config table" convention.
+SELECT extconfig IS NOT NULL AS has_config_tables, extcondition
+  FROM pg_extension WHERE extname = 'gp_local_test';
+EXPLAIN (COSTS OFF) SELECT key, value FROM ext_local_test.settings ORDER BY key;
+SELECT key, value FROM ext_local_test.settings ORDER BY key;
+
+-- Exercise the extension's functions against the QD-only table, neither
+-- carrying any EXECUTE ON clause. Again, no Motion in the plan.
+EXPLAIN (COSTS OFF) SELECT ext_local_test.bump_counter('counter');
+SELECT ext_local_test.bump_counter('counter');
+SELECT ext_local_test.bump_counter('counter');
+EXPLAIN (COSTS OFF) SELECT ext_local_test.current_counter('counter');
+SELECT ext_local_test.current_counter('counter');
+EXPLAIN (COSTS OFF) SELECT code, value FROM ext_local_test.state;
+SELECT code, value FROM ext_local_test.state;
+
+-- Schema evolution: ALTER EXTENSION UPDATE must be able to add a column,
+-- a new table, and replace a function's language (SQL -> plpgsql) on a
+-- QD-only table, and the table must remain QD-only afterward.
+ALTER EXTENSION gp_local_test UPDATE TO '1.1';
+
+SELECT count(*) FROM gp_distribution_policy
+ WHERE localoid IN ('ext_local_test.state'::regclass,
+                     'ext_local_test.history'::regclass);
+
+EXPLAIN (COSTS OFF) SELECT ext_local_test.bump_counter('counter');
+SELECT ext_local_test.bump_counter('counter');
+EXPLAIN (COSTS OFF) SELECT code, old_value, new_value FROM ext_local_test.history ORDER BY id;
+SELECT code, old_value, new_value FROM ext_local_test.history ORDER BY id;
+
+EXPLAIN (COSTS OFF) SELECT ext_local_test.reset_counter('counter');
+SELECT ext_local_test.reset_counter('counter');
+EXPLAIN (COSTS OFF) SELECT code, value FROM ext_local_test.state;
+SELECT code, value FROM ext_local_test.state;
+
+-- And back down again.
+ALTER EXTENSION gp_local_test UPDATE TO '1.0';
+EXPLAIN (COSTS OFF) SELECT code, value FROM ext_local_test.state;
+SELECT code, value FROM ext_local_test.state;
+
+-- Drop and re-create from scratch: the schema/tables/functions must not
+-- linger past DROP EXTENSION, and a fresh CREATE EXTENSION afterward must
+-- produce a fully working, QD-only extension again, not inherit any state
+-- from the dropped one.
+DROP EXTENSION gp_local_test;
+
+CREATE EXTENSION gp_local_test;
+
+SELECT count(*) FROM gp_distribution_policy
+ WHERE localoid IN ('ext_local_test.state'::regclass,
+                     'ext_local_test.settings'::regclass);
+
+EXPLAIN (COSTS OFF) SELECT gp_segment_id, code, value FROM ext_local_test.state;
+SELECT gp_segment_id, code, value FROM ext_local_test.state;
+EXPLAIN (COSTS OFF) SELECT ext_local_test.bump_counter('counter');
+SELECT ext_local_test.bump_counter('counter');
+EXPLAIN (COSTS OFF) SELECT ext_local_test.current_counter('counter');
+SELECT ext_local_test.current_counter('counter');
+
+-- Deliberately left installed (not dropped) here: gpcheckcat's normal
+-- installcheck-world pass and the pg_upgrade test (test_gpdb.sh), which
+-- both examine the "regression" database as it stands at the end of this
+-- suite, then get to exercise a real QD-only extension's catalog state
+-- and pg_upgrade path too, not just this test's own assertions.


### PR DESCRIPTION
Add support for local (coordinator-only) extensions

This patch adds a local extension mode that lets an ordinary, MPP-incompatible
PostgreSQL extension (e.g. pg_cron-style extensions that assume a single-node
Postgres and use plain heap tables plus a persistent background worker) install
and run correctly on the coordinator only, instead of requiring every table it
creates to be dispatched and distributed across segments.

To make an extension local, a special flag should be added to the .control file
of the extension - 'gg_local = true'.

While that extension's install/upgrade script is executing, every plain
CREATE TABLE it issues is given POLICYTYPE_ENTRY (no gp_distribution_policy
row — i.e. the table lives only on the coordinator) instead of the usual
hash/random distribution a table gets when created via CREATE EXTENSION in
dispatch mode.

How entry policy is assigned:
- creating_extension_local (extension.c) is a new global, set from the control
file's local flag for the duration of execute_extension_script(), mirroring the
existing creating_extension flag. It's only set outside GP_ROLE_EXECUTE, so it
never leaks onto a QE.
- When creating_extension_local is set, `transformDistributedBy()` returns
NULL (entry policy) for a plain CREATE TABLE with no explicit distribution.

'transformDistributedBy()' now also returns NULL (entry policy) if
IsBinaryUpgrade is set and no explicit policy is supplied. It is needed for
the '--binary-upgrade' scenario.
'pg_upgrade/pg_restore --binary-upgrade' restores everything through a
coordinator-only postmaster running in utility mode. Before this change,
transformDistributedBy()'s utility-mode bypass for IsBinaryUpgrade computed
a real (hash/random) policy for every restored table, including ones that were
actually entry-distributed on the source — since dump never carries a
DISTRIBUTED BY clause for those. That produced tables with a hash policy.
Now we only compute a policy when the restore actually carries a distribution
clause; fall through to entry policy otherwise. This is safe because pg_dump
always emits an explicit DISTRIBUTED BY/RANDOMLY/REPLICATED clause for any
table that has a real policy — omitting the clause is only ever the
entry-table case.

pg_dump is updated to support config tables (the tables marked with
'pg_extension_config_dump()') of the local extensions. 'dumpTableData()' now
forces INSERT-based dumping (not COPY) for a table with no distribution policy,
since COPY would otherwise dispatch as a writer-gang operation across segments —
which doesn't work for a coordinator-only table. -o/--oids option of pg_dump
combined with such a table is rejected, matching existing pg_dump's check
for INSERT-mode dumps.

gpexpand is also updated. A segment newly added by gpexpand is bootstrapped
by cloning the coordinator's data directory, so it can inherit data for any
extension-owned table that physically exists there — most notably a local
extension's coordinator-only tables, which have real data on the coordinator's
own storage (unlike a normally-distributed table, where the coordinator never
holds row data to begin with). cleanup_new_segments() now discovers every
extension-member table (via pg_depend/pg_extension, not scoped to local
extensions specifically) and issues a DELETE for each.

Current limitations:
- Partitioned tables are rejected inside a local extension script, as
supporting them would require reworking assumptions baked into the legacy
GPDB partitioning code.
- CREATE TABLE AS / CREATE MATERIALIZED VIEW are rejected: their
distribution-policy assignment goes through a different path
(setQryDistributionPolicy()/apply_motion()) that isn't aware of
creating_extension_local, and even suppressing that isn't sufficient on its
own — the populate phase still dispatches as a normal writer-gang operation.
Use CREATE TABLE + INSERT INTO ... SELECT instead.
- If the table does carry an explicit distribution — a plain DISTRIBUTED BY
clause, LIKE ... INCLUDING DISTRIBUTION - such cases are rejected as well.
As the feature is targeting native PG extensions, that is unlikely to happen in
real life.
- Still there can be SQL commands not supported by the Greengage. For ex.
queries with multiple writing CTEs.

New tests are not included in this patch, as yet there is no real extension
in our src code tree, that we can use as a local one.

(cherry picked from commit 3965f41ed8503d748e62bb8bb3e2f661770b0510)

Changes comparing to the original commit:
 - updated check for partitioned tables (as partitioned tables were completely
reworked in 7x to be more Postgres-like);
 - support for '--oids' option had been removed from pg_dump, so all checks
related to it were removed;
 - dumpTableData_insert() had been reworked in pg_dump, so some additional
changes were required to address these changes;
 - gpexpand was updated as 'execSQL()' doesn't return cursor anymore, so use
'query()' now;
 - pg_dump now rejects '--binary-upgrade' with '--no-gp-syntax': without a
distribution clause, every table - not just local-extension ones - would
restore with the wrong policy;
 - gpexpand's new-segment cleanup now truncates all extension tables in one
statement instead of one DELETE per table, and skips a database it can't
connect to instead of aborting;
 - changed the order of checks in transformDistributedBy() to keep local-extension
working in both dispatch and utility mode;
 - added test local extension and regression test.


