### PR TITLE
GG-784 Fix configure dropping CFLAGS and PG_USE_INLINE when --with-product-n…

### DIFF
--- a/configure
+++ b/configure
@@ -2989,6 +2989,10 @@ cat >>confdefs.h <<_ACEOF
 #define GP_PRODUCT_NAME "$gp_product_name"
 _ACEOF
 
+cat >>confdefs.h <<\_ACEOF
+#undef PACKAGE_NAME
+#undef PACKAGE_STRING
+_ACEOF
 
 cat >>confdefs.h <<_ACEOF
 #define PACKAGE_NAME "$gp_product_name"

--- a/configure.in
+++ b/configure.in
@@ -82,6 +82,17 @@ fi
 
 AC_DEFINE_UNQUOTED(GP_PRODUCT_NAME, ["$gp_product_name"],
                    [Product name used in version strings])
+dnl AC_INIT has already written PACKAGE_NAME and PACKAGE_STRING to confdefs.h,
+dnl and confdefs.h is the preamble of every test program configure compiles.
+dnl A second definition with a different value makes the compiler warn about a
+dnl redefined macro in every one of them, and the checks that run with
+dnl ac_c_werror_flag set (the CFLAGS probes, PGAC_C_INLINE, ...) then fail on
+dnl that warning alone.  Undefine first.  config.status only reads the
+dnl "#define" lines of confdefs.h, so the header still gets the last value.
+cat >>confdefs.h <<\_ACEOF
+#undef PACKAGE_NAME
+#undef PACKAGE_STRING
+_ACEOF
 AC_DEFINE_UNQUOTED(PACKAGE_NAME, ["$gp_product_name"],
                    [Define to the full name of this package.])
 AC_DEFINE_UNQUOTED(PACKAGE_STRING, ["$gp_product_name $PACKAGE_VERSION"],


### PR DESCRIPTION
Follow-up to #573.

### Problem

`--with-product-name` redefines `PACKAGE_NAME` and `PACKAGE_STRING`, which `AC_INIT` has already put into `confdefs.h`. `confdefs.h` is compiled into every configure probe, so with the option set gcc warns `"PACKAGE_NAME" redefined` in each of them. The probes that run in werror mode (`-fwrapv`, `-fno-strict-aliasing`, all `CXXFLAGS`, `PGAC_C_INLINE`, ...) treat that warning as failure and answer `no`.

`configure` still exits 0. The result is a build with stripped `CFLAGS`, empty `CXXFLAGS` and no `PG_USE_INLINE`. The default build is not affected: there both definitions are identical and gcc does not warn.

### Symptom

Without `PG_USE_INLINE`, `ginCompareItemPointers()` is a macro for `ItemPointerCompare()`. The full `postgres` links `itemptr.o` and builds fine. The gin unit test links `ginpostinglist.o` alone and fails:

```
ginpostinglist.c:346: undefined reference to `ItemPointerCompare'
```

So `make -C gpAux dist` with a product name succeeds silently with the wrong flags, and a `ci/Dockerfile.*` build fails at `make unittest-check`.

### Fix

`#undef` both macros in `confdefs.h` before redefining them. `config.status` reads only `#define` lines, so `pg_config.h` is unchanged. `configure` regenerated with autoconf 2.69, 4 lines.

Why not a single definition: `AC_INIT` takes a literal only and writes `PACKAGE_NAME` to `confdefs.h` before option parsing (`configure:2657`), while the first line of `configure.in` code runs after it (`configure:2949`); autoconf has no hook in between. Leaving `PACKAGE_NAME` alone and switching the code to `GP_PRODUCT_NAME` would keep the stock name in the installed `pg_config.h`, which extensions build against, so the renamed build would differ from the intended one there.

### Verification

With `--with-product-name=Greengrocer`, before and after this change:

| | before | after |
|---|---|---|
| `grep -c redefined config.log` | 628 | 0 |
| `CFLAGS`, `CXXFLAGS` vs default build | stripped | identical |
| `pg_config.h` vs default build | 6 lines | 4 lines, all the product name |
| gin unit test | link error | passes |

Default build: `pg_config.h` and `Makefile.global` byte-identical before and after. Full build, named vs default: same 71 ELF files, same symbol sets, same `.text` sizes, identical `postgres` `.dynsym`.

Any build made with `--with-product-name` before this change should be rebuilt.



Task: GG-784