### PR TITLE
Backport local (coordinator-only) extension improvements to 6.x

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -33,6 +33,7 @@ else
 endif
 	$(MAKE) -C contrib/indexscan all
 	$(MAKE) -C contrib/pageinspect all  # needed by src/test/isolation
+	$(MAKE) -C contrib/gp_local_test all  # needed by src/test/regress
 	$(MAKE) -C contrib/pg_upgrade_support all
 	$(MAKE) -C contrib/pg_upgrade all
 	$(MAKE) -C contrib/pg_xlogdump all
@@ -86,6 +87,7 @@ ifneq ($(OS),Darwin)
 endif
 	$(MAKE) -C contrib/indexscan $@ 
 	$(MAKE) -C contrib/pageinspect $@  # needed by src/test/isolation
+	$(MAKE) -C contrib/gp_local_test $@  # needed by src/test/regress
 	$(MAKE) -C contrib/pg_upgrade_support $@
 	$(MAKE) -C contrib/pg_upgrade $@
 	$(MAKE) -C contrib/pg_xlogdump $@

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -66,6 +66,7 @@ SUBDIRS += \
 		formatter_fixedwidth \
 		extprotocol \
 		indexscan \
+		gp_local_test
 
 ifeq ($(with_openssl),yes)
 SUBDIRS += sslinfo

