### PR TITLE
CI-6269 Bump workflows to use ipv6

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v42
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v51
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
@@ -52,7 +52,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v46
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v51
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
@@ -73,7 +73,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v49
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v51
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
@@ -114,7 +114,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v28
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v51
     with:
       version: 6
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
### CI-6269 Bump workflows to use ipv6 (#588)

- build, behave, regression and orca workflows were bumped
to use ipv6.

Task: CI-6269