--- a/contrib/gp_local_test/Makefile
+++ b/contrib/gp_local_test/Makefile
@@ -1,0 +1,19 @@
+# contrib/gp_local_test/Makefile
+
+EXTENSION = gp_local_test
+DATA = gp_local_test--1.0.sql \
+       gp_local_test--1.1.sql \
+       gp_local_test--1.0--1.1.sql \
+       gp_local_test--1.1--1.0.sql
+PGFILEDESC = "gp_local_test - sample extension for testing local (coordinator-only) extensions"
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = contrib/gp_local_test
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/contrib/gp_local_test/gp_local_test--1.0--1.1.sql
+++ b/contrib/gp_local_test/gp_local_test--1.0--1.1.sql
@@ -1,0 +1,41 @@
+-- gp_local_test--1.0--1.1.sql
+\echo Use "ALTER EXTENSION gp_local_test UPDATE TO '1.1'" to load this file. \quit
+
+ALTER TABLE @extschema@.state ADD COLUMN last_reset timestamptz;
+
+CREATE TABLE @extschema@.history (
+    id         serial PRIMARY KEY,
+    code       text NOT NULL,
+    old_value  integer NOT NULL,
+    new_value  integer NOT NULL,
+    changed_at timestamptz UNIQUE NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION @extschema@.bump_counter(p_code text) RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_old integer;
+    v_new integer;
+BEGIN
+    UPDATE @extschema@.state
+       SET value = value + 1,
+           updated_at = now()
+     WHERE code = p_code
+    RETURNING value - 1, value INTO v_old, v_new;
+
+    INSERT INTO @extschema@.history (code, old_value, new_value)
+    VALUES (p_code, v_old, v_new);
+
+    RETURN v_new;
+END;
+$$;
+
+CREATE FUNCTION @extschema@.reset_counter(p_code text) RETURNS void
+LANGUAGE sql
+AS $$
+    UPDATE @extschema@.state
+       SET value = 0,
+           last_reset = now()
+     WHERE code = p_code;
+$$;

--- a/contrib/gp_local_test/gp_local_test--1.0.sql
+++ b/contrib/gp_local_test/gp_local_test--1.0.sql
@@ -1,0 +1,47 @@
+-- gp_local_test--1.0.sql
+\echo Use "CREATE EXTENSION gp_local_test" to load this file. \quit
+
+-- Deliberately vanilla: no DISTRIBUTED BY, no Greengage-specific clauses.
+-- id is PRIMARY KEY *and* code is independently UNIQUE — two
+-- non-overlapping unique constraints, which fails under Greengage's
+-- default hash-distributed policy but is perfectly ordinary Postgres.
+CREATE TABLE @extschema@.state (
+    id         serial PRIMARY KEY,
+    code       text UNIQUE NOT NULL,
+    value      integer NOT NULL DEFAULT 0,
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+INSERT INTO @extschema@.state (code, value) VALUES ('counter', 0);
+
+-- Genuine "config" table: DBA-tunable settings that must survive
+-- backup/restore even though the rest of the extension's schema is
+-- recreated fresh by re-running this script. Marked via
+-- pg_extension_config_dump() per the standard PostgreSQL convention
+-- so pg_dump/gpbackup include its row data instead of treating it as
+-- pure extension-owned reference data.
+CREATE TABLE @extschema@.settings (
+    key   text PRIMARY KEY,
+    value text NOT NULL
+);
+
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.settings', '');
+
+-- Plain SQL-language function, no EXECUTE ON clause at all —
+-- exercises the "function defaults" side of the mechanism.
+CREATE FUNCTION @extschema@.bump_counter(p_code text) RETURNS integer
+LANGUAGE sql
+AS $$
+    UPDATE @extschema@.state
+       SET value = value + 1,
+           updated_at = now()
+     WHERE code = p_code
+    RETURNING value;
+$$;
+
+-- Plain SQL-language read, also no EXECUTE ON clause.
+CREATE FUNCTION @extschema@.current_counter(p_code text) RETURNS integer
+LANGUAGE sql STRICT
+AS $$
+    SELECT value FROM @extschema@.state WHERE code = p_code;
+$$;

--- a/contrib/gp_local_test/gp_local_test--1.1--1.0.sql
+++ b/contrib/gp_local_test/gp_local_test--1.1--1.0.sql
@@ -1,0 +1,20 @@
+-- gp_local_test--1.1--1.0.sql
+\echo Use "ALTER EXTENSION gp_local_test UPDATE TO '1.0'" to load this file. \quit
+
+DROP FUNCTION @extschema@.reset_counter(text);
+
+-- Revert bump_counter to the pre-1.1 body (no history logging)
+CREATE OR REPLACE FUNCTION @extschema@.bump_counter(p_code text) RETURNS integer
+LANGUAGE sql
+AS $$
+    UPDATE @extschema@.state
+       SET value = value + 1,
+           updated_at = now()
+     WHERE code = p_code
+    RETURNING value;
+$$;
+
+DROP TABLE @extschema@.history;
+
+ALTER TABLE @extschema@.state DROP COLUMN last_reset;
+

--- a/contrib/gp_local_test/gp_local_test--1.1.sql
+++ b/contrib/gp_local_test/gp_local_test--1.1.sql
@@ -1,0 +1,78 @@
+-- gp_local_test--1.1.sql
+\echo Use "CREATE EXTENSION gp_local_test" to load this file. \quit
+
+-- Deliberately vanilla: no DISTRIBUTED BY, no Greengage-specific clauses.
+-- id is PRIMARY KEY *and* code is independently UNIQUE — two
+-- non-overlapping unique constraints, which fails under Greengage's
+-- default hash-distributed policy but is perfectly ordinary Postgres.
+CREATE TABLE @extschema@.state (
+    id         serial PRIMARY KEY,
+    code       text UNIQUE NOT NULL,
+    value      integer NOT NULL DEFAULT 0,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    last_reset timestamptz
+);
+
+INSERT INTO @extschema@.state (code, value) VALUES ('counter', 0);
+
+-- Genuine "config" table: DBA-tunable settings that must survive
+-- backup/restore even though the rest of the extension's schema is
+-- recreated fresh by re-running this script. Marked via
+-- pg_extension_config_dump() per the standard PostgreSQL convention
+-- so pg_dump/gpbackup include its row data instead of treating it as
+-- pure extension-owned reference data.
+CREATE TABLE @extschema@.settings (
+    key   text PRIMARY KEY,
+    value text NOT NULL
+);
+
+INSERT INTO @extschema@.settings (key, value) VALUES ('bump_interval_seconds', '5');
+
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.settings', '');
+
+CREATE TABLE @extschema@.history (
+    id         serial PRIMARY KEY,
+    code       text NOT NULL,
+    old_value  integer NOT NULL,
+    new_value  integer NOT NULL,
+    changed_at timestamptz UNIQUE NOT NULL DEFAULT now()
+);
+
+-- plpgsql, no EXECUTE ON clause — logs each bump into history.
+CREATE FUNCTION @extschema@.bump_counter(p_code text) RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_old integer;
+    v_new integer;
+BEGIN
+    UPDATE @extschema@.state
+       SET value = value + 1,
+           updated_at = now()
+     WHERE code = p_code
+    RETURNING value - 1, value INTO v_old, v_new;
+
+    INSERT INTO @extschema@.history (code, old_value, new_value)
+    VALUES (p_code, v_old, v_new);
+
+    RETURN v_new;
+END;
+$$;
+
+-- Plain SQL-language function, no EXECUTE ON clause at all —
+-- exercises the "function defaults" side of the mechanism.
+CREATE FUNCTION @extschema@.reset_counter(p_code text) RETURNS void
+LANGUAGE sql
+AS $$
+    UPDATE @extschema@.state
+       SET value = 0,
+           last_reset = now()
+     WHERE code = p_code;
+$$;
+
+-- Plain SQL-language read, also no EXECUTE ON clause.
+CREATE FUNCTION @extschema@.current_counter(p_code text) RETURNS integer
+LANGUAGE sql STRICT
+AS $$
+    SELECT value FROM @extschema@.state WHERE code = p_code;
+$$;

--- a/contrib/gp_local_test/gp_local_test.control
+++ b/contrib/gp_local_test/gp_local_test.control
@@ -1,0 +1,7 @@
+# gp_local_test.control
+comment = 'Sample extension to test coordinator-only (LOCAL) semantics'
+default_version = '1.0'
+relocatable = false
+schema = 'ext_local_test'
+gg_local = true
+

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1482,6 +1482,7 @@ class gpexpand(object):
             where
             c.relkind = 'r' and
             d.deptype = 'e' and
+            d.objsubid = 0 and
             d.classid = 'pg_class'::regclass and
             d.refclassid = 'pg_extension'::regclass'''
 
@@ -1491,9 +1492,22 @@ class gpexpand(object):
             if database[0] == 'template0':
                 continue
             url.pgdb = database[0]
-            with closing (dbconn.connect(url, encoding='UTF8')) as conn:
-                cursor = dbconn.execSQL(conn, extTablesSql)
-                db_statements_by_dbname[database[0]] = statements + ["delete from %s" % row[0] for row in cursor]
+            try:
+                with closing(dbconn.connect(url, encoding='UTF8')) as conn:
+                    ext_tables = [row[0] for row in dbconn.execSQL(conn, extTablesSql)]
+            except Exception as e:
+                self.logger.warning(
+                    "Could not connect to database %s to look up extension-owned "
+                    "tables for new-segment cleanup, skipping: %s" % (database[0], str(e)))
+                ext_tables = []
+
+            db_statements = list(statements)
+            if ext_tables:
+                # A single TRUNCATE naming every extension table together, rather
+                # than one DELETE per table (order-dependent) or CASCADE (which
+                # could reach into unrelated, non-extension tables).
+                db_statements.append("truncate %s" % ", ".join(ext_tables))
+            db_statements_by_dbname[database[0]] = db_statements
 
         """
           Connect to each database in the new segments, and clean up the catalog tables.

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -1863,6 +1863,31 @@ transformDistributedBy(CreateStmtContext *cxt,
 	int			numsegments;
 
 	/*
+	 * Checked ahead of the Gp_role/IsBinaryUpgrade fallback below: a local
+	 * extension's own install-script tables must always follow these rules
+	 * regardless of what mode the script happens to be running in -
+	 * normal or utility.
+	 */
+	if (creating_extension_local)
+	{
+		/*
+		 * POLICYTYPE_ENTRY for local extensions. An explicit distribution
+		 * (given directly, or inherited via LIKE ... INCLUDING DISTRIBUTION)
+		 * can't be honored, but silently discarding it and returning NULL
+		 * here isn't safe either: some callers (writable external tables)
+		 * assume a non-NULL result whenever they passed in a non-NULL
+		 * distributedBy or likeDistributedBy, and dereference it right
+		 * after the call. Error out instead of handing them a NULL they
+		 * don't check for.
+		 */
+		if (distributedBy != NULL || likeDistributedBy != NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("explicit distribution is not supported inside a local extension script")));
+		return NULL;
+	}
+
+	/*
 	 * utility mode creates can't have a policy.  Only the QD can have policies.
 	 *
 	 * IsBinaryUpgrade normally bypasses this, since --binary-upgrade restore
@@ -1876,25 +1901,6 @@ transformDistributedBy(CreateStmtContext *cxt,
 	if (Gp_role != GP_ROLE_DISPATCH &&
 		(!IsBinaryUpgrade || distributedBy == NULL))
 		return NULL;
-
-	/*
-	 * POLICYTYPE_ENTRY for local extensions. An explicit distribution
-	 * (given directly, or inherited via LIKE ... INCLUDING DISTRIBUTION, or
-	 * inherited by a partition child from its parent) can't be honored, but
-	 * silently discarding it and returning NULL here isn't safe either:
-	 * some callers (partition children, writable external tables) assume a
-	 * non-NULL result whenever they passed in a non-NULL distributedBy or
-	 * likeDistributedBy, and dereference it right after the call. Error out
-	 * instead of handing them a NULL they don't check for.
-	 */
-	if (creating_extension_local)
-	{
-		if (distributedBy != NULL || likeDistributedBy != NULL)
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("explicit distribution is not supported inside a local extension script")));
-		return NULL;
-	}
 
 	if (distributedBy && distributedBy->numsegments > 0)
 		/* If numsegments is set in DISTRIBUTED BY use the specified value */

--- a/src/test/regress/expected/gp_local_extension.out
+++ b/src/test/regress/expected/gp_local_extension.out
@@ -1,0 +1,246 @@
+-- Exercises the local (QD-only/coordinator-only) extension mechanism
+-- (the gg_local control-file flag) end to end, using the gp_local_test
+-- sample extension in contrib/.
+-- This test deliberately leaves the extension installed at the end (see
+-- the closing comment below), so guard against a prior run's leftover
+-- state to stay safely re-runnable against the same database.
+-- start_ignore
+DROP EXTENSION IF EXISTS gp_local_test;
+-- end_ignore
+CREATE EXTENSION gp_local_test;
+-- Every table the extension's install script created must have no
+-- distribution policy at all - that's the defining property of a
+-- QD-only table.
+SELECT count(*) FROM gp_distribution_policy
+ WHERE localoid IN ('ext_local_test.state'::regclass,
+                     'ext_local_test.settings'::regclass);
+ count 
+-------
+     0
+(1 row)
+
+-- QD-only tables live only on the coordinator (segment id -1), never
+-- dispatched to segments. EXPLAIN confirms the plan itself has no Motion
+-- node moving data from segments - it's a plain local scan.
+EXPLAIN (COSTS OFF) SELECT gp_segment_id, code, value FROM ext_local_test.state;
+            QUERY PLAN             
+-------------------------------------
+ Seq Scan on state
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+SELECT gp_segment_id, code, value FROM ext_local_test.state;
+ gp_segment_id |  code   | value 
+---------------+---------+-------
+            -1 | counter |     0
+(1 row)
+
+-- settings is registered via pg_extension_config_dump() with an empty
+-- (unfiltered) condition - the standard "config table" convention.
+SELECT extconfig IS NOT NULL AS has_config_tables, extcondition
+  FROM pg_extension WHERE extname = 'gp_local_test';
+ has_config_tables | extcondition 
+-------------------+--------------
+ t                 | {""}
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT key, value FROM ext_local_test.settings ORDER BY key;
+                 QUERY PLAN                 
+-------------------------------------
+ Sort
+   Sort Key: key
+   ->  Seq Scan on settings
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+SELECT key, value FROM ext_local_test.settings ORDER BY key;
+ key | value 
+-----+-------
+(0 rows)
+
+-- Exercise the extension's functions against the QD-only table, neither
+-- carrying any EXECUTE ON clause. Again, no Motion in the plan.
+EXPLAIN (COSTS OFF) SELECT ext_local_test.bump_counter('counter');
+            QUERY PLAN             
+-------------------------------------
+ Result
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+SELECT ext_local_test.bump_counter('counter');
+ bump_counter 
+--------------
+            1
+(1 row)
+
+SELECT ext_local_test.bump_counter('counter');
+ bump_counter 
+--------------
+            2
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT ext_local_test.current_counter('counter');
+            QUERY PLAN             
+-------------------------------------
+ Result
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+SELECT ext_local_test.current_counter('counter');
+ current_counter 
+-----------------
+               2
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT code, value FROM ext_local_test.state;
+            QUERY PLAN             
+-------------------------------------
+ Seq Scan on state
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+SELECT code, value FROM ext_local_test.state;
+  code   | value 
+---------+-------
+ counter |     2
+(1 row)
+
+-- Schema evolution: ALTER EXTENSION UPDATE must be able to add a column,
+-- a new table, and replace a function's language (SQL -> plpgsql) on a
+-- QD-only table, and the table must remain QD-only afterward.
+ALTER EXTENSION gp_local_test UPDATE TO '1.1';
+SELECT count(*) FROM gp_distribution_policy
+ WHERE localoid IN ('ext_local_test.state'::regclass,
+                     'ext_local_test.history'::regclass);
+ count 
+-------
+     0
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT ext_local_test.bump_counter('counter');
+            QUERY PLAN             
+-------------------------------------
+ Result
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+SELECT ext_local_test.bump_counter('counter');
+ bump_counter 
+--------------
+            3
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT code, old_value, new_value FROM ext_local_test.history ORDER BY id;
+                QUERY PLAN                
+-------------------------------------
+ Sort
+   Sort Key: id
+   ->  Seq Scan on history
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+SELECT code, old_value, new_value FROM ext_local_test.history ORDER BY id;
+  code   | old_value | new_value 
+---------+-----------+-----------
+ counter |         2 |         3
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT ext_local_test.reset_counter('counter');
+            QUERY PLAN             
+-------------------------------------
+ Result
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+SELECT ext_local_test.reset_counter('counter');
+ reset_counter 
+---------------
+ 
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT code, value FROM ext_local_test.state;
+            QUERY PLAN             
+-------------------------------------
+ Seq Scan on state
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+SELECT code, value FROM ext_local_test.state;
+  code   | value 
+---------+-------
+ counter |     0
+(1 row)
+
+-- And back down again.
+ALTER EXTENSION gp_local_test UPDATE TO '1.0';
+EXPLAIN (COSTS OFF) SELECT code, value FROM ext_local_test.state;
+            QUERY PLAN             
+-------------------------------------
+ Seq Scan on state
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+SELECT code, value FROM ext_local_test.state;
+  code   | value 
+---------+-------
+ counter |     0
+(1 row)
+
+-- Drop and re-create from scratch: the schema/tables/functions must not
+-- linger past DROP EXTENSION, and a fresh CREATE EXTENSION afterward must
+-- produce a fully working, QD-only extension again, not inherit any state
+-- from the dropped one.
+DROP EXTENSION gp_local_test;
+CREATE EXTENSION gp_local_test;
+SELECT count(*) FROM gp_distribution_policy
+ WHERE localoid IN ('ext_local_test.state'::regclass,
+                     'ext_local_test.settings'::regclass);
+ count 
+-------
+     0
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT gp_segment_id, code, value FROM ext_local_test.state;
+            QUERY PLAN             
+-------------------------------------
+ Seq Scan on state
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+SELECT gp_segment_id, code, value FROM ext_local_test.state;
+ gp_segment_id |  code   | value 
+---------------+---------+-------
+            -1 | counter |     0
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT ext_local_test.bump_counter('counter');
+            QUERY PLAN             
+-------------------------------------
+ Result
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+SELECT ext_local_test.bump_counter('counter');
+ bump_counter 
+--------------
+            1
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT ext_local_test.current_counter('counter');
+            QUERY PLAN             
+-------------------------------------
+ Result
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+SELECT ext_local_test.current_counter('counter');
+ current_counter 
+-----------------
+               1
+(1 row)
+
+-- Deliberately left installed (not dropped) here: gpcheckcat's normal
+-- installcheck-world pass and the pg_upgrade test (test_gpdb.sh), which
+-- both examine the "regression" database as it stands at the end of this
+-- suite, then get to exercise a real QD-only extension's catalog state
+-- and pg_upgrade path too, not just this test's own assertions.

--- a/src/test/regress/greengage_schedule
+++ b/src/test/regress/greengage_schedule
@@ -320,4 +320,5 @@ test: gp_orphaned_files
 
 test: gp_libpq_events
 
+test: gp_local_extension
 # end of tests

--- a/src/test/regress/sql/gp_local_extension.sql
+++ b/src/test/regress/sql/gp_local_extension.sql
@@ -1,0 +1,91 @@
+-- Exercises the local (QD-only/coordinator-only) extension mechanism
+-- (the gg_local control-file flag) end to end, using the gp_local_test
+-- sample extension in contrib/.
+
+-- This test deliberately leaves the extension installed at the end (see
+-- the closing comment below), so guard against a prior run's leftover
+-- state to stay safely re-runnable against the same database.
+-- start_ignore
+DROP EXTENSION IF EXISTS gp_local_test;
+-- end_ignore
+
+CREATE EXTENSION gp_local_test;
+
+-- Every table the extension's install script created must have no
+-- distribution policy at all - that's the defining property of a
+-- QD-only table.
+SELECT count(*) FROM gp_distribution_policy
+ WHERE localoid IN ('ext_local_test.state'::regclass,
+                     'ext_local_test.settings'::regclass);
+
+-- QD-only tables live only on the coordinator (segment id -1), never
+-- dispatched to segments. EXPLAIN confirms the plan itself has no Motion
+-- node moving data from segments - it's a plain local scan.
+EXPLAIN (COSTS OFF) SELECT gp_segment_id, code, value FROM ext_local_test.state;
+SELECT gp_segment_id, code, value FROM ext_local_test.state;
+
+-- settings is registered via pg_extension_config_dump() with an empty
+-- (unfiltered) condition - the standard "config table" convention.
+SELECT extconfig IS NOT NULL AS has_config_tables, extcondition
+  FROM pg_extension WHERE extname = 'gp_local_test';
+EXPLAIN (COSTS OFF) SELECT key, value FROM ext_local_test.settings ORDER BY key;
+SELECT key, value FROM ext_local_test.settings ORDER BY key;
+
+-- Exercise the extension's functions against the QD-only table, neither
+-- carrying any EXECUTE ON clause. Again, no Motion in the plan.
+EXPLAIN (COSTS OFF) SELECT ext_local_test.bump_counter('counter');
+SELECT ext_local_test.bump_counter('counter');
+SELECT ext_local_test.bump_counter('counter');
+EXPLAIN (COSTS OFF) SELECT ext_local_test.current_counter('counter');
+SELECT ext_local_test.current_counter('counter');
+EXPLAIN (COSTS OFF) SELECT code, value FROM ext_local_test.state;
+SELECT code, value FROM ext_local_test.state;
+
+-- Schema evolution: ALTER EXTENSION UPDATE must be able to add a column,
+-- a new table, and replace a function's language (SQL -> plpgsql) on a
+-- QD-only table, and the table must remain QD-only afterward.
+ALTER EXTENSION gp_local_test UPDATE TO '1.1';
+
+SELECT count(*) FROM gp_distribution_policy
+ WHERE localoid IN ('ext_local_test.state'::regclass,
+                     'ext_local_test.history'::regclass);
+
+EXPLAIN (COSTS OFF) SELECT ext_local_test.bump_counter('counter');
+SELECT ext_local_test.bump_counter('counter');
+EXPLAIN (COSTS OFF) SELECT code, old_value, new_value FROM ext_local_test.history ORDER BY id;
+SELECT code, old_value, new_value FROM ext_local_test.history ORDER BY id;
+
+EXPLAIN (COSTS OFF) SELECT ext_local_test.reset_counter('counter');
+SELECT ext_local_test.reset_counter('counter');
+EXPLAIN (COSTS OFF) SELECT code, value FROM ext_local_test.state;
+SELECT code, value FROM ext_local_test.state;
+
+-- And back down again.
+ALTER EXTENSION gp_local_test UPDATE TO '1.0';
+EXPLAIN (COSTS OFF) SELECT code, value FROM ext_local_test.state;
+SELECT code, value FROM ext_local_test.state;
+
+-- Drop and re-create from scratch: the schema/tables/functions must not
+-- linger past DROP EXTENSION, and a fresh CREATE EXTENSION afterward must
+-- produce a fully working, QD-only extension again, not inherit any state
+-- from the dropped one.
+DROP EXTENSION gp_local_test;
+
+CREATE EXTENSION gp_local_test;
+
+SELECT count(*) FROM gp_distribution_policy
+ WHERE localoid IN ('ext_local_test.state'::regclass,
+                     'ext_local_test.settings'::regclass);
+
+EXPLAIN (COSTS OFF) SELECT gp_segment_id, code, value FROM ext_local_test.state;
+SELECT gp_segment_id, code, value FROM ext_local_test.state;
+EXPLAIN (COSTS OFF) SELECT ext_local_test.bump_counter('counter');
+SELECT ext_local_test.bump_counter('counter');
+EXPLAIN (COSTS OFF) SELECT ext_local_test.current_counter('counter');
+SELECT ext_local_test.current_counter('counter');
+
+-- Deliberately left installed (not dropped) here: gpcheckcat's normal
+-- installcheck-world pass and the pg_upgrade test (test_gpdb.sh), which
+-- both examine the "regression" database as it stands at the end of this
+-- suite, then get to exercise a real QD-only extension's catalog state
+-- and pg_upgrade path too, not just this test's own assertions.


### PR DESCRIPTION
Backport local (coordinator-only) extension improvements to 6.x

This patch backports some improvements from commit
3f3846f7db7aa511a987b6f57c002341cf295e0d

List of changes:
 - gpexpand's new-segment cleanup now truncates all extension tables in one
statement instead of one DELETE per table, and skips a database it can't
connect to instead of aborting;
 - changed the order of checks in transformDistributedBy() to keep
local-extension working in both dispatch and utility mode;
 - added test local extension and regression test.